### PR TITLE
Remove excludes in CopyLicense.ps1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 The file `LICENSE.TXT` in the main folder of the repo is the leading license
 information, even if it does not show up in the Visual Studio solution. To
-update all dependent license files, manually start `CopyLicense.bat`.
+update all dependent license files, manually start `src/CopyLicense.ps1`.
 
 ## Pull Requests
 

--- a/src/CopyLicense.ps1
+++ b/src/CopyLicense.ps1
@@ -17,7 +17,8 @@ function Main
     # Excludes and includes need to be absolute paths.
 
     $excludes = @{
-        $( Join-Path $srcDir "AasxPluginBomStructure" ) = true
+    # Example:
+    # $( Join-Path $srcDir "AasxPluginBomStructure" ) = true
     }
 
     $includes = @(


### PR DESCRIPTION
Some plugin directories had custom `LICENSE.txt` files. We will move to
a different system in the near future (probably: same `LICENSE.txt`
for all subdirectories and special `LICENSE-PLUGIN.txt` for the
plugins).