### PR TITLE
Point to Git-Lfs in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,11 @@ the feature branch in your forked repository. See [this Github tuturial](
 https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork
 ) for more guidance. 
 
-We use Git Large File Support (LFS) to handle binary files. Please make sure 
-the files are tracked before you add binaries to the repository.
+We use Git Large File Support (LFS) to handle binary files. Please do not forget
+to install Git-Lfs (https://git-lfs.github.com) on your computer.
 
-Invoking:
+You need to make sure the files are tracked before you add binaries to the 
+repository. Invoking:
 ```bash
 $ git lfs track
 ```


### PR DESCRIPTION
The contributors need to have Git-Lfs installed before they can commit
binary files (otherwise, they will pollute the Git with binary blocks as
if Git-Lfs was not in place!). This change points them to install
Git-Lfs from the corresponding web site.