### PR TITLE
Add workflow to publish docdev to `gh-pages`

### DIFF
--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -1,0 +1,26 @@
+name: Generate-doc
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  Execute:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install docdev dependencies
+        working-directory: src
+        run: powershell .\InstallDocdevDependencies.ps1
+
+      - name: Generate the docdev
+        working-directory: src
+        run: powershell .\GenerateDocdev.ps1
+
+      - name: Deploy to gh-pages 🚀
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: artefacts/gh-pages

--- a/docdev/docfx_project/docfx.json
+++ b/docdev/docfx_project/docfx.json
@@ -54,7 +54,7 @@
         ]
       }
     ],
-    "dest": "_site",
+    "dest": "../../artefacts/gh-pages/devdoc",
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],
     "template": [

--- a/src/GenerateDocdev.ps1
+++ b/src/GenerateDocdev.ps1
@@ -4,7 +4,8 @@ This script generates the documentation for developers in the docdev directory.
 #>
 
 Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
-    GetToolsDir
+    GetToolsDir, `
+    CreateAndGetArtefactsDir
 
 
 function Main
@@ -25,6 +26,8 @@ function Main
                 "Did you install it using InstallDocdevDependencies.ps1?")
         }
 
+        $artefactsDir = CreateAndGetArtefactsDir
+
         $repoDir = Split-Path -Parent $PSScriptRoot
         $docfxProjectDir = Join-Path $repoDir "docdev" `
             | Join-Path -ChildPath "docfx_project"
@@ -36,7 +39,9 @@ function Main
             throw "docfx failed. See above for error logs."
         }
 
-        $siteDir = Join-Path $docfxProjectDir "_site"
+        $siteDir = Join-Path $artefactsDir "gh-pages" `
+            | Join-Path -ChildPath "devdoc"
+
         Write-Host "The documentation has been generated to: '$siteDir'"
         Write-Host "You can serve it locally with:"
         Write-Host "'$docfxExe' serve '$siteDir'"


### PR DESCRIPTION
This introduces a workflow to generate documentation for developers
and publish it to the branch `gh-pages`.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.