### PR TITLE
Check pull request message on edits

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -1,6 +1,12 @@
 name: Check-commit-messages
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+    - '*'
+
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   Execute:


### PR DESCRIPTION
The default triggers for `pull_request` workflow event are:
opened, synchronize, or reopened (see Github actions reference). 
This prevented the checker of commit messages to re-run when we edit 
the title or the body of the pull request, thus actually preventing 
the developer to react to the checker's feedback.

This patch fixes the issue by explicitly including `edited` to the
triggers.