### PR TITLE
Fix FindMSBuild null bug in Common.psm1

### DIFF
--- a/src/Common.psm1
+++ b/src/Common.psm1
@@ -21,7 +21,7 @@ function FindMSBuild
 
     $msbuildCommand = Get-Command "MSBuild.exe" -ErrorAction SilentlyContinue
     $msbuildFailedSearches = @()
-    if ($null -eq $msbuildCommand)
+    if ($null -ne $msbuildCommand)
     {
         $msbuild = $msbuildCommand.Source
     }
@@ -32,6 +32,7 @@ function FindMSBuild
         {
             throw "Could not find vswhere at: $vswherePath"
         }
+
         $ids = 'Community', 'Professional', 'Enterprise', 'BuildTools' `
             | ForEach-Object { 'Microsoft.VisualStudio.Product.' + $_ }
 
@@ -62,7 +63,7 @@ function FindMSBuild
 
     if (!$msbuild)
     {
-        throw "Could not find MSBuild. Searched in PATH and at the following locations: $( $msbuildFailedSearches -join ';' )"
+        throw "Could not find MSBuild in PATH and at these locations: $( $msbuildFailedSearches -join ';' )"
     }
 
     return $msbuild


### PR DESCRIPTION
FindMSBuild function in Common.psm1 compared MS Build location against
`$null` instead of not-equal. This was caused by a superficial
refactoring.

The bug was only visible locally when MSBuild was not in the PATH.