### PR TITLE
Upgrade commit message check to 1.0.5

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v1.0.4
+        uses: mristin/opinionated-commit-message@v1.0.5
 
       - name: Check licenses
         working-directory: src

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v1.0.4
+        uses: mristin/opinionated-commit-message@v1.0.5


### PR DESCRIPTION
This updates the version of opinionated-commit-message in workflows
to version 1.0.5. We need this since the verbs "reformat" and
"update" are quite necessary.