### PR TITLE
Allow steps to fail in check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,7 @@ jobs:
 
       - name: Check the commit message(s)
         uses: mristin/opinionated-commit-message@v1.0.8
+        continue-on-error: true
 
       - name: Check licenses
         working-directory: src
@@ -58,14 +59,17 @@ jobs:
       - name: Check format
         working-directory: src
         run: powershell .\CheckFormat.ps1
+        continue-on-error: true
 
       - name: Check bite-sized
         working-directory: src
         run: powershell .\CheckBiteSized.ps1
+        continue-on-error: true
 
       - name: Check dead code
         working-directory: src
         run: powershell .\CheckDeadCode.ps1
+        continue-on-error: true
 
       - name: Build
         working-directory: src


### PR DESCRIPTION
This lets the job in check.yml Github workflow continue the execution
even though certain steps failed such as commit message check and
formatting check.

While the whole build still fails, it allows for faster development
so that the developer can get as much information from a remote CI
run as possible (instead of failing fast).