### PR TITLE
Fix CheckLicenses.ps1 name in Check.ps1

### DIFF
--- a/src/Check.ps1
+++ b/src/Check.ps1
@@ -6,7 +6,7 @@ check the quality of the code base.
 $ErrorActionPreference = "Stop"
 
 Set-Location $PSScriptRoot
-.\CheckLicense.ps1
+.\CheckLicenses.ps1
 .\CheckFormat.ps1
 .\CheckDeadCode.ps1
 .\Build.ps1


### PR DESCRIPTION
The `Check.ps1` script had a typo in the `CheckLicenses.ps1` invocation.  This patch fixes the typo.