### PR TITLE
Allow skipping of build-test-inspect workflow

### DIFF
--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -5,12 +5,19 @@ on:
     branches:
       - master
       - V20DataModel
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   Execute:
     runs-on: windows-latest
+    if: contains(github.event.pull_request.body, 'The workflow build-test-inspect was intentionally skipped.') == false
     steps:
       - uses: actions/checkout@master
+
+      - name: Debug
+        env:
+          COMMIT_MESSAGE: ${{ toJson(github.event.pull_request) }}
+        run: Write-Host $env:COMMIT_MESSAGE
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -5,10 +5,11 @@ on:
     branches:
       - master
       - V20DataModel
-
+    types: [opened, synchronize, reopened, edited]
 jobs:
   Execute:
     runs-on: windows-latest
+    if: contains(github.event.pull_request.body, 'The workflow check-style was intentionally skipped.') == false
     steps:
       - uses: actions/checkout@master
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,16 @@ https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/cr
 actions. The CI includes building the solution, running the test, inspecting
 the code *etc.* (see below the section "Pre-merge Checks").
 
+Please note that running the Github actions consumes limited resources (we have only 2,000 minutes
+per month available for CI on our current Github plan). You can manually disable workflows
+by appending the following lines to the body of the pull request:
+* `The workflow build-test-inspect was intentionally skipped.`
+* `The workflow check-style was intentionally skipped.`.
+
+For an example, see [this pull request](
+https://github.com/admin-shell-io/aasx-package-explorer/pull/94
+).
+
 ## Commit Messages
 
 The commit messages follow the guidelines from 


### PR DESCRIPTION
Running the workflow `build-test-inspect` is time consuming and
wastes resources (we have only 2,000 minutes available each month
for CI on the free Github plan). This patch allows the developers to
intentionally skip running certain workflows.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.