### PR TITLE
Move `Tetra` beneath `AasxPluginTechnicalData`

### DIFF
--- a/src/AasxPluginTechnicalData/PimpedPaginator.cs
+++ b/src/AasxPluginTechnicalData/PimpedPaginator.cs
@@ -11,7 +11,7 @@ using System.Windows.Media;
 
 // see: https://www.codeproject.com/Articles/31834/FlowDocument-pagination-with-repeating-page-header
 
-namespace Tetra.Framework.WPF
+namespace AasxPluginTechnicalData.Tetra.Framework.WPF
 {
 
     /// <summary>

--- a/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml.cs
@@ -13,9 +13,9 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
+using AasxPluginTechnicalData.Tetra.Framework.WPF;
 using AasxPredefinedConcepts;
 using AdminShellNS;
-using Tetra.Framework.WPF;
 
 namespace AasxPluginTechnicalData
 {


### PR DESCRIPTION
This refactoring moves the third-party namespace `Tetra` beneath the
namespace `AasxPluginTechnicalData`.

Since `Tetra` is not used elsewhere, this makes it obvious that `Tetra`
is only used in the context of this particular plug-in. Additionally,
the API documentation is a bit more readable with less global
namespaces to grok.