### PR TITLE
Add PowerShell scripts for building and development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,3 +44,51 @@ gives you the list like this one:
 Listing tracked patterns
     *.png (.gitattributes)
 ```
+
+# Building the Solution
+
+We provide PowerShell scripts to help you install the dependencies and build 
+the solution from the command line.
+
+First, change to the `src/` directory. All the subsequent scripts will be 
+invoked from there.
+
+We separated *development* dependencies, which are installed for many different
+solutions (such as Visual Studio Build tools) and *solution* dependencies
+which are specific to this particular solution.
+
+To install the development dependencies (for example, on a virtual machine), 
+run:
+
+```powershell
+.\InstallDevDependencies.ps1
+```
+
+To install the solution dependencies, invoke:
+
+```powershell
+.\InstallBuildDependencies.ps1
+```
+
+Now you are all set to build the solution:
+
+```powershell
+.\BuildSolution.ps1
+```
+
+## Pre-merge Checks
+
+We still assume the current directory is `src/`. Besides scripts for building,
+we provide scripts to run pre-merge checks on your local machine.
+
+To inspect the code with Resharper CodeInspect, run:
+
+```powershell
+.\Resharp.ps1
+```
+
+and to format the code with `dotnet-format`:
+
+```powershell
+.\FormatCode.ps1
+```

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -3,3 +3,5 @@ packages/
 */obj/
 **/BuildDate.txt
 Microsoft.Net.Compilers.2.10.0/
+installation/
+resharper-code-inspection.xml

--- a/src/BuildSolution.ps1
+++ b/src/BuildSolution.ps1
@@ -1,0 +1,25 @@
+﻿# This script builds the solution. 
+#
+# It is expected that you installed 
+# the dev dependencies (with InstallDevDependenciesOnMV.ps1 or manually) 
+# as well as solution dependencies (InstallBuildDependencies.ps1 or manually).
+
+$vswherePath = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (!(Test-Path $vswherePath)) {
+    throw "Could not find vswhere at: $vswherePath"
+}
+
+
+$ids = 'Community', 'Professional', 'Enterprise', 'BuildTools' | foreach { 'Microsoft.VisualStudio.Product.' + $_ }
+$instance = & $vswherePath -latest -products $ids -requires Microsoft.Component.MSBuild -format json `
+    | Convertfrom-Json `
+    | Select-Object -first 1
+$msbuildPath = Join-Path $instance.installationPath 'MSBuild\15.0\Bin\MSBuild.exe' 
+if (!(Test-Path $msbuildPath)) {
+    throw "Could not find MSBuild. Expected at: $msbuildPath"
+}
+
+Write-Host "Using MSBuild from: $msbuildPath"
+
+cd $PSScriptRoot
+& $msbuildPath --% /p:Configuration=Debug /p:Platform=x64 

--- a/src/FormatCode.ps1
+++ b/src/FormatCode.ps1
@@ -1,0 +1,17 @@
+﻿if(!(Test-Path env:DOTNET_ROOT)) {
+    $dotnetRoot = Join-Path $env:LOCALAPPDATA "Microsoft\dotnet"
+    if(!(Test-Path $dotnetRoot)) {
+        throw "Expected dotnet root to exist, but it does not: $dotnetRoot"
+    }
+
+    Write-Host "Setting DOTNET_ROOT environment variable to: $dotnetRoot"
+    [Environment]::SetEnvironmentVariable(
+        "DOTNET_ROOT",
+        $dotnetRoot)
+}
+
+$dotnetFormatPath=Join-Path $env:UserProfile ".dotnet\tools\dotnet-format.exe"
+
+cd $PSScriptRoot
+
+& $dotnetFormatPath

--- a/src/InstallBuildDependencies.ps1
+++ b/src/InstallBuildDependencies.ps1
@@ -1,0 +1,16 @@
+﻿# This script installs the dependencies necessary to build the solution.
+# The script uses nuget and the dependencies are stored in the packages/ 
+# subdirectory.
+
+if ((Get-Command "nuget.exe" -ErrorAction SilentlyContinue) -eq $null) 
+{ 
+   throw "Unable to find nuget.exe in your PATH"
+}
+
+cd $PSScriptRoot
+
+Write-Host "Installing .NET compilers 2.10.0 ..."
+nuget install Microsoft.NET.Compilers -Version 2.10.0
+
+Write-Host "Restoring packages for the solution ..."
+nuget.exe restore AasxPackageExplorer.sln

--- a/src/InstallDevDependencies.ps1
+++ b/src/InstallDevDependencies.ps1
@@ -1,0 +1,106 @@
+# This script installs the dependencies necessary for building and developing the solution.
+# The script is expected to run only once per development machine.
+# The dependencies include, for example, Git, Visual Studio 2017 Build Tools and nuget.
+
+if(!$PSScriptRoot) {
+    $defaultInstallationDir = Join-Path (Get-Location).path "installation"
+} else {
+    $defualtInstallationDir = Join-Path $PSScriptRoot "installation"
+}
+
+param ($installationDir=$defaultInstallationDir)
+
+Write-Host "Installation directory is: $installationDir"
+
+
+New-Item -ItemType Directory -Force -Path $installationDir
+
+Write-Host "Downloading Git to: $installationDir"
+Invoke-WebRequest `
+    https://github.com/git-for-windows/git/releases/download/v2.26.2.windows.1/Git-2.26.2-64-bit.exe `
+    -OutFile $installationDir\Git-2.26.2-64-bit.exe
+
+Write-Host "Installing Git ..."
+$gitDir="C:\Program Files\Git"
+@"
+[Setup]
+Lang=default
+Dir=$gitDir
+Group=Git
+NoIcons=0
+SetupType=default
+Components=icons,ext\reg\shellhere,assoc,assoc_sh
+Tasks=
+PathOption=Cmd
+SSHOption=OpenSSH
+CRLFOption=CRLFAlways
+BashTerminalOption=ConHost
+PerformanceTweaksFSCache=Enabled
+UseCredentialManager=Enabled
+EnableSymlinks=Disabled
+EnableBuiltinDifftool=Disabled
+"@ | Set-Content -Path $installationDir\git-config.inf
+& "$installationDir\Git-2.26.2-64-bit.exe" /VERYSILENT /LOADINF="$installationDir\git-config.inf"
+
+Write-Host "Adding Git to system path ..."
+ [System.Environment]::SetEnvironmentVariable(`
+    "Path", `
+    [System.Environment]::GetEnvironmentVariable('Path', [System.EnvironmentVariableTarget]::Machine) + `
+    ";$gitDir\cmd")
+
+$url = 'https://aka.ms/vs/15/release/vs_buildtools.exe'
+Write-Host "Downloading Visual Studio 2017 build tools from $url to: $installationDir"
+Invoke-WebRequest $url -OutFile $installationDir\vs_buildtools.exe
+
+& "$installationDir\vs_buildtools.exe" `
+    --add Microsoft.VisualStudio.Workload.MSBuildTools `
+    --add Microsoft.Net.Component.4.6.1.SDK `
+    --add Microsoft.Net.Component.4.6.1.TargetingPack `
+    --add Microsoft.NetCore.Component.Runtime.3.1 `
+    --add Microsoft.NetCore.Component.SDK `
+    --add Microsoft.VisualStudio.Component.NuGet.BuildTools `
+    --quiet --norestart
+
+$vswherePath = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+$ids = 'Community', 'Professional', 'Enterprise', 'BuildTools' | foreach { 'Microsoft.VisualStudio.Product.' + $_ }
+$instance = & $vswherePath -latest -products $ids -requires Microsoft.Component.MSBuild -format json `
+    | Convertfrom-json `
+    | Select-Object -first 1
+$msbuildPath = Join-Path $instance.installationPath 'MSBuild\15.0\Bin\MSBuild.exe' 
+
+Write-Host "MSBuild can be found at: $msbuildPath"
+
+$nugetDir = "${Env:ProgramFiles(x86)}\nuget"
+New-Item -ItemType Directory -Force -Path $nugetDir
+Write-Host "Downloading latest nuget to: $nugetDir"
+Invoke-WebRequest `
+    https://dist.nuget.org/win-x86-commandline/latest/nuget.exe  `
+    -OutFile $nugetDir\nuget.exe
+
+Write-Host "Adding nuget to system path ..."
+[Environment]::SetEnvironmentVariable(
+    "Path",
+    [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";$nugetDir",
+    [EnvironmentVariableTarget]::Machine)
+
+Write-Host "Downloading resharper to: $installationDir"
+Invoke-WebRequest `
+    https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.2/JetBrains.ReSharper.CommandLineTools.2020.1.2.zip `
+    -OutFile $installationDir\JetBrains.ReSharper.CommandLineTools.2020.1.2.zip
+
+$resharperDir="${Env:ProgramFiles(x86)}\resharper.2020.1.2"
+Write-Host "Unzipping resharper to: $resharperDir"
+Expand-Archive `
+    -LiteralPath $installationDir\JetBrains.ReSharper.CommandLineTools.2020.1.2.zip `
+    -DestinationPath $resharperDir
+
+Write-Host "Downloading dotnet-install.ps1 to: $installationDir"
+Invoke-WebRequest `
+    https://dot.net/v1/dotnet-install.ps1 `
+    -OutFile $installationDir\dotnet-install.ps1
+
+& $installationDir\dotnet-install.ps1 -Version 3.1.202
+& $installationDir\dotnet-install.ps1 -Runtime dotnet -Version 3.1.4
+
+Write-Host "Install dotnet-format ..."
+dotnet tool install --global dotnet-format --version 3.3.111304

--- a/src/Resharp.ps1
+++ b/src/Resharp.ps1
@@ -1,0 +1,40 @@
+﻿# This script runs Resharper tools (InspectCode, dupFinder and CleanupCode) to improve
+# the quality of the code base.
+#
+# This script is expected to be run after the solution has been built.
+
+$inspectcode = ''
+if ((Get-Command "inspectcode.exe" -ErrorAction SilentlyContinue) -ne $null) 
+{ 
+   $inspectcode = 'inspectcode.exe'
+} else {
+    $resharperDir="${Env:ProgramFiles(x86)}\resharper.2020.1.2"
+    $inspectcode = Join-path $resharperDir 'inspectcode.exe'
+    if(!(Test-Path $inspectcode)) {
+        throw 'Resharper inspectcode.exe could not be found neither in PATH nor at: $inspectcode';
+    }
+}
+
+cd $PSScriptRoot
+
+# InspectCode passes over the properties to MSBuild,
+# see https://www.jetbrains.com/help/resharper/InspectCode.html#msbuild-related-parameters
+& $inspectcode `
+    --properties:Configuration=Debug `
+    --properties:Platform=x64 `
+    "-o=resharper-code-inspection.xml" `
+    AasxPackageExplorer.sln
+ 
+$fails = @()
+
+[xml]$inspection = Get-Content "resharper-code-inspection.xml"
+$issueCount = $inspection.SelectNodes('//Issue').Count
+if( $issueCount -ne 0 ) {
+    $fails += "* There are $issueCount InspectCode issue(s). " + `
+        "The issues are stored in: $PSScriptRoot\resharper-code-inspection.xml"
+}
+
+if($fails.Count -ne 0) {
+    $parts = @("Resharping failed:") + $fails
+    Write-Error ($parts -join "`r`n") -ErrorAction Stop
+}


### PR DESCRIPTION
This commit adds powershell scripts to automate installation of
development and solution dependencies as well as building and checking
the solution.

This is particularly handy when you need to develop or test the building
pipeline on a virtual machine.