### PR TITLE
Fix dotnet-format version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,7 +44,7 @@ jobs:
         run: nuget restore AasxPackageExplorer.sln
 
       - name: Install dotnet-format
-        run: dotnet tool install -g dotnet-format
+        run: dotnet tool install -g dotnet-format --version 3.3.111304
 
       - name: Setup ReSharper Command Line Tools
         uses: goit/setup-resharper@v1.0.0


### PR DESCRIPTION
The `check.yml` did not specify the version of the dotnet-format. This
change is necessary so that we have a controllable format (instead of
always installing the newest version of dotnet-format which breaks our
workflow).