### PR TITLE
Fix missing test DLLs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,7 +45,7 @@ jobs:
           cache-name: cache-global-nuget-packages
         with:
           path: ~/.nuget/packages/
-          key: ${{ env.cache-name }}-${{ hashFiles('src/InstallTools.ps1') }}-${{ hashFiles('src/.config/dotnet-tools.json') }}
+          key: ${{ env.cache-name }}-${{ hashFiles('src/InstallTools.ps1') }}-${{ hashFiles('src/.config/dotnet-tools.json') }}-2020-07-06
 
       - name: Install tools
         working-directory: src

--- a/src/InstallBuildDependencies.ps1
+++ b/src/InstallBuildDependencies.ps1
@@ -15,8 +15,12 @@ function Main {
        throw "Unable to find nuget.exe in your PATH"
     }
 
+    Push-Location
+
+    Set-Location $PSScriptRoot
+
     Write-Host "Restoring packages for the solution ..."
-    nuget.exe restore AasxPackageExplorer.sln
+    nuget.exe restore AasxPackageExplorer.sln -PackagesDirectory packages
 }
 
 Main

--- a/src/tests.nunit
+++ b/src/tests.nunit
@@ -1,6 +1,0 @@
-<NUnitProject>
-  <Settings activeconfig="Debug"/>
-  <Config name="Debug">
-    <assembly path="AasxCsharpLibrary.Tests\bin\Debug\AasxCsharpLibrary.Tests.dll"/>
-  </Config>
-</NUnitProject>


### PR DESCRIPTION
The test DLLs were actually not executed, but the error went
unnoticed.

First, the main culprit is `src/tests.nunit` project file which messed
up the loading of DLLs such as dependencies stored in
`artefacts/build/Debug`. Second, the nuget dependencies were installed
globally (to `~/.nuget` instead of `src/packages`) and were
not found by nunit console.

This fix removes `src/tests.nunit` and specifies test DLLs explicitly
in `src/Test.ps1`.

The cache of global nuget packages had to be invalidated since
many packages were installed globally instead of `packages/`
directory.