### PR TITLE
Change to Apache 2 License at splash

### DIFF
--- a/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
+++ b/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
@@ -43,7 +43,7 @@ The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www
 
                 <ScrollViewer  Grid.Column="1" Grid.Row="3" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                 <TextBlock x:Name="TextBlockLicenses" FontSize="9" TextWrapping="Wrap" Margin="0,8,0,0" VerticalAlignment="Top">
-                    This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0).  <LineBreak/>
+                    This software is licensed under the Apache License 2.0.<LineBreak/>
                     The browser functionality is under the cefSharp. <LineBreak/>
                     The JSON serialization is under the MIT (Newtonsoft.JSON). <LineBreak/>
                     The QR code generation is under the MIT license (QRcoder). <LineBreak/>


### PR DESCRIPTION
The license was changed from Eclipse Public License to Apache 2 during
the migration to Github. This changes the license information shown at
splash screen.