### PR TITLE
Introduce dotnet tool manifest

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,35 +23,14 @@ jobs:
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.0.2
 
-      - name: Install Microsoft .NET Compilers
-        run: nuget install Microsoft.NET.Compilers -Version 2.10.0 -OutputDirectory tools
-
-      - name: Install Nunit Console Runner
-        run: nuget install NUnit.ConsoleRunner -Version 3.11.1 -OutputDirectory tools
-
-      - name: Install Nunit Project Loader
-        run: nuget install NUnit.Extension.NUnitProjectLoader -Version 3.6.0 -OutputDirectory tools
-
-      - name: Install OpenCover
-        run: nuget install OpenCover -Version 4.7.922 -OutputDirectory tools
-
-      - name: Install ReportGenerator
-        run: nuget install ReportGenerator -Version 4.6.0 -OutputDirectory tools
-
-      - name: Install Resharper CLI
-        run: nuget install JetBrains.ReSharper.CommandLineTools -Version 2020.1.2 -OutputDirectory tools
-
       - name: Install .NET core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.100'
 
-      - name: Restore NuGet Packages
+      - name: Install build dependencies
         working-directory: src
-        run: nuget restore AasxPackageExplorer.sln
-
-      - name: Install dotnet-format
-        run: dotnet tool install -g dotnet-format --version 3.3.111304
+        run: powershell .\InstallBuildDependencies.ps1
 
       - name: Check format
         working-directory: src
@@ -68,4 +47,3 @@ jobs:
       - name: Inspect code
         working-directory: src
         run: powershell .\InspectCode.ps1
-

--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-format": {
+      "version": "3.3.111304",
+      "commands": [
+        "dotnet-format"
+      ]
+    }
+  }
+}

--- a/src/CheckLicenses.ps1
+++ b/src/CheckLicenses.ps1
@@ -13,20 +13,20 @@ function Main
     $includes = @($srcDir)
 
     $excludes = @{
-    # Example
-    # $( Join-Path $srcDir "AasxPluginBomStructure" ) = true
+        $( Join-Path $srcDir ".config" ) = $true
+        $( Join-Path $srcDir ".idea" ) = $true
     }
 
     $acceptedDirs = @()
-    foreach ($dir in $( Dir -Directory $srcDir|Select -Expand FullName ))
+    foreach ($dir in $( Get-ChildItem -Directory $srcDir -Force|Select-Object -Expand FullName ))
     {
-        if (!$excludes.ContainsKey($dir) -or !$excludes[$dir])
+        if (($excludes.ContainsKey($dir)) -and ($excludes[$dir]))
         {
-            $acceptedDirs += $dir
+            Write-Host "The subdirectory is exluded intentionally: $dir"
         }
         else
         {
-            Write-Host "The subdirectory is exluded intentionally: $dir"
+            $acceptedDirs += $dir
         }
     }
 

--- a/src/InstallBuildDependencies.ps1
+++ b/src/InstallBuildDependencies.ps1
@@ -1,35 +1,46 @@
-﻿# This script installs the dependencies necessary to build the solution.
-# The script uses nuget and the dependencies are stored in the packages/ 
-# subdirectory.
+﻿<#
+.Synopsis
+This script installs the dependencies necessary to build the solution.
+#>
 
-if ((Get-Command "nuget.exe" -ErrorAction SilentlyContinue) -eq $null)
-{ 
-   throw "Unable to find nuget.exe in your PATH"
+Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
+    AssertDotnet, `
+    GetToolsDir
+
+function Main {
+    if ($null -eq (Get-Command "nuget.exe" -ErrorAction SilentlyContinue))
+    {
+       throw "Unable to find nuget.exe in your PATH"
+    }
+
+    $toolsDir = GetToolsDir
+    New-Item -ItemType Directory -Force -Path $toolsDir
+
+    Write-Host "Installing .NET compilers 2.10.0 ..."
+    nuget install Microsoft.NET.Compilers -Version 2.10.0 `
+        -OutputDirectory $toolsDir
+
+    Write-Host "Installing Nunit Console Runner ..."
+    nuget install NUnit.ConsoleRunner -Version 3.11.1 `
+        -OutputDirectory $toolsDir
+
+    nuget install NUnit.Extension.NUnitProjectLoader -Version 3.6.0 `
+        -OutputDirectory $toolsDir
+
+    Write-Host "Installing OpenCover ..."
+    nuget install OpenCover -Version 4.7.922 -OutputDirectory $toolsDir
+    nuget install ReportGenerator -Version 4.6.0 -OutputDirectory $toolsDir
+
+    Write-Host "Installing Resharper CLI ..."
+    nuget install JetBrains.ReSharper.CommandLineTools -Version 2020.1.2 -OutputDirectory $toolsDir
+    
+    cd $PSScriptRoot
+
+    Write-Host "Restoring dotnet tools for the solution ..."
+    dotnet tool restore
+
+    Write-Host "Restoring packages for the solution ..."
+    nuget.exe restore AasxPackageExplorer.sln
 }
 
-$toolsDir = Join-Path (Split-Path $PSScriptRoot -Parent) "tools"
-New-Item -ItemType Directory -Force -Path $toolsDir
-
-Write-Host "Installing the tools in: $toolsDir"
-
-Write-Host "Installing .NET compilers 2.10.0 ..."
-nuget install Microsoft.NET.Compilers -Version 2.10.0 `
-    -OutputDirectory $toolsDir
-
-Write-Host "Installing Nunit Console Runner ..."
-nuget install NUnit.ConsoleRunner -Version 3.11.1 `
-    -OutputDirectory $toolsDir
-
-nuget install NUnit.Extension.NUnitProjectLoader -Version 3.6.0 `
-    -OutputDirectory $toolsDir
-
-Write-Host "Installing OpenCover ..."
-nuget install OpenCover -Version 4.7.922 -OutputDirectory $toolsDir
-nuget install ReportGenerator -Version 4.6.0 -OutputDirectory $toolsDir
-
-Write-Host "Installing Resharper CLI ..."
-nuget install JetBrains.ReSharper.CommandLineTools -Version 2020.1.2 -OutputDirectory $toolsDir
-
-Write-Host "Restoring packages for the solution ..."
-cd $PSScriptRoot
-nuget.exe restore AasxPackageExplorer.sln
+Main

--- a/src/InstallDevDependencies.ps1
+++ b/src/InstallDevDependencies.ps1
@@ -48,6 +48,3 @@ Invoke-WebRequest `
 
 & $installationDir\dotnet-install.ps1 -Version 3.1.202
 & $installationDir\dotnet-install.ps1 -Runtime dotnet -Version 3.1.4
-
-Write-Host "Install dotnet-format ..."
-dotnet tool install --global dotnet-format --version 3.3.111304


### PR DESCRIPTION
The tool manifest allow us to pin the versions of the dotnet tools
specific to this solution. Additionally, `dotnet tool restore` is a
handy way to install them locally.