### PR TITLE
Unify OpenID features in `AasxOpenIdClient`

### DIFF
--- a/src/AasxOpenidClient/ConsoleExtensions.cs
+++ b/src/AasxOpenidClient/ConsoleExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 
-// ReSharper disable All .. as this is code from others!
+// ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
 
-namespace Clients
+namespace AasxOpenIdClient
 {
     public static class ConsoleExtensions
     {

--- a/src/AasxOpenidClient/Constants.cs
+++ b/src/AasxOpenidClient/Constants.cs
@@ -1,6 +1,6 @@
-﻿// ReSharper disable All .. as this is code from others!
+﻿// ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
 
-namespace Clients
+namespace AasxOpenIdClient
 {
     public class Constants
     {

--- a/src/AasxOpenidClient/OpenIDCLient.cs
+++ b/src/AasxOpenidClient/OpenIDCLient.cs
@@ -10,7 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
-using Clients;
+using AasxOpenIdClient;
 using IdentityModel;
 using IdentityModel.Client;
 using Jose;
@@ -18,9 +18,9 @@ using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-// ReSharper disable All .. as this is code from others!
+// ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
 
-namespace AasxPrivateKeyJwtClient
+namespace AasxOpenIdClient
 {
     public class OpenIDClient
     {

--- a/src/AasxOpenidClient/TokenResponseExtensions.cs
+++ b/src/AasxOpenidClient/TokenResponseExtensions.cs
@@ -4,7 +4,7 @@ using IdentityModel;
 using IdentityModel.Client;
 using Newtonsoft.Json.Linq;
 
-namespace Clients
+namespace AasxOpenIdClient
 {
     public static class TokenResponseExtensions
     {

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -780,12 +780,12 @@ namespace AasxPackageExplorer
                     {
                         thePackageEnv.Close();
                     }
-                    await AasxPrivateKeyJwtClient.OpenIDClient.Run(tag, value);
+                    await AasxOpenIdClient.OpenIDClient.Run(tag, value);
 
                     UiLoadPackageWithNew(
                         ref thePackageEnv,
-                        new AdminShellPackageEnv(AasxPrivateKeyJwtClient.OpenIDClient.outputDir + "\\download.aasx"),
-                        AasxPrivateKeyJwtClient.OpenIDClient.outputDir + "\\download.aasx", onlyAuxiliary: false);
+                        new AdminShellPackageEnv(AasxOpenIdClient.OpenIDClient.outputDir + "\\download.aasx"),
+                        AasxOpenIdClient.OpenIDClient.outputDir + "\\download.aasx", onlyAuxiliary: false);
                     return;
                 }
 


### PR DESCRIPTION
This refactoring renames the namespaces `Clients` and
`AasxPrivateJwtClient` in a single namespace `AasxOpenIdClient`. Such a
naming should be more informative for a reader (all OpenID client
functionality in a single namespace) and make the documentation easier
to browse.