### PR TITLE
Upgrade DeadCsharp to 1.0.0-beta4

### DIFF
--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "deadcsharp": {
-      "version": "1.0.0-beta3",
+      "version": "1.0.0-beta4",
       "commands": [
         "dead-csharp"
       ]

--- a/src/Common.psm1
+++ b/src/Common.psm1
@@ -157,7 +157,7 @@ Check the version of dead-csharp so that the dead code is always detected in the
 #>
 function AssertDeadCsharpVersion
 {
-    AssertDotnetToolVersion -packageID "deadcsharp" -expectedVersion "1.0.0-beta3"
+    AssertDotnetToolVersion -packageID "deadcsharp" -expectedVersion "1.0.0-beta4"
 }
 
 function FindInspectCode


### PR DESCRIPTION
The version 1.0.0-beta4 of DeadCsharp detects dead attributes.