### PR TITLE
Add additional verbs for commit checker

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -15,4 +15,6 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v2.0.0-pre3
+        uses: mristin/opinionated-commit-message@v2.0.0-pre4
+        with:
+          path-to-additional-verbs: src/AdditionalVerbsInImperativeMood.txt

--- a/src/AdditionalVerbsInImperativeMood.txt
+++ b/src/AdditionalVerbsInImperativeMood.txt
@@ -1,0 +1,7 @@
+unit test
+integration test
+rewrap
+unwrap
+re-wrap
+undo
+re-do

--- a/src/CheckPushCommitMessages.ps1
+++ b/src/CheckPushCommitMessages.ps1
@@ -25,8 +25,6 @@ function Main
 
         Set-Location $PSScriptRoot
 
-        $
-
         # Get commit hashes not available in the master
         $hashesText = git log 'origin/master..HEAD' '--format=format:%H'|Out-String
 
@@ -46,7 +44,10 @@ function Main
             Write-Host "--- Verifying the message: ---"
             Write-Host $message
             Write-Host "---"
-            powershell -File OpinionatedCommitMessage.ps1 -message $message
+            powershell `
+                -File OpinionatedCommitMessage.ps1 `
+                -message $message `
+                -pathToAdditionalVerbs AdditionalVerbsInImperativeMood.txt
         }
     }
     finally


### PR DESCRIPTION
This points the commit checker (both local and in remote CI) to
consider a file containing additional verbs in imperative mood to be
whitelisted in the checker.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.