### PR TITLE
Upgrade commit checker to 2.0.0-pre3

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v2.0.0-pre2
+        uses: mristin/opinionated-commit-message@v2.0.0-pre3


### PR DESCRIPTION
This upgrade is necessary so that carriage returns are ignored since
they caused quite some false positives when the line length was
exactly 72 characters long.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.