### PR TITLE
Call msbuild with /maxcpucount

### DIFF
--- a/src/Build.ps1
+++ b/src/Build.ps1
@@ -32,7 +32,8 @@ function Main
     & $msbuild `
         /p:OutputPath=$outputPath `
         /p:Configuration=$configuration `
-        /p:Platform=x64
+        /p:Platform=x64 `
+        /maxcpucount
 }
 
 Main


### PR DESCRIPTION
This patch adds the /maxcpucount flag to the msbuild call in Build.ps1.
This allows msbuild to spawn as many processes as there are CPU cores.