### PR TITLE
Make `Build.ps1` fail when MSBuild fails

### DIFF
--- a/src/Build.ps1
+++ b/src/Build.ps1
@@ -34,6 +34,13 @@ function Main
         /p:Configuration=$configuration `
         /p:Platform=x64 `
         /maxcpucount
+
+    $buildExitCode = $LASTEXITCODE
+    Write-Host "Build exit code: $buildExitCode"
+    if ($buildExitCode -ne 0)
+    {
+        throw "Build failed."
+    }
 }
 
 Main


### PR DESCRIPTION
Build.ps1 previously did not check for `$LASTEXITCODE`. Though the
`ErrorActionPreference` was set to `"Stop"`, MSBuild did not write to
STDERR and hence it was not signaled as failure. This patch checks
explicitly for `$LASTEXITCODE` and throws an exception on non-zero
values.

Hence, when MSBuild fails, `Build.ps1` will fail as well, as expected.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.