### PR TITLE
Separate commit message checks into a workflow

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -1,0 +1,12 @@
+name: Check-commit-messages
+
+on: [push, pull_request]
+
+jobs:
+  Execute:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Check the commit message(s)
+        uses: mristin/opinionated-commit-message@v2.0.0-pre1

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v1.0.8
-
       - name: Check licenses
         working-directory: src
         run: powershell .\CheckLicenses.ps1


### PR DESCRIPTION
This splits the commit message checks from the check styles into a
separate workflow which runs on every pull request and push.

The style checks were run only on pull request, hence ignoring the
commit messages of a branch in the pull request.

See also this issue of the checker:
https://github.com/mristin/opinionated-commit-message/issues/28