### PR TITLE
Remove references to the obsolete tests.nunit file

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -1,6 +1,12 @@
 name: Check-commit-messages
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+    - '*'
+
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   Execute:

--- a/src/Test.ps1
+++ b/src/Test.ps1
@@ -1,5 +1,5 @@
 ﻿<# 
-This script runs all the unit tests specified in `.\tests.nunit` file.
+This script runs all the unit tests specified in the testDlls variable below.
 #>
 
 $ErrorActionPreference = "Stop"
@@ -17,9 +17,6 @@ function Main
     $reportGenerator = FindReportGenerator
 
     Set-Location $PSScriptRoot
-    $nunitProjectPath = Join-Path $PSScriptRoot "tests.nunit"
-
-    Write-Host "Running the tests specified in: $nunitProjectPath"
 
     $artefactsDir = CreateAndGetArtefactsDir
 


### PR DESCRIPTION
This patch removes all references to the obsolete tests.nunit file from
the `Tests.ps1` script.