### PR TITLE
Standardize style of powershell script

### DIFF
--- a/src/Build.ps1
+++ b/src/Build.ps1
@@ -1,5 +1,6 @@
 ﻿<#
-This script builds the solution. 
+.DESCRIPTION
+This script builds the solution.
 
 It is expected that you installed 
 the dev dependencies (with InstallDevDependenciesOnMV.ps1 or manually) 
@@ -43,4 +44,5 @@ function Main
     }
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/Check.ps1
+++ b/src/Check.ps1
@@ -1,18 +1,24 @@
 ﻿<#
-This script builds the solution, runs Resharper InspectCode and dotnet-format to
-check the quality of the code base.
+.SYNOPSIS
+This script runs all the pre-merge checks locally.
 #>
 
 $ErrorActionPreference = "Stop"
 
-Set-Location $PSScriptRoot
-.\CheckPushCommitMessages.ps1
-.\CheckLicenses.ps1
-.\CheckFormat.ps1
-.\CheckBiteSized.ps1
-.\CheckDeadCode.ps1
-.\CheckTodos.ps1
-.\Doctest.ps1 -check
-.\Build.ps1
-.\Test.ps1
-.\InspectCode.ps1
+function Main
+{
+    Set-Location $PSScriptRoot
+    .\CheckPushCommitMessages.ps1
+    .\CheckLicenses.ps1
+    .\CheckFormat.ps1
+    .\CheckBiteSized.ps1
+    .\CheckDeadCode.ps1
+    .\CheckTodos.ps1
+    .\Doctest.ps1 -check
+    .\Build.ps1
+    .\Test.ps1
+    .\InspectCode.ps1
+}
+
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/CheckBiteSized.ps1
+++ b/src/CheckBiteSized.ps1
@@ -1,5 +1,6 @@
 #!/usr/bin/env pwsh
 <#
+.SYNOPSIS
 This script checks that the C# files are "bite sized": no long lines, not too long.
 #>
 
@@ -37,4 +38,5 @@ function Main {
     }
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/CheckDeadCode.ps1
+++ b/src/CheckDeadCode.ps1
@@ -1,5 +1,6 @@
 <#
-This script checks the format of the code.
+.SYNOPSIS
+This script checks that there is no dead code in the comments.
 #>
 
 $ErrorActionPreference = "Stop"
@@ -22,4 +23,5 @@ function Main
     }
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/CheckFormat.ps1
+++ b/src/CheckFormat.ps1
@@ -1,4 +1,5 @@
 ﻿<#
+.SYNOPSIS
 This script checks the format of the code.
 #>
 
@@ -28,4 +29,5 @@ function Main
     }
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/CheckLicenses.ps1
+++ b/src/CheckLicenses.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 <#
-.Description
+.DESCRIPTION
 This script inspects all the individual subdirectories to check that
 they contain LICENSE.txt. It also checks that there are no conflicting
 LICENSE and LICENSE.TXT (mind the case) files.
@@ -8,7 +8,7 @@ LICENSE and LICENSE.TXT (mind the case) files.
 
 function Main
 {
-    param($srcDir)
+    $srcDir = $PSScriptRoot
 
     $includes = @($srcDir)
 
@@ -69,12 +69,12 @@ function Main
 
         $nl = [Environment]::NewLine
         $msg = $parts -Join $nl
-        Write-Host $msg
-        Exit 1
+        throw $msg
     }
 
     Write-Host "All subdirectories contain LICENSE.txt. "
     Write-Host "Mind that the content has not been checked."
 }
 
-Main($PSScriptRoot)
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/CheckTodos.ps1
+++ b/src/CheckTodos.ps1
@@ -13,23 +13,16 @@ function Main
 {
     AssertOpinionatedCsharpTodosVersion
 
-    Push-Location
-    try
+    Set-Location $PSScriptRoot
+    Write-Host "Inspecting the TODOs in the code..."
+    dotnet opinionated-csharp-todos `
+        --inputs '**/*.cs' `
+        --excludes 'packages/**' '**/obj/**' 'MsaglWpfControl/**'
+    if($LASTEXITCODE -ne 0)
     {
-        Set-Location $PSScriptRoot
-        Write-Host "Inspecting the TODOs in the code..."
-        dotnet opinionated-csharp-todos `
-            --inputs '**/*.cs' `
-            --excludes 'packages/**' '**/obj/**' 'MsaglWpfControl/**'
-        if($LASTEXITCODE -ne 0)
-        {
-            throw "Failed to validate the TODOs in the code."
-        }
-    }
-    finally
-    {
-        Pop-Location
+        throw "Failed to validate the TODOs in the code."
     }
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/Common.psm1
+++ b/src/Common.psm1
@@ -1,9 +1,10 @@
 ﻿<#
+.SYNOPSIS
 This module contains common functions for continuous integration.
 #>
 
 <#
-.Synopsis
+.SYNOPSIS
 Join the path to the directory where build tools reside.
 #>
 function GetToolsDir
@@ -12,7 +13,7 @@ function GetToolsDir
 }
 
 <#
-.Synopsis
+.SYNOPSIS
 Search for MSBuild in the path and at expected locations using `vswhere.exe`.
 #>
 function FindMSBuild
@@ -70,7 +71,7 @@ function FindMSBuild
 }
 
 <#
-.Synopsis
+.SYNOPSIS
 Asserts that dotnet is on the path.
 #>
 function AssertDotnet
@@ -118,7 +119,7 @@ function FindDotnetToolVersion($PackageID) {
 }
 
 <#
-.Synopsis
+.SYNOPSIS
 Check the version of the given dotnet tool.
  #>
 function AssertDotnetToolVersion($PackageID, $ExpectedVersion) {
@@ -144,7 +145,7 @@ function AssertDotnetToolVersion($PackageID, $ExpectedVersion) {
 }
 
 <#
-.Synopsis
+.SYNOPSIS
 Check the version of dotnet-format so that the code is always formatted in the same manner.
 #>
 function AssertDotnetFormatVersion
@@ -153,7 +154,7 @@ function AssertDotnetFormatVersion
 }
 
 <#
-.Synopsis
+.SYNOPSIS
 Check the version of dead-csharp so that the dead code is always detected in the same manner.
 #>
 function AssertDeadCsharpVersion
@@ -162,7 +163,7 @@ function AssertDeadCsharpVersion
 }
 
 <#
-.Synopsis
+.SYNOPSIS
 Check the version of doctest-csharp so that the code is always generated and checked in the same manner.
 #>
 function AssertDoctestCsharpVersion
@@ -171,7 +172,7 @@ function AssertDoctestCsharpVersion
 }
 
 <#
-.Synopsis
+.SYNOPSIS
 Check the version of opinionated-csharp-todos so that the TODOs are always inspected in the same manner.
 #>
 function AssertOpinionatedCsharpTodosVersion

--- a/src/CopyLicense.ps1
+++ b/src/CopyLicense.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 <#
-.Description
+.DESCRIPTION
 This script copies the LICENSE.txt from the repository root in all
 the first-level subdirectories within `src/`.
 Please make sure to add the excludes and the includes to this script.
@@ -9,7 +9,7 @@ The includes trump the excludes.
 
 function Main
 {
-    param ($srcDir)
+    $srcDir = $PSScriptRoot
 
     Write-Host "The src directory is: $srcDir"
     $licenseTxt = Join-Path $srcDir "LICENSE.txt"
@@ -60,4 +60,5 @@ function Main
     }
 }
 
-Main($PSScriptRoot)
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/FormatCode.ps1
+++ b/src/FormatCode.ps1
@@ -1,4 +1,7 @@
-﻿# This script formats the code in-place.
+﻿<#
+.SYNOPSIS
+This script formats the code in-place.
+#>
 
 $ErrorActionPreference = "Stop"
 
@@ -6,8 +9,14 @@ Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
     AssertDotnet, `
     AssertDotnetFormatVersion
 
-AssertDotnet
-AssertDotnetFormatVersion
+function Main
+{
+    AssertDotnet
+    AssertDotnetFormatVersion
 
-cd $PSScriptRoot
-dotnet format --exclude "**/DocTest*.cs"
+    Set-Location $PSScriptRoot
+    dotnet format --exclude "**/DocTest*.cs"
+}
+
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/GenerateDocdev.ps1
+++ b/src/GenerateDocdev.ps1
@@ -10,46 +10,39 @@ Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
 
 function Main
 {
-    Push-Location
-    try
+    Set-Location $PSScriptRoot
+
+    $toolsDir = GetToolsDir
+    $docfxExe = Join-Path $toolsDir "docfx.console.2.56.1" `
+        | Join-Path -ChildPath "tools" `
+        | Join-Path -ChildPath "docfx.exe"
+
+    if(!(Test-Path -Path $docfxExe))
     {
-        Set-Location $PSScriptRoot
-
-        $toolsDir = GetToolsDir
-        $docfxExe = Join-Path $toolsDir "docfx.console.2.56.1" `
-            | Join-Path -ChildPath "tools" `
-            | Join-Path -ChildPath "docfx.exe"
-
-        if(!(Test-Path -Path $docfxExe))
-        {
-            throw ("The docfx.exe could not be found: $docfxExe; " + `
-                "Did you install it using InstallDocdevDependencies.ps1?")
-        }
-
-        $artefactsDir = CreateAndGetArtefactsDir
-
-        $repoDir = Split-Path -Parent $PSScriptRoot
-        $docfxProjectDir = Join-Path $repoDir "docdev" `
-            | Join-Path -ChildPath "docfx_project"
-
-        Set-Location $docfxProjectDir
-        & $docfxExe "docfx.json"
-        if($LASTEXITCODE -ne 0)
-        {
-            throw "docfx failed. See above for error logs."
-        }
-
-        $siteDir = Join-Path $artefactsDir "gh-pages" `
-            | Join-Path -ChildPath "devdoc"
-
-        Write-Host "The documentation has been generated to: '$siteDir'"
-        Write-Host "You can serve it locally with:"
-        Write-Host "'$docfxExe' serve '$siteDir'"
+        throw ("The docfx.exe could not be found: $docfxExe; " + `
+            "Did you install it using InstallDocdevDependencies.ps1?")
     }
-    finally
+
+    $artefactsDir = CreateAndGetArtefactsDir
+
+    $repoDir = Split-Path -Parent $PSScriptRoot
+    $docfxProjectDir = Join-Path $repoDir "docdev" `
+        | Join-Path -ChildPath "docfx_project"
+
+    Set-Location $docfxProjectDir
+    & $docfxExe "docfx.json"
+    if($LASTEXITCODE -ne 0)
     {
-        Pop-Location
+        throw "docfx failed. See above for error logs."
     }
+
+    $siteDir = Join-Path $artefactsDir "gh-pages" `
+        | Join-Path -ChildPath "devdoc"
+
+    Write-Host "The documentation has been generated to: '$siteDir'"
+    Write-Host "You can serve it locally with:"
+    Write-Host "'$docfxExe' serve '$siteDir'"
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/InspectCode.ps1
+++ b/src/InspectCode.ps1
@@ -1,7 +1,6 @@
 ﻿<#
-This script inspects the code quality.
-
-It should be run after the build.
+.SYNOPSIS
+This script inspects the code quality after the build.
 #>
 
 $ErrorActionPreference = "Stop"
@@ -23,8 +22,6 @@ function Main
 
     $cachesHome = Join-Path $artefactsDir "inspectcode-caches"
     New-Item -ItemType Directory -Force -Path "$cachesHome"|Out-Null
-
-    $excludePattern = '*\obj\*'
 
     # InspectCode passes over the properties to MSBuild,
     # see https://www.jetbrains.com/help/resharper/InspectCode.html#msbuild-related-parameters
@@ -59,4 +56,6 @@ function Main
     }
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }
+

--- a/src/InstallBuildDependencies.ps1
+++ b/src/InstallBuildDependencies.ps1
@@ -1,5 +1,5 @@
 ﻿<#
-.Synopsis
+.SYNOPSIS
 This script installs the dependencies necessary to build the solution.
 #>
 
@@ -15,12 +15,11 @@ function Main {
        throw "Unable to find nuget.exe in your PATH"
     }
 
-    Push-Location
-
     Set-Location $PSScriptRoot
 
     Write-Host "Restoring packages for the solution ..."
     nuget.exe restore AasxPackageExplorer.sln -PackagesDirectory packages
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/InstallDevDependencies.ps1
+++ b/src/InstallDevDependencies.ps1
@@ -1,7 +1,7 @@
 param(
     [Parameter(HelpMessage = "If set, only downloads the dependencies without actually installing them.")]
     [switch]
-    $dryRun = $false
+    $DryRun = $false
 )
 
 <#
@@ -50,7 +50,7 @@ function Main
            "--add", "Microsoft.VisualStudio.Component.NuGet.BuildTools",
            "--quiet", "--norestart")
 
-    if ($true -eq $dryRun)
+    if ($true -eq $DryRun)
     {
         $steps += "'$cmd' $( $cmdArgs -Join " " )"
     }
@@ -89,7 +89,7 @@ function Main
     }
 
     $nugetDir = Join-Path ${Env:ProgramFiles(x86)} "nuget"
-    if($true -eq $dryRun)
+    if($true -eq $DryRun)
     {
         $steps += "Copy nuget from $targetPath to: $nugetDir"
         $steps += "Add nuget directory to PATH: $nugetDir"
@@ -135,7 +135,7 @@ function Main
     }
 
     $cmd = $targetPath
-    if ($true -eq $dryRun)
+    if ($true -eq $DryRun)
     {
         $steps += "'$cmd' -Version 3.1.202"
     }
@@ -146,7 +146,7 @@ function Main
         & $cmd -Version 3.1.202
     }
 
-    if ($true -eq $dryRun)
+    if ($true -eq $DryRun)
     {
         $steps += "'$cmd' -Runtime dotnet -Version 3.1.4"
     }
@@ -157,7 +157,7 @@ function Main
         & $cmd -Runtime dotnet -Version 3.1.4
     }
 
-    if ($true -eq $dryRun)
+    if ($true -eq $DryRun)
     {
         Write-Host ""
         Write-Host "This was a just a dry run. Here are the steps if you want to execute them manually:"
@@ -169,4 +169,5 @@ function Main
     }
 }
 
-Main($dryRun)
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/InstallDocdevDependencies.ps1
+++ b/src/InstallDocdevDependencies.ps1
@@ -17,21 +17,13 @@ function Main
        throw "Unable to find nuget.exe in your PATH"
     }
 
-    Push-Location
+    Set-Location $PSScriptRoot
+    $toolsDir = GetToolsDir
+    New-Item -ItemType Directory -Force -Path $toolsDir
 
-    try
-    {
-        Set-Location $PSScriptRoot
-        $toolsDir = GetToolsDir
-        New-Item -ItemType Directory -Force -Path $toolsDir
-
-        Write-Host "Installing DocFX 2.56.1 ..."
-        nuget install docfx.console -Version 2.56.1 -OutputDirectory $toolsDir
-    }
-    finally
-    {
-        Pop-Location
-    }
+    Write-Host "Installing DocFX 2.56.1 ..."
+    nuget install docfx.console -Version 2.56.1 -OutputDirectory $toolsDir
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/InstallToolsForBuildTestInspect.ps1
+++ b/src/InstallToolsForBuildTestInspect.ps1
@@ -1,5 +1,5 @@
 <#
-.Synopsis
+.SYNOPSIS
 This script installs the tools necessary to build and check the solution.
 #>
 
@@ -40,4 +40,5 @@ function Main {
     dotnet tool restore
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/InstallToolsForStyle.ps1
+++ b/src/InstallToolsForStyle.ps1
@@ -1,5 +1,5 @@
 <#
-.Synopsis
+.SYNOPSIS
 This script installs the tools necessary to build and check the solution.
 #>
 
@@ -7,14 +7,11 @@ Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
     AssertDotnet
 
 function Main {
-    Push-Location
-
     Set-Location $PSScriptRoot
 
     Write-Host "Restoring dotnet tools for the solution ..."
     dotnet tool restore
-
-    Pop-Location
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }

--- a/src/Test.ps1
+++ b/src/Test.ps1
@@ -1,4 +1,5 @@
-﻿<# 
+﻿<#
+.SYNOPSIS
 This script runs all the unit tests specified in the testDlls variable below.
 #>
 
@@ -40,7 +41,7 @@ function Main
         -register:user `
         -filter:"+[Aasx*]*"
 
-    if(!$?) {
+    if($LASTEXITCODE -ne 0) {
         throw "The unit test(s) failed."
     }
 
@@ -54,4 +55,5 @@ function Main
         -sourcedirs:$srcDir
 }
 
-Main
+Push-Location
+try { Main } finally { Pop-Location }


### PR DESCRIPTION
This patch makes all the powershell script conform to a style (*e.g.,
push location, try main, pop location).

So far, the scripts tended to get messy.