### PR TITLE
Upgrade commit-message-checker to 1.0.8

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v1.0.7
+        uses: mristin/opinionated-commit-message@v1.0.8
 
       - name: Check licenses
         working-directory: src


### PR DESCRIPTION
This upgrade adds "correct" and "invalidate" to the list of accepted
verbs in the subject of the commit message.