### PR TITLE
Run style checks despite previous failures

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -14,16 +14,17 @@ jobs:
 
       - name: Check the commit message(s)
         uses: mristin/opinionated-commit-message@v1.0.8
-        continue-on-error: true
 
       - name: Check licenses
         working-directory: src
         run: powershell .\CheckLicenses.ps1
+        if: always()
 
       - name: Install .NET core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.100'
+        if: always()
 
       - name: Cache global nuget packages
         uses: actions/cache@v2
@@ -32,22 +33,24 @@ jobs:
         with:
           path: ~/.nuget/packages/
           key: ${{ env.cache-name }}-${{ hashFiles('src/InstallTools.ps1') }}-${{ hashFiles('src/.config/dotnet-tools.json') }}-2020-07-06
+        if: always()
 
       - name: Install tools for style
         working-directory: src
         run: powershell .\InstallToolsForStyle.ps1
+        if: always()
 
       - name: Check format
         working-directory: src
         run: powershell .\CheckFormat.ps1
-        continue-on-error: true
+        if: always()
 
       - name: Check bite-sized
         working-directory: src
         run: powershell .\CheckBiteSized.ps1
-        continue-on-error: true
+        if: always()
 
       - name: Check dead code
         working-directory: src
         run: powershell .\CheckDeadCode.ps1
-        continue-on-error: true
+        if: always()


### PR DESCRIPTION
The style checks had previously `continue-on-error` set which actually
ignore the errors and hid them in the user interface.

This patch makes the failed checks visible in the user interface, but
still lets the remainder of the checks run for a speedier developing 
workflow.