### PR TITLE
Gitignore installation-dev-dependencies

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -4,4 +4,5 @@ packages/
 **/BuildDate.txt
 Microsoft.Net.Compilers.2.10.0/
 installation/
+installation-dev-dependencies/
 resharper-code-inspection.xml


### PR DESCRIPTION
This commit gitignores `installation-dev-dependencies/` since this
directory is used by the installation of development dependencies in the
`src/`.