### PR TITLE
Stop InstallBuildDependencies.ps1 on errors

### DIFF
--- a/src/InstallBuildDependencies.ps1
+++ b/src/InstallBuildDependencies.ps1
@@ -3,6 +3,8 @@
 This script installs the dependencies necessary to build the solution.
 #>
 
+$ErrorActionPreference = "Stop"
+
 Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
     AssertDotnet, `
     GetToolsDir


### PR DESCRIPTION
This change makes the InstallBuildDependencies.ps1 halt on any print
to STDERR by setting `$ErrorActionPreference`.