### PR TITLE
Upgrade commit message checker to 1.0.4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@master
  
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v1.0.0
+        uses: mristin/opinionated-commit-message@v1.0.4
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.0


### PR DESCRIPTION
This upgrades the checker used in the Github action to check commit
messages to latest version 1.0.3 (due to: additional verbs in the
accepted list, tolerance for codes after squash & merge).