### PR TITLE
Run checks only on pull requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,9 +1,10 @@
 name: Check
 
 on:
-  push:
-    branches-ignore:
-      - '*/doc/*'
+  pull_request:
+    branches:
+      - master
+      - V20DataModel
 
 jobs:
   Execute:


### PR DESCRIPTION
This changes the check workflow to be only run when there is actually a
pull request.

This is useful for developers who want to push their changes to remote
frequently, but want to avoid wasting CI server resources.