### PR TITLE
Introduce caching of code inspection in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,6 +55,14 @@ jobs:
         working-directory: src
         run: powershell .\Test.ps1
 
+      - name: Cache inspect code
+        uses: actions/cache@v2
+        env:
+          cache-name: inspect-code
+        with:
+          path: artefacts/inspectcode-caches
+          key: ${{ env.cache-name }}-2020-07-06-T-14-40Z
+
       - name: Inspect code
         working-directory: src
         run: powershell .\InspectCode.ps1

--- a/src/InspectCode.ps1
+++ b/src/InspectCode.ps1
@@ -21,12 +21,19 @@ function Main
 
     Write-Host "Inspecting the code with inspectcode.exe ..."
 
+    $cachesHome = Join-Path $artefactsDir "inspectcode-caches"
+    New-Item -ItemType Directory -Force -Path "$cachesHome"|Out-Null
+
+    $excludePattern = '*\obj\*'
+
     # InspectCode passes over the properties to MSBuild,
     # see https://www.jetbrains.com/help/resharper/InspectCode.html#msbuild-related-parameters
     & $inspectcode `
         "--properties:Configuration=Debug" `
         "--properties:Platform=x64" `
         "-o=$codeInspectionPath" `
+        "--caches-home=$cachesHome" `
+        '--exclude=*\obj\*;packages\*;*\bin\*' `
         AasxPackageExplorer.sln
 
     [xml]$inspection = Get-Content $codeInspectionPath


### PR DESCRIPTION
It takes a long time to inspect all the code from scratch (~ minutes).
This change instructs Github to keep the inspectcode caches between
the runs to accelerate the inspection.

The key of the cache was arbitrarily set to the today's date. To
invalidate the cache, simply set a different key.