### PR TITLE
Assign all TODOs to Michael Hoffmeister

### DIFF
--- a/src/AasxAmlImExport/AmlExport.cs
+++ b/src/AasxAmlImExport/AmlExport.cs
@@ -298,7 +298,7 @@ namespace AasxAmlImExport
                     var a = AppendAttributeNameAndRole(
                         parent.Attribute, smep.idShort, AmlConst.Attributes.SME_Property, smep.value);
 
-                    // TODO: here is no equivalence to set a match!!
+                    // TODO (Michael Hoffmeister, 1970-01-01): here is no equivalence to set a match!!
 
                     // add some data underneath
                     SetReferable(a.Attribute, sme);
@@ -859,7 +859,7 @@ namespace AasxAmlImExport
             AdminShell.DataSpecificationIEC61360 source61360 = null;
             if (cd.embeddedDataSpecification?.dataSpecificationContent?.dataSpecificationIEC61360 != null)
                 source61360 = cd.embeddedDataSpecification.dataSpecificationContent.dataSpecificationIEC61360;
-            // TODO: source99999
+            // TODO (Michael Hoffmeister, 1970-01-01): source99999
 
             // decide which approach to take (1 or 2 IE)
             AttributeSequence dest61360 = null;
@@ -1038,10 +1038,12 @@ namespace AasxAmlImExport
             }
         }
 
-        // TODO:
-        //      * ConceptDescriptions - done
-        //      * Views
-        //      * Types -> SystemUnitClasses & linkings - done
+        /*
+        TODO (Michael Hoffmeister, 1970-01-01): Export tasks
+              * ConceptDescriptions - done
+              * Views
+              * Types -> SystemUnitClasses & linkings - done
+        */
 
         public static bool ExportTo(AdminShellPackageEnv package, string amlfn, bool tryUseCompactProperties = false)
         {

--- a/src/AasxAmlImExport/AmlImport.cs
+++ b/src/AasxAmlImExport/AmlImport.cs
@@ -188,21 +188,23 @@ namespace AasxAmlImExport
 
             public bool CheckForRoleClassOrRoleRequirements(SystemUnitClassType ie, string classPath)
             {
-                // TODO MICHA+M. WIEGAND: I dont understand the determinism behind that!
-                // WIEGAND: me, neither ;-)
-                // Wiegand:  ich hab mir von Prof.Drath nochmal erklären lassen, wie SupportedRoleClass und
-                // RoleRequirement verwendet werden:
-                // In CAEX2.15(aktuelle AML Version und unsere AAS Mapping Version):
-                //   1.Eine SystemUnitClass hat eine oder mehrere SupportedRoleClasses, die ihre „mögliche Rolle
-                //     beschreiben(Drucker / Fax / kopierer)
-                //   2.Wird die SystemUnitClass als InternalElement instanziiert entscheidet man sich für eine
-                //     Hauptrolle, die dann zum RoleRequirement wird und evtl. Nebenklassen die dann
-                //     SupportedRoleClasses sind(ist ein Workaround weil CAEX2.15 in der Norm nur
-                //     ein RoleReuqirement erlaubt)
-                // InCAEX3.0(nächste AMl Version):
-                //   1.Wie bei CAEX2.15
-                //   2.Wird die SystemUnitClass als Internal Elementinstanziiert werden die verwendeten Rollen
-                //     jeweils als RoleRequirement zugewiesen (in CAEX3 sind mehrere RoleReuqirements nun erlaubt)
+                /*
+                 TODO (MICHA+M. WIEGAND, 1970-01-01): I dont understand the determinism behind that!
+                 WIEGAND: me, neither ;-)
+                 Wiegand:  ich hab mir von Prof.Drath nochmal erklären lassen, wie SupportedRoleClass und
+                 RoleRequirement verwendet werden:
+                 In CAEX2.15(aktuelle AML Version und unsere AAS Mapping Version):
+                   1.Eine SystemUnitClass hat eine oder mehrere SupportedRoleClasses, die ihre „mögliche Rolle
+                     beschreiben(Drucker / Fax / kopierer)
+                   2.Wird die SystemUnitClass als InternalElement instanziiert entscheidet man sich für eine
+                     Hauptrolle, die dann zum RoleRequirement wird und evtl. Nebenklassen die dann
+                     SupportedRoleClasses sind(ist ein Workaround weil CAEX2.15 in der Norm nur
+                     ein RoleReuqirement erlaubt)
+                 InCAEX3.0(nächste AMl Version):
+                   1.Wie bei CAEX2.15
+                   2.Wird die SystemUnitClass als Internal Elementinstanziiert werden die verwendeten Rollen
+                     jeweils als RoleRequirement zugewiesen (in CAEX3 sind mehrere RoleReuqirements nun erlaubt)
+                */
 
                 // Remark: SystemUnitClassType is suitable for SysUnitClasses and InternalElements
 
@@ -1338,7 +1340,10 @@ namespace AasxAmlImExport
                                             var eds = new AdminShell.EmbeddedDataSpecification();
                                             cd.embeddedDataSpecification = eds;
 
-                                            // TODO: fill out eds.hasDataSpecification by using outer attributes
+                                            /*
+                                             TODO (Michael Hoffmeister, 1970-01-01): fill out 
+                                             eds.hasDataSpecification by using outer attributes
+                                            */
                                             var hds = FindAttributeValueByRefSemantic(
                                                 ie.Attribute, AmlConst.Attributes.CD_DataSpecificationRef);
                                             if (hds != null)

--- a/src/AasxCsharpLibrary/AasxCompatibilityModels/V10/AdminShellV10.cs
+++ b/src/AasxCsharpLibrary/AasxCompatibilityModels/V10/AdminShellV10.cs
@@ -1847,7 +1847,7 @@ containedElements == null) return null; return containedElements[index];
             void System.IDisposable.Dispose() { }
             public void GetData() { }
             // from HasDataSpecification
-            // TODO: in V1.0, shall be a list of embeddedDataSpecification
+            // TODO (Michael Hoffmeister, 1970-01-01): in V1.0, shall be a list of embeddedDataSpecification
             [XmlElement(ElementName = "embeddedDataSpecification")]
             [JsonIgnore]
             public EmbeddedDataSpecification embeddedDataSpecification = new EmbeddedDataSpecification();
@@ -2591,7 +2591,7 @@ containedElements == null) return null; return containedElements[index];
 
             // from hasSemantics:
             [XmlElement(ElementName = "semanticId")]
-            // TODO: Qualifiers not working!
+            // TODO (Michael Hoffmeister, 1970-01-01): Qualifiers not working!
             // 190410: test-wise enable them again, everyhing works fine ..
             // [JsonIgnore]
             public SemanticId semanticId = null;
@@ -2954,7 +2954,7 @@ containedElements == null) return null; return containedElements[index];
                                 return FindReferableByReference(
                                     (smw.submodelElement as SubmodelElementCollection).value, rf, keyIndex + 1);
 
-                            // TODO: Operation
+                            // TODO (Michael Hoffmeister, 1970-01-01): Operation
 
                             // else:
                             return null;
@@ -3964,7 +3964,7 @@ containedElements == null) return null; return containedElements[index];
                     // load only XML
                     try
                     {
-                        // TODO: use aasenv serialzers here!
+                        // TODO (Michael Hoffmeister, 1970-01-01): use aasenv serialzers here!
                         XmlSerializer serializer = new XmlSerializer(
                             typeof(AdminShellV10.AdministrationShellEnv), "http://www.admin-shell.io/aas/1/0");
                         TextReader reader = new StreamReader(fn);
@@ -3989,7 +3989,7 @@ containedElements == null) return null; return containedElements[index];
                     {
                         using (StreamReader file = System.IO.File.OpenText(fn))
                         {
-                            // TODO: use aasenv serialzers here!
+                            // TODO (Michael Hoffmeister, 1970-01-01): use aasenv serialzers here!
                             JsonSerializer serializer = new JsonSerializer();
                             serializer.Converters.Add(new AdminShellV10.JsonAasxConverter("modelType", "name"));
                             this.aasenv = (AdministrationShellEnv)serializer.Deserialize(
@@ -4096,7 +4096,7 @@ containedElements == null) return null; return containedElements[index];
                 {
                     using (var file = new StringReader(content))
                     {
-                        // TODO: use aasenv serialzers here!
+                        // TODO (Michael Hoffmeister, 1970-01-01): use aasenv serialzers here!
                         JsonSerializer serializer = new JsonSerializer();
                         serializer.Converters.Add(new AdminShellV10.JsonAasxConverter("modelType", "name"));
                         this.aasenv = (AdministrationShellEnv)serializer.Deserialize(
@@ -4125,7 +4125,7 @@ containedElements == null) return null; return containedElements[index];
                     {
                         using (var s = new StreamWriter(this.fn))
                         {
-                            // TODO: use aasenv serialzers here!
+                            // TODO (Michael Hoffmeister, 1970-01-01): use aasenv serialzers here!
                             var serializer = new XmlSerializer(typeof(AdminShellV10.AdministrationShellEnv));
                             var nss = new XmlSerializerNamespaces();
                             nss.Add("xsi", System.Xml.Schema.XmlSchema.InstanceNamespace);
@@ -4152,7 +4152,7 @@ containedElements == null) return null; return containedElements[index];
                     {
                         using (var sw = new StreamWriter(fn))
                         {
-                            // TODO: use aasenv serialzers here!
+                            // TODO (Michael Hoffmeister, 1970-01-01): use aasenv serialzers here!
 
                             sw.AutoFlush = true;
 

--- a/src/AasxCsharpLibrary/AdminShell.cs
+++ b/src/AasxCsharpLibrary/AdminShell.cs
@@ -2555,7 +2555,7 @@ namespace AdminShellNS
             void System.IDisposable.Dispose() { }
             public void GetData() { }
             // from HasDataSpecification
-            // TODO: in V1.0, shall be a list of embeddedDataSpecification
+            // TODO (Michael Hoffmeister, 1970-01-01): in V1.0, shall be a list of embeddedDataSpecification
             [XmlElement(ElementName = "embeddedDataSpecification")]
             [JsonIgnore]
             public EmbeddedDataSpecification embeddedDataSpecification = new EmbeddedDataSpecification();
@@ -3505,7 +3505,7 @@ namespace AdminShellNS
             public SemanticId semanticId = null;
 
             // this class
-            // TODO: check, if Json has Qualifiers or not
+            // TODO (Michael Hoffmeister, 1970-01-01): check, if Json has Qualifiers or not
 
             [MetaModelName("Qualifier.type")]
             [TextSearchable]

--- a/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
+++ b/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
@@ -227,7 +227,7 @@ namespace AdminShellNS
                 {
                     using (StreamReader file = System.IO.File.OpenText(fn))
                     {
-                        // TODO: use aasenv serialzers here!
+                        // TODO (Michael Hoffmeister, 1970-01-01): use aasenv serialzers here!
                         JsonSerializer serializer = new JsonSerializer();
                         serializer.Converters.Add(new AdminShellConverters.JsonAasxConverter("modelType", "name"));
                         this.aasenv = (AdminShell.AdministrationShellEnv)serializer.Deserialize(
@@ -347,7 +347,7 @@ namespace AdminShellNS
             {
                 using (var file = new StringReader(content))
                 {
-                    // TODO: use aasenv serialzers here!
+                    // TODO (Michael Hoffmeister, 1970-01-01): use aasenv serialzers here!
                     JsonSerializer serializer = new JsonSerializer();
                     serializer.Converters.Add(new AdminShellConverters.JsonAasxConverter("modelType", "name"));
                     this.aasenv = (AdminShell.AdministrationShellEnv)serializer.Deserialize(
@@ -386,7 +386,7 @@ namespace AdminShellNS
                 {
                     using (var s = new StreamWriter(this.fn))
                     {
-                        // TODO: use aasenv serialzers here!
+                        // TODO (Michael Hoffmeister, 1970-01-01): use aasenv serialzers here!
                         var serializer = new XmlSerializer(typeof(AdminShell.AdministrationShellEnv));
                         var nss = GetXmlDefaultNamespaces();
                         serializer.Serialize(s, this.aasenv, nss);
@@ -410,7 +410,7 @@ namespace AdminShellNS
                 {
                     using (var sw = new StreamWriter(fn))
                     {
-                        // TODO: use aasenv serialzers here!
+                        // TODO (Michael Hoffmeister, 1970-01-01): use aasenv serialzers here!
 
                         sw.AutoFlush = true;
 

--- a/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
@@ -646,8 +646,7 @@ namespace AasxIntegrationBase.AasForms
             var smecSource = this.sourceSme as AdminShell.SubmodelElementCollection;
             if (smecSource != null)
             {
-                // take over
-                // TODO
+                // TODO (Michael Hoffmeister, 1970-01-01): take over
                 if (this.PairInstances != null)
                     foreach (var pair in this.PairInstances)
                     {
@@ -767,7 +766,7 @@ namespace AasxIntegrationBase.AasForms
             var pSource = this.sourceSme as AdminShell.Property;
             if (p != null && Touched && pSource != null && editSource)
             {
-                // TODO: MICHA
+                // TODO (Michael Hoffmeister, 1970-01-01): MICHA
                 pSource.valueType = p.valueType;
                 pSource.value = p.value;
                 return false;

--- a/src/AasxRestServerLibrary/AasxRestClient.cs
+++ b/src/AasxRestServerLibrary/AasxRestClient.cs
@@ -53,7 +53,10 @@ namespace AasxRestServerLibrary
             else
             {
                 var pi = WebRequest.GetSystemWebProxy();
-                // TODO: Andreas, check this. System.Net.WebProxy.GetDefaultProxy was deprecated
+                /*
+                 TODO (Michael Hoffmeister, 1970-01-01): Andreas, check this. 
+                 System.Net.WebProxy.GetDefaultProxy was deprecated.
+                */
                 this.proxy = (WebProxy)pi;
                 if (this.proxy != null)
                     this.proxy.UseDefaultCredentials = true;

--- a/src/AasxSignature/AasxSignature.cs
+++ b/src/AasxSignature/AasxSignature.cs
@@ -170,7 +170,7 @@ namespace AasxSignature
                 using (Package.Open(packagePath, FileMode.Open, FileAccess.Read))
                 {
                     // If openend, I think that the package is according to the OPC standard
-                    // TODO Is package according to the Logical model of the Admin Shell?
+                    // TODO (Michael Hoffmeister, 1970-01-01): Is package according to the Logical model of the AAS?
                     // => use AdminShell logical model to compare
                 }
 
@@ -204,11 +204,13 @@ namespace AasxSignature
 
                 // If there are no signatures - OK, but must be mentioned in the result
 
-                // TODO is package sealed? => no other signatures can be added?
+                // TODO (Michael Hoffmeister, 1970-01-01): is package sealed? => no other signatures can be added?
                 // All files are signed (except those that could not be signed). New files (unsigned) were added
 
-                // TODO The information from the analysis
-                //  -> return as an object (list of enums with the issues/warings???)
+                /*
+                 TODO (Michael Hoffmeister, 1970-01-01): The information from the analysis
+                  -> return as an object (list of enums with the issues/warings???)
+                */
             }
             catch (Exception e)
             {

--- a/src/AasxUANodesetImExport/UANodeSet.cs
+++ b/src/AasxUANodesetImExport/UANodeSet.cs
@@ -17,8 +17,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-// TODO: License
-// TODO Fraunhofer IOSB: Check ReSharper
+// TODO (Michael Hoffmeister, 1970-01-01): License
+// TODO (Michael Hoffmeister, 1970-01-01): Fraunhofer IOSB: Check ReSharper
 
 // ReSharper disable PartialTypeWithSinglePart
 // ReSharper disable RedundantCast

--- a/src/AasxUANodesetImExport/UANodeSetExport.cs
+++ b/src/AasxUANodesetImExport/UANodeSetExport.cs
@@ -23,8 +23,8 @@ using System.Xml.Serialization;
 using AdminShellNS;
 using static AdminShellNS.AdminShellV20;
 
-// TODO: License
-// TODO Fraunhofer IOSB: Check ReSharper
+// TODO (Michael Hoffmeister, 1970-01-01): License
+// TODO (Michael Hoffmeister, 1970-01-01): Fraunhofer IOSB: Check ReSharper
 
 // ReSharper disable PartialTypeWithSinglePart
 // ReSharper disable RedundantCast

--- a/src/AasxUANodesetImExport/UANodeSetImport.cs
+++ b/src/AasxUANodesetImExport/UANodeSetImport.cs
@@ -20,8 +20,8 @@ using System.Windows;
 using AdminShellNS;
 using static AdminShellNS.AdminShellV20;
 
-// TODO: License
-// TODO Fraunhofer IOSB: Check ReSharper
+// TODO (Michael Hoffmeister, 1970-01-01): License
+// TODO (Michael Hoffmeister, 1970-01-01): Fraunhofer IOSB: Check ReSharper
 
 // ReSharper disable PartialTypeWithSinglePart
 // ReSharper disable RedundantCast

--- a/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
+++ b/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
@@ -2370,7 +2370,7 @@ namespace AasxPackageExplorer
                             helper.AddKeyListLangStr(stack, "shortName", dsiec.shortName.langString, repo);
 
                         // dead-csharp off
-                        // TODO: add Sync to shortName
+                        // TODO (Michael Hoffmeister, 1970-01-01): add Sync to shortName
                         /*
                         helper.AddHintBubble(stack, hintMode, new [] {
                             new HintCheck( () => { return dsiec.shortName == null || dsiec.shortName.Count < 1; },
@@ -2858,7 +2858,7 @@ namespace AasxPackageExplorer
                                         helper.AddElementInListBefore<AdminShell.SubmodelElementWrapper>(
                                             pcarel.annotations, smw2, wrapper);
 
-                                    // TODO: Operation mssing here?
+                                    // TODO (Michael Hoffmeister, 1970-01-01): Operation mssing here?
                                 }
                                 if ((int)buttonNdx == 3)
                                 {
@@ -2880,7 +2880,7 @@ namespace AasxPackageExplorer
                                         helper.AddElementInListAfter<AdminShell.SubmodelElementWrapper>(
                                             pcarel.annotations, smw2, wrapper);
 
-                                    // TODO: Operation mssing here?
+                                    // TODO (Michael Hoffmeister, 1970-01-01): Operation mssing here?
                                 }
                                 if ((int)buttonNdx == 4)
                                 {
@@ -4019,7 +4019,7 @@ namespace AasxPackageExplorer
                 else
                     helper.AddKeyValue(stack, "Values", "Please add elements via editing of sub-ordinate entities");
 
-                // TODO: ordered, allowDuplicates
+                // TODO (Michael Hoffmeister, 1970-01-01): ordered, allowDuplicates
 
                 // dead-csharp off
                 /* non-edit mode fails

--- a/src/AasxWpfControlLibrary/DispEditHelper.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelper.cs
@@ -1159,8 +1159,7 @@ namespace AasxPackageExplorer
 
             if (repo == null)
             {
-                // possibly [Jump] button??
-                // TODO
+                // TODO (Michael Hoffmeister, 1970-01-01): possibly [Jump] button??
             }
             else
             if (keys != null)
@@ -1303,7 +1302,7 @@ namespace AasxPackageExplorer
                         // save in current context
                         var currentI = 0 + i;
 
-                        // TODO MIHO
+                        // TODO (Michael Hoffmeister, 1970-01-01): Needs to be revisted
 
                         // type
                         var cbType = repo.RegisterControl(

--- a/src/AasxWpfControlLibrary/VisualAasxElements.cs
+++ b/src/AasxWpfControlLibrary/VisualAasxElements.cs
@@ -24,7 +24,7 @@ The QR code generation is under the MIT license (see https://github.com/codebude
 The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
 */
 
-// TODO: check again
+// TODO (Michael Hoffmeister, 1970-01-01): check again
 // ReSharper disable VirtualMemberCallInConstructor
 
 namespace AasxPackageExplorer

--- a/src/AdditionalVerbsInImperativeMood.txt
+++ b/src/AdditionalVerbsInImperativeMood.txt
@@ -6,3 +6,4 @@ re-wrap
 undo
 re-do
 inline
+assign


### PR DESCRIPTION
The TODO comments occurred in many different styles and had only bare
information lacking any information about the author and the
time stamp of the TODO.

This patch introduces Michael Hoffmeister as the author of all the
TODOs (since he is the main contributor) and assigns a dummy timestamp
(1970-01-01) to indicate that the time stamp of the TODO is unknown.

The workflow build-test-inspect was intentionally skipped.