### PR TITLE
Add bite-sized to CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,6 +39,10 @@ jobs:
         working-directory: src
         run: powershell .\CheckFormat.ps1
 
+      - name: Check bite-sized
+        working-directory: src
+        run: powershell .\CheckBiteSized.ps1
+
       - name: Check dead code
         working-directory: src
         run: powershell .\CheckDeadCode.ps1

--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "dead-csharp"
       ]
+    },
+    "bitesized": {
+      "version": "1.0.0-beta1",
+      "commands": [
+        "bite-sized"
+      ]
     }
   }
 }

--- a/src/Check.ps1
+++ b/src/Check.ps1
@@ -8,6 +8,7 @@ $ErrorActionPreference = "Stop"
 Set-Location $PSScriptRoot
 .\CheckLicenses.ps1
 .\CheckFormat.ps1
+.\CheckBiteSized.ps1
 .\CheckDeadCode.ps1
 .\Build.ps1
 .\Test.ps1

--- a/src/CheckBiteSized.ps1
+++ b/src/CheckBiteSized.ps1
@@ -1,0 +1,40 @@
+#!/usr/bin/env pwsh
+<#
+This script checks that the C# files are "bite sized": no long lines, not too long.
+#>
+
+Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
+    AssertDotnetToolVersion
+
+function Main {
+    AssertDotnetToolVersion -PackageID "BiteSized" -ExpectedVersion "1.0.0-beta1"
+
+    Set-Location $PSScriptRoot
+
+    # Exclude:
+    # * Auto-generated files
+    # * Files containing too many hard-wired strings
+    # * External, third-party files
+
+    dotnet bite-sized `
+        --inputs "**/*.cs" `
+        --excludes `
+            "**/obj/**" `
+            "packages/**" `
+            "**/Settings.Designer.cs" `
+            "**/Resources.Designer.cs" `
+            "AasxGenerate/Program.cs" `
+            "AasxPluginExportTable/ExportTableFlyout.xaml.cs" `
+            "MsaglWpfControl/GraphViewer.cs" `
+            "MsaglWpfControl/VEdge.cs" `
+            "MsaglWpfControl/VNode.cs" `
+        --max-lines-in-file 100000 `
+        --max-line-length 120
+
+    if($LASTEXITCODE -ne 0)
+    {
+        throw "The bite-sized check failed."
+    }
+}
+
+Main

--- a/src/Common.psm1
+++ b/src/Common.psm1
@@ -224,6 +224,7 @@ function CreateAndGetArtefactsDir
 Export-ModuleMember -Function `
     GetToolsDir, `
      AssertDotnet, `
+     AssertDotnetToolVersion, `
      AssertDotnetFormatVersion, `
      AssertDeadCsharpVersion, `
      FindMSBuild, `


### PR DESCRIPTION
This introduces bite-sized to the CI in order to limit the line length
and the total number of lines in the C# files.