### PR TITLE
Add opinionated commit messages

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@master
+ 
+      - name: Check the commit message(s)
+        uses: mristin/opinionated-commit-message@v1.0.0
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.0


### PR DESCRIPTION
Previously, no style was enforced on the commit messages resulting in
different formats and conventions. This change adds the Github action
"opinionated-commit-message" to make the messages more informative and
easier to follow.