### PR TITLE
Remove obsolete splash screen PNG

### DIFF
--- a/src/AasxPackageExplorer/AasxPackageExplorer.csproj
+++ b/src/AasxPackageExplorer/AasxPackageExplorer.csproj
@@ -326,9 +326,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Resource Include="Resources\splash_screen.png" />
-  </ItemGroup>
-  <ItemGroup>
     <Resource Include="icon-set\aasx.ico" />
     <None Include="icon-set\how-to.txt" />
     <None Include="icon-set\Icon_AASX_16x16_2_W.bmp" />

--- a/src/AasxPackageExplorer/Resources/splash_screen.png
+++ b/src/AasxPackageExplorer/Resources/splash_screen.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5f3de5b71ef3115d71ab6cf01bea6d0d5e9623f46d0ecf81ef5add7c58db9b61
-size 21711


### PR DESCRIPTION
The splash screen was later implemented *via* `CustomSplashScreenNew`
class which made the `splash_screen.png` obsolete.