### PR TITLE
Remove Eclipse license from the code

### DIFF
--- a/src/AasxAmlImExport/AmlExport.cs
+++ b/src/AasxAmlImExport/AmlExport.cs
@@ -10,7 +10,6 @@ using Aml.Engine.CAEX;
 using AasxIntegrationBase;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxAmlImExport/AmlImport.cs
+++ b/src/AasxAmlImExport/AmlImport.cs
@@ -10,7 +10,6 @@ using Aml.Engine.CAEX;
 using AasxIntegrationBase;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxCsharpLibrary/AasxCompatibilityModels/V10/AdminShellV10.cs
+++ b/src/AasxCsharpLibrary/AasxCompatibilityModels/V10/AdminShellV10.cs
@@ -13,7 +13,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxCsharpLibrary/AdminShell.cs
+++ b/src/AasxCsharpLibrary/AdminShell.cs
@@ -15,7 +15,6 @@ using System.Reflection;
 using System.Linq;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxGenerate/Log.cs
+++ b/src/AasxGenerate/Log.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Text;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxGenerate/Program.cs
+++ b/src/AasxGenerate/Program.cs
@@ -15,7 +15,6 @@ using AasxIntegrationBase.AasForms;
 #pragma warning disable CS0162 // dead code
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxGenerate/UriIdentifierRepository.cs
+++ b/src/AasxGenerate/UriIdentifierRepository.cs
@@ -12,7 +12,6 @@ using System.Text.RegularExpressions;
 using System.Globalization;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxIntegrationBase/LogInstance.cs
+++ b/src/AasxIntegrationBase/LogInstance.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md). */
 

--- a/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml
+++ b/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml
@@ -8,7 +8,6 @@
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml.cs
@@ -17,7 +17,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxIntegrationBaseWpf/IFlyoutControl.cs
+++ b/src/AasxIntegrationBaseWpf/IFlyoutControl.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxIntegrationBaseWpf/IFlyoutProvider.cs
+++ b/src/AasxIntegrationBaseWpf/IFlyoutProvider.cs
@@ -7,7 +7,6 @@ using System.Windows;
 using System.Windows.Controls;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml
+++ b/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml
@@ -7,7 +7,6 @@
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml.cs
@@ -17,7 +17,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxIntegrationBaseWpf/Resources/Graphics.xaml
+++ b/src/AasxIntegrationBaseWpf/Resources/Graphics.xaml
@@ -3,7 +3,6 @@
                     xmlns:local="clr-namespace:AasxIntegrationBase">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxIntegrationBaseWpf/Themes/Generic.xaml
+++ b/src/AasxIntegrationBaseWpf/Themes/Generic.xaml
@@ -3,7 +3,6 @@
                     xmlns:local="clr-namespace:AasxIntegrationBase">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 -->
 
     <Style x:Key="TranspRoundCorner" TargetType="{x:Type Button}">

--- a/src/AasxIntegrationEmptySample/Plugin.cs
+++ b/src/AasxIntegrationEmptySample/Plugin.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 */
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase

--- a/src/AasxMqtt/Plugin.cs
+++ b/src/AasxMqtt/Plugin.cs
@@ -11,7 +11,6 @@ using JetBrains.Annotations;
    Copyright (c) 2019 Fraunhofer IOSB-INA Lemgo, eine rechtlich nicht selbständige Einrichtung der Fraunhofer-Gesellschaft
     zur Förderung der angewandten Forschung e.V. <florian.pethig@iosb-ina.fraunhofer.de>, author: Florian Pethig
 
-   This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 */
 
 /* For Mqtt Content:

--- a/src/AasxMqttClient/GrapevineLoggerConsumers.cs
+++ b/src/AasxMqttClient/GrapevineLoggerConsumers.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxMqttClient/MqttClient.cs
+++ b/src/AasxMqttClient/MqttClient.cs
@@ -13,7 +13,6 @@ using AdminShellNS;
    Copyright (c) 2019 Fraunhofer IOSB-INA Lemgo, eine rechtlich nicht selbständige Einrichtung der Fraunhofer-Gesellschaft
     zur Förderung der angewandten Forschung e.V. <florian.pethig@iosb-ina.fraunhofer.de>, author: Florian Pethig
 
-   This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 */
 
 /* For Mqtt Content:

--- a/src/AasxPackageExplorer/AboutBox.xaml
+++ b/src/AasxPackageExplorer/AboutBox.xaml
@@ -8,7 +8,6 @@
         Title="About" Height="500" Width="600" Loaded="Window_Loaded" MinWidth="150">
 
  <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPackageExplorer/AboutBox.xaml.cs
+++ b/src/AasxPackageExplorer/AboutBox.xaml.cs
@@ -15,7 +15,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
@@ -39,7 +38,7 @@ namespace AasxPackageExplorer
             this.HeaderText.Text = "AASX Package Explorer\n" +
                 "Copyright (c) 2018-2020 Festo AG & Co. KG and further (see below)\n" +
                 "Authors: " + Options.Curr.PrefAuthors + " (see below)\n" +
-                "This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see below)" + "\n" +
+                "This software is licensed under the Apache License 2.0 (see below)" + "\n" +
                 "Version: " + Options.Curr.PrefVersion + "\n" +
                 "Build date: " + Options.Curr.PrefBuildDate;
 

--- a/src/AasxPackageExplorer/App.config
+++ b/src/AasxPackageExplorer/App.config
@@ -2,7 +2,6 @@
 <configuration>
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPackageExplorer/App.xaml
+++ b/src/AasxPackageExplorer/App.xaml
@@ -5,7 +5,6 @@
              Startup="Application_Startup">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPackageExplorer/App.xaml.cs
+++ b/src/AasxPackageExplorer/App.xaml.cs
@@ -11,7 +11,6 @@ using System.Windows;
 using JetBrains.Annotations;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
+++ b/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
@@ -10,7 +10,6 @@
     <!-- -->    
     
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
@@ -43,11 +42,11 @@ The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www
 
                 <ScrollViewer  Grid.Column="1" Grid.Row="3" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                 <TextBlock x:Name="TextBlockLicenses" FontSize="9" TextWrapping="Wrap" Margin="0,8,0,0" VerticalAlignment="Top">
-                    This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0).  <LineBreak/>
+                    This software is licensed under the Apache License 2.0. <LineBreak/>
                     The browser functionality is under the cefSharp. <LineBreak/>
                     The JSON serialization is under the MIT (Newtonsoft.JSON). <LineBreak/>
                     The QR code generation is under the MIT license (QRcoder). <LineBreak/>
-                    The Dot Matrix Code generation is under Apache license v.2 (ZXing.Net). <LineBreak/>
+                    The Dot Matrix Code generation is under the Apache License 2.0 (ZXing.Net). <LineBreak/>
                 </TextBlock>
                 </ScrollViewer>
 

--- a/src/AasxPackageExplorer/CustomSplashScreenNew.xaml.cs
+++ b/src/AasxPackageExplorer/CustomSplashScreenNew.xaml.cs
@@ -16,7 +16,6 @@ using System.Windows.Shapes;
 using System.Windows.Threading;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -33,7 +33,6 @@ using System.Windows.Forms;
 /* Copyright (c) 2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
    Copyright (c) 2019 Phoenix Contact GmbH & Co. KG <>, author: Andreas Orzelski 
   
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPackageExplorer/MainWindow.xaml
+++ b/src/AasxPackageExplorer/MainWindow.xaml
@@ -12,7 +12,6 @@
         PreviewKeyDown="mainWindow_PreviewKeyDown" >
 
     <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPackageExplorer/MainWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MainWindow.xaml.cs
@@ -21,7 +21,6 @@ using AasxIntegrationBase;
 // using SampleClient; // Read property values by OPC UA
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPackageExplorer/MessageReportWindow.xaml
+++ b/src/AasxPackageExplorer/MessageReportWindow.xaml
@@ -8,7 +8,6 @@
         Title="Message Report" Height="600" Width="800">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPackageExplorer/MessageReportWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MessageReportWindow.xaml.cs
@@ -15,7 +15,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPluginBomStructure/GenericBomControl.cs
+++ b/src/AasxPluginBomStructure/GenericBomControl.cs
@@ -9,7 +9,6 @@ using AasxIntegrationBase;
 using AdminShellNS;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
 The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
 */

--- a/src/AasxPluginBomStructure/Plugin.cs
+++ b/src/AasxPluginBomStructure/Plugin.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
 The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
 */

--- a/src/AasxPluginDocumentShelf/Plugin.cs
+++ b/src/AasxPluginDocumentShelf/Plugin.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
 The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
 */

--- a/src/AasxPluginExportTable/ExportTableFlyout.xaml
+++ b/src/AasxPluginExportTable/ExportTableFlyout.xaml
@@ -9,7 +9,6 @@
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPluginExportTable/ExportTableFlyout.xaml.cs
+++ b/src/AasxPluginExportTable/ExportTableFlyout.xaml.cs
@@ -21,7 +21,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxPluginExportTable/Plugin.cs
+++ b/src/AasxPluginExportTable/Plugin.cs
@@ -11,7 +11,6 @@ using System.Windows;
 using JetBrains.Annotations;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
 The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
 */

--- a/src/AasxPluginExportTable/Themes/Generic.xaml
+++ b/src/AasxPluginExportTable/Themes/Generic.xaml
@@ -3,7 +3,6 @@
                     xmlns:local="clr-namespace:AasxPluginExportTable">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The OpenXML SDK is under MIT license. 
 -->
 

--- a/src/AasxPluginGenericForms/Plugin.cs
+++ b/src/AasxPluginGenericForms/Plugin.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
 The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
 */

--- a/src/AasxPluginTechnicalData/Plugin.cs
+++ b/src/AasxPluginTechnicalData/Plugin.cs
@@ -10,7 +10,6 @@ using System.Windows.Controls;
 using JetBrains.Annotations;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
 The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
 */

--- a/src/AasxPluginWebBrowser/Plugin.cs
+++ b/src/AasxPluginWebBrowser/Plugin.cs
@@ -11,7 +11,6 @@ using System.Windows.Controls;
 using JetBrains.Annotations;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
 The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
 */

--- a/src/AasxRestServerLibrary/AasxHttpContextHelper.cs
+++ b/src/AasxRestServerLibrary/AasxHttpContextHelper.cs
@@ -21,7 +21,6 @@ using System.Dynamic;
 using System.Globalization;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxRestServerLibrary/AasxHttpHandleStore.cs
+++ b/src/AasxRestServerLibrary/AasxHttpHandleStore.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading.Tasks;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxRestServerLibrary/AasxRestServer.cs
+++ b/src/AasxRestServerLibrary/AasxRestServer.cs
@@ -18,7 +18,6 @@ using System.Reflection;
 using Grapevine.Interfaces.Shared;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxRestServerLibrary/GrapevineLoggerConsumers.cs
+++ b/src/AasxRestServerLibrary/GrapevineLoggerConsumers.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/AasxPrintFunctions.cs
+++ b/src/AasxWpfControlLibrary/AasxPrintFunctions.cs
@@ -16,7 +16,6 @@ using Newtonsoft.Json;
 using System.IO;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation (QRCoder) is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml
+++ b/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml
@@ -8,7 +8,6 @@
              d:DesignHeight="300" d:DesignWidth="600">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml.cs
+++ b/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml.cs
@@ -18,7 +18,6 @@ using AdminShellNS;
 using JetBrains.Annotations;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml
+++ b/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml
@@ -8,7 +8,6 @@
              d:DesignHeight="300" d:DesignWidth="300" Loaded="UserControl_Loaded">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
+++ b/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
@@ -20,7 +20,6 @@ using AdminShellNS;
 using AasxIntegrationBase;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/DispEditHelper.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelper.cs
@@ -15,7 +15,6 @@ using AdminShellNS;
 using AasxGlobalLogging;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/EclassUtils.cs
+++ b/src/AasxWpfControlLibrary/EclassUtils.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using System.Xml;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/FakeBrowser.xaml
+++ b/src/AasxWpfControlLibrary/FakeBrowser.xaml
@@ -8,7 +8,6 @@
              d:DesignHeight="300" d:DesignWidth="300">
     
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/FakeBrowser.xaml.cs
+++ b/src/AasxWpfControlLibrary/FakeBrowser.xaml.cs
@@ -14,7 +14,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/HintBubble.xaml
+++ b/src/AasxWpfControlLibrary/HintBubble.xaml
@@ -8,7 +8,6 @@
              d:DesignHeight="100" d:DesignWidth="300">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/HintBubble.xaml.cs
+++ b/src/AasxWpfControlLibrary/HintBubble.xaml.cs
@@ -14,7 +14,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/LogMessageFlyout.xaml
+++ b/src/AasxWpfControlLibrary/LogMessageFlyout.xaml
@@ -7,7 +7,6 @@
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
 
     <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/LogMessageFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/LogMessageFlyout.xaml.cs
@@ -19,7 +19,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/ModifyRepo.cs
+++ b/src/AasxWpfControlLibrary/ModifyRepo.cs
@@ -9,7 +9,6 @@ using System.Windows.Controls;
 using System.Windows.Input;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/Options.cs
+++ b/src/AasxWpfControlLibrary/Options.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using System.Windows.Media;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
@@ -86,12 +85,12 @@ namespace AasxPackageExplorer
         /// The current (used) licenses of the application. Use of Options as singleton.
         /// </summary>
         [JsonIgnore]
-        public string PrefLicenseShort = "This software is licensed under the Eclipse Public License 2.0 (EPL-2.0)." + Environment.NewLine +
+        public string PrefLicenseShort = "This software is licensed under the Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
                 "The browser functionality is licensed under the cefSharp license." + Environment.NewLine +
                 "The Newtonsoft.JSON serialization is licensed under the MIT License (MIT)." + Environment.NewLine +
                 "The QR code generation is licensed under the MIT license (MIT)." + Environment.NewLine +
                 "The Zxing.Net Dot Matrix Code (DMC) generation is licensed under the Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
-                "The Grapevine REST server framework is licensed under Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
+                "The Grapevine REST server framework is licensed under the Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
                 "The AutomationML.Engine is licensed under the MIT license (MIT).";
 
         /// <summary>

--- a/src/AasxWpfControlLibrary/Plugins.cs
+++ b/src/AasxWpfControlLibrary/Plugins.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Threading.Tasks;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).

--- a/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml
+++ b/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml
@@ -7,7 +7,6 @@
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
 
     <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml.cs
@@ -17,7 +17,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml
@@ -9,7 +9,6 @@
              d:DesignHeight="400" d:DesignWidth="900" MaxHeight="600" MaxWidth="1600" Loaded="UserControl_Loaded">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml.cs
@@ -22,7 +22,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectAasEntityDialogueByTree.xaml
+++ b/src/AasxWpfControlLibrary/SelectAasEntityDialogueByTree.xaml
@@ -8,7 +8,6 @@
         Title="Select AAS entity .." Height="300" Width="542.535" Loaded="Window_Loaded">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectAasEntityDialogueByTree.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectAasEntityDialogueByTree.xaml.cs
@@ -15,7 +15,6 @@ using System.Windows.Shapes;
 using AdminShellNS;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml
+++ b/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml
@@ -9,7 +9,6 @@
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
 
     <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml.cs
@@ -18,7 +18,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectEclassEntity.xaml
+++ b/src/AasxWpfControlLibrary/SelectEclassEntity.xaml
@@ -8,7 +8,6 @@
         Title="Select eCl@ss entity .." Height="300" Width="700" Loaded="Window_Loaded">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectEclassEntity.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectEclassEntity.xaml.cs
@@ -18,7 +18,6 @@ using System.Xml;
 using AdminShellNS;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml
@@ -9,7 +9,6 @@
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml.cs
@@ -19,7 +19,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml
@@ -10,7 +10,6 @@
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
 
     <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml.cs
@@ -18,7 +18,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml
@@ -8,7 +8,6 @@
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded" KeyDown="UserControl_KeyDown">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml.cs
@@ -17,7 +17,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml
@@ -10,7 +10,6 @@
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
 
     <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml.cs
@@ -19,7 +19,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/TextBoxFlyout.xaml
+++ b/src/AasxWpfControlLibrary/TextBoxFlyout.xaml
@@ -7,7 +7,6 @@
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/TextBoxFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/TextBoxFlyout.xaml.cs
@@ -17,7 +17,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/Themes/Generic.xaml
+++ b/src/AasxWpfControlLibrary/Themes/Generic.xaml
@@ -3,7 +3,6 @@
                     xmlns:local="clr-namespace:AasxWpfControlLibrary">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/TreeListView.cs
+++ b/src/AasxWpfControlLibrary/TreeListView.cs
@@ -16,7 +16,6 @@ using System.Windows.Shapes;
 using System.Windows.Controls.Primitives;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/VisualAasxElements.cs
+++ b/src/AasxWpfControlLibrary/VisualAasxElements.cs
@@ -11,7 +11,6 @@ using System.Windows.Media;
 using AdminShellNS;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml
+++ b/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml
@@ -10,7 +10,6 @@
              d:DesignHeight="30" d:DesignWidth="200" Loaded="UserControl_Loaded">
 
 <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).

--- a/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml.cs
+++ b/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml.cs
@@ -19,7 +19,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-This software is licensed under the Eclipse Public License - v 2.0 (EPL-2.0) (see https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt).
 The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
 The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
 The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).


### PR DESCRIPTION
The Eclipse Foundation license is a legacy from when the code based
lived on Eclipse Foundation servers and was mandated by it. We changed
the license to Apache 2 during the migration from Gitlab to Github
repository.