### PR TITLE
Upgrade commit message checker to 1.0.7

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v1.0.5
+        uses: mristin/opinionated-commit-message@v1.0.7
 
       - name: Check licenses
         working-directory: src

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v1.0.5
+        uses: mristin/opinionated-commit-message@v1.0.7


### PR DESCRIPTION
The previous version of the checker lacked "rename" and "revert",
widely used verbs in the context of programming, in its list of
accepted header verbs. This new version 1.07 adds these two
verbs.