### PR TITLE
Reword remarks about copyrights in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-## Notes on Licenses and Copyrights
+## Licenses and Copyrights
 
 The file `LICENSE.TXT` in the main folder of the repo is the leading license
 information, even if it does not show up in the Visual Studio solution. To
@@ -25,8 +25,10 @@ files:
    only the organization and omit the individual contributors.
 5) All the copyrights of a file are joined into a single comment block 
    (`/* ... */`).
+6) Reference all the used libraries and dependencies in the copyright block as
+   well.
 
-Example copyright note:
+Example copyright block in the source code:
 ```cs
 /*
 Copyright (c) 2018-2019 Festo AG & Co. KG 
@@ -36,11 +38,69 @@ Author: Michael Hoffmeister
 Copyright (c) 2019-2020 PHOENIX CONTACT GmbH & Co. KG 
 <opensource@phoenixcontact.com> 
 Author: Andreas Orzelski
+
+The browser functionality is under the cefSharp license
+(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
+
+The JSON serialization is under the MIT license
+(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
+
+The QR code generation is under the MIT license 
+(see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
+
+The Dot Matrix Code (DMC) generation is under Apache license v2.0 
+(see http://www.apache.org/licenses/LICENSE-2.0).
 */
 ``` 
 
 Please make sure to add the copyright notes in the main [`LICENSE.txt`](
 LICENSE.txt) file as well and call `src/CopyLicense.ps1` on changes.
+The licenses of the dependencies have to be listed in the main LICENSE.txt as
+well.
+
+Example of the LICENSE.txt header:
+
+```
+Copyright (c) 2018-2020 Festo AG & Co. KG 
+<https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+Copyright (c) 2019-2020 PHOENIX CONTACT GmbH & Co. KG 
+<opensource@phoenixcontact.com>
+Author: Andreas Orzelski
+
+Copyright (c) 2019-2020 Fraunhofer IOSB-INA Lemgo, 
+    eine rechtlich nicht selbstaendige Einrichtung der Fraunhofer-Gesellschaft
+    zur Foerderung der angewandten Forschung e.V.
+
+Copyright (c) 2020 Schneider Electric Automation GmbH 
+<marco.mendes@se.com>
+Author: Marco Mendes
+
+... more contributors ...
+
+This software is licensed under the Apache License 2.0 (Apache-2.0) (see below)
+
+The browser functionality is licensed under the cefSharp license (see below)
+The QR code generation is licensed under the MIT license (MIT) (see below)
+
+... more references to dependencies ...
+```
+
+Example of the dependency license down in the body of LICENSE.txt:
+```
+ With respect to cefSharp
+=========================
+(https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
+// Copyright © The CefSharp Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+...
+```
+
+
 
 ## Pull Requests
 


### PR DESCRIPTION
This rephrasing clarifies in more detail who is the bearer of the
copyright ("legal entity" instead of "organization") and points out
that the contributors should update the main `LICENSE.txt` with
copyright notes as well as hint that there are specific plug-in
licenses.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.