### PR TITLE
Remove Notes{,Backup}.txt from project file

### DIFF
--- a/src/AasxPackageExplorer/AasxPackageExplorer.csproj
+++ b/src/AasxPackageExplorer/AasxPackageExplorer.csproj
@@ -246,9 +246,6 @@
     <Resource Include="Resources\round_right.png" />
   </ItemGroup>
   <ItemGroup>
-    <Resource Include="NotesBackup.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <Resource Include="Resources\thumb-aasxplore.ico" />
   </ItemGroup>
   <ItemGroup>
@@ -262,9 +259,6 @@
       <ProductName>.NET Framework 3.5 SP1</ProductName>
       <Install>false</Install>
     </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup>
-    <Resource Include="Notes.txt" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxAmlImExport\AasxAmlImExport.csproj">


### PR DESCRIPTION
The `src/AasxPackageExplorer/Notes{,Backup}.txt` files were moved outside the source tree in 8fc82bfb620a221274fbe8ad8728ad37e441d505, but they were still present in the project definition.  This caused build errors when building the project within Visual Studio.

This patch removes the obsolete files from the project file to fix the build.