### PR TITLE
Unify `AasxUtilities` with `AasxIntegrationBase`

### DIFF
--- a/src/AasxIntegrationBaseWpf/WpfViewmodelBase.cs
+++ b/src/AasxIntegrationBaseWpf/WpfViewmodelBase.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace AasxUtilities
+namespace AasxIntegrationBase
 {
     public class WpfViewModelBase : INotifyPropertyChanged
     {

--- a/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
+++ b/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
@@ -53,7 +53,7 @@ namespace AasxPluginDocumentShelf
 
         private ViewModel theViewModel = new ViewModel();
 
-        public class ViewModel : AasxUtilities.WpfViewModelBase
+        public class ViewModel : AasxIntegrationBase.WpfViewModelBase
         {
 
             private int theSelectedDocClass = 0;
@@ -341,7 +341,7 @@ namespace AasxPluginDocumentShelf
 
         #region REDRAW of contents
 
-        private void TheViewModel_ViewModelChanged(AasxUtilities.WpfViewModelBase obj)
+        private void TheViewModel_ViewModelChanged(AasxIntegrationBase.WpfViewModelBase obj)
         {
             // re-display
             ParseSubmodelToListItems(

--- a/src/AasxPluginGenericForms/GenericFormsControl.xaml.cs
+++ b/src/AasxPluginGenericForms/GenericFormsControl.xaml.cs
@@ -45,7 +45,7 @@ namespace AasxPluginGenericForms
 
         private ViewModel theViewModel = new ViewModel();
 
-        public class ViewModel : AasxUtilities.WpfViewModelBase
+        public class ViewModel : AasxIntegrationBase.WpfViewModelBase
         {
         }
 
@@ -123,7 +123,7 @@ namespace AasxPluginGenericForms
         #region REDRAW of contents
         //========================
 
-        private void TheViewModel_ViewModelChanged(AasxUtilities.WpfViewModelBase obj)
+        private void TheViewModel_ViewModelChanged(AasxIntegrationBase.WpfViewModelBase obj)
         {
         }
 


### PR DESCRIPTION
This refactoring unifies the namespace `AasxUtilities` with
`AasxIntegrationBase` since there is only a single class residing in the
original namespace and this class conceptually also belongs to
`AasxIntegrationBase`.