### PR TITLE
Fix FormatCode and dotnet path

### DIFF
--- a/src/FormatCode.ps1
+++ b/src/FormatCode.ps1
@@ -8,10 +8,14 @@
     [Environment]::SetEnvironmentVariable(
         "DOTNET_ROOT",
         $dotnetRoot)
+} else {
+    $dotnetRoot= $env:DOTNET_ROOT
 }
+
+$env:Path += ";$dotnetRoot" 
 
 $dotnetFormatPath=Join-Path $env:UserProfile ".dotnet\tools\dotnet-format.exe"
 
 cd $PSScriptRoot
 
-& $dotnetFormatPath
+dotnet format


### PR DESCRIPTION
This commit fixes FormatCode.ps1 by adding dotnet on the PATH. This
caused problems with dotnet-format which could not locate MSBuild.