### PR TITLE
Fix missing docdev dependencies in CI

### DIFF
--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Install .NET core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.100'
+
       - name: Install docdev dependencies
         working-directory: src
         run: powershell .\InstallDocdevDependencies.ps1

--- a/src/InstallDocdevDependencies.ps1
+++ b/src/InstallDocdevDependencies.ps1
@@ -16,13 +16,18 @@ function Main
     {
        throw "Unable to find nuget.exe in your PATH"
     }
+    
+    AssertDotnet
 
     Set-Location $PSScriptRoot
     $toolsDir = GetToolsDir
-    New-Item -ItemType Directory -Force -Path $toolsDir
+    New-Item -ItemType Directory -Force -Path $toolsDir|Out-Null
 
     Write-Host "Installing DocFX 2.56.1 ..."
     nuget install docfx.console -Version 2.56.1 -OutputDirectory $toolsDir
+
+
+    dotnet tool restore
 }
 
 Push-Location


### PR DESCRIPTION
This patch restores dotnet tools since we need
opinionated-csharp-comments to generate TODO reports.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.