### PR TITLE
Remove references to `V20DataModel` branch

### DIFF
--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - master
-      - V20DataModel
     types: [opened, synchronize, reopened, edited]
 
 jobs:

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     branches:
       - master
-      - V20DataModel
     types: [opened, synchronize, reopened, edited]
+
 jobs:
   Execute:
     runs-on: windows-latest


### PR DESCRIPTION
The branch `V20DataModel` used to be the development branch. It has
been merged into master and is discontinued, while all the
development should take place on the master branch.

This patch removes all the references to it to avoid future confusion.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.