### PR TITLE
Introduce caching of tools in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,6 +31,26 @@ jobs:
         with:
           dotnet-version: '3.1.100'
 
+      - name: Cache local nuget tools
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-local-nuget-tools
+        with:
+          path: tools
+          key: ${{ env.cache-name }}-${{ hashFiles('src/InstallTools.ps1') }}-${{ hashFiles('src/.config/dotnet-tools.json') }}
+
+      - name: Cache global nuget packages
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-global-nuget-packages
+        with:
+          path: ~/.nuget/packages/
+          key: ${{ env.cache-name }}-${{ hashFiles('src/InstallTools.ps1') }}-${{ hashFiles('src/.config/dotnet-tools.json') }}
+
+      - name: Install tools
+        working-directory: src
+        run: powershell .\InstallTools.ps1
+
       - name: Install build dependencies
         working-directory: src
         run: powershell .\InstallBuildDependencies.ps1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,12 @@ run:
 .\InstallDevDependencies.ps1
 ```
 
+To install the tools for building & checking, call:
+
+```powershell
+.\InstallTools.ps1
+```
+
 To install the solution dependencies, invoke:
 
 ```powershell

--- a/src/InstallBuildDependencies.ps1
+++ b/src/InstallBuildDependencies.ps1
@@ -15,32 +15,6 @@ function Main {
        throw "Unable to find nuget.exe in your PATH"
     }
 
-    $toolsDir = GetToolsDir
-    New-Item -ItemType Directory -Force -Path $toolsDir
-
-    Write-Host "Installing .NET compilers 2.10.0 ..."
-    nuget install Microsoft.NET.Compilers -Version 2.10.0 `
-        -OutputDirectory $toolsDir
-
-    Write-Host "Installing Nunit Console Runner ..."
-    nuget install NUnit.ConsoleRunner -Version 3.11.1 `
-        -OutputDirectory $toolsDir
-
-    nuget install NUnit.Extension.NUnitProjectLoader -Version 3.6.0 `
-        -OutputDirectory $toolsDir
-
-    Write-Host "Installing OpenCover ..."
-    nuget install OpenCover -Version 4.7.922 -OutputDirectory $toolsDir
-    nuget install ReportGenerator -Version 4.6.0 -OutputDirectory $toolsDir
-
-    Write-Host "Installing Resharper CLI ..."
-    nuget install JetBrains.ReSharper.CommandLineTools -Version 2020.1.2 -OutputDirectory $toolsDir
-    
-    cd $PSScriptRoot
-
-    Write-Host "Restoring dotnet tools for the solution ..."
-    dotnet tool restore
-
     Write-Host "Restoring packages for the solution ..."
     nuget.exe restore AasxPackageExplorer.sln
 }

--- a/src/InstallTools.ps1
+++ b/src/InstallTools.ps1
@@ -1,0 +1,45 @@
+<#
+.Synopsis
+This script installs the tools necessary to build and check the solution.
+#>
+
+Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
+    AssertDotnet, `
+    GetToolsDir
+
+function Main {
+    if ($null -eq (Get-Command "nuget.exe" -ErrorAction SilentlyContinue))
+    {
+       throw "Unable to find nuget.exe in your PATH"
+    }
+
+    AssertDotnet
+
+    $toolsDir = GetToolsDir
+    New-Item -ItemType Directory -Force -Path $toolsDir
+
+    Write-Host "Installing .NET compilers 2.10.0 ..."
+    nuget install Microsoft.NET.Compilers -Version 2.10.0 `
+        -OutputDirectory $toolsDir
+
+    Write-Host "Installing Nunit Console Runner ..."
+    nuget install NUnit.ConsoleRunner -Version 3.11.1 `
+        -OutputDirectory $toolsDir
+
+    nuget install NUnit.Extension.NUnitProjectLoader -Version 3.6.0 `
+        -OutputDirectory $toolsDir
+
+    Write-Host "Installing OpenCover ..."
+    nuget install OpenCover -Version 4.7.922 -OutputDirectory $toolsDir
+    nuget install ReportGenerator -Version 4.6.0 -OutputDirectory $toolsDir
+
+    Write-Host "Installing Resharper CLI ..."
+    nuget install JetBrains.ReSharper.CommandLineTools -Version 2020.1.2 -OutputDirectory $toolsDir
+
+    Set-Location $PSScriptRoot
+
+    Write-Host "Restoring dotnet tools for the solution ..."
+    dotnet tool restore
+}
+
+Main


### PR DESCRIPTION
This change factors out the installation of tools from the
InstallBuildDependencies.ps1 into InstallTools.ps1 so that we can
cache the tools separately on the server.