### PR TITLE
Fix location restoring in scripts

### DIFF
--- a/src/Build.ps1
+++ b/src/Build.ps1
@@ -44,5 +44,4 @@ function Main
     }
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/Check.ps1
+++ b/src/Check.ps1
@@ -20,5 +20,4 @@ function Main
     .\InspectCode.ps1
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/CheckBiteSized.ps1
+++ b/src/CheckBiteSized.ps1
@@ -38,5 +38,4 @@ function Main {
     }
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/CheckDeadCode.ps1
+++ b/src/CheckDeadCode.ps1
@@ -23,5 +23,4 @@ function Main
     }
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/CheckFormat.ps1
+++ b/src/CheckFormat.ps1
@@ -29,5 +29,4 @@ function Main
     }
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/CheckLicenses.ps1
+++ b/src/CheckLicenses.ps1
@@ -76,5 +76,4 @@ function Main
     Write-Host "Mind that the content has not been checked."
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/CheckPushCommitMessages.ps1
+++ b/src/CheckPushCommitMessages.ps1
@@ -47,5 +47,4 @@ function Main
     }
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/CheckTodos.ps1
+++ b/src/CheckTodos.ps1
@@ -24,5 +24,4 @@ function Main
     }
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/CopyLicense.ps1
+++ b/src/CopyLicense.ps1
@@ -60,5 +60,4 @@ function Main
     }
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/Doctest.ps1
+++ b/src/Doctest.ps1
@@ -77,5 +77,4 @@ function Main
     }
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/FormatCode.ps1
+++ b/src/FormatCode.ps1
@@ -18,5 +18,4 @@ function Main
     dotnet format --exclude "**/DocTest*.cs"
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/GenerateDocdev.ps1
+++ b/src/GenerateDocdev.ps1
@@ -44,5 +44,4 @@ function Main
     Write-Host "'$docfxExe' serve '$siteDir'"
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/GenerateTodoReport.ps1
+++ b/src/GenerateTodoReport.ps1
@@ -225,5 +225,4 @@ function Main
     GenerateTaskList -ReportPath $reportPath -TaskListDir $taskListDir
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/InspectCode.ps1
+++ b/src/InspectCode.ps1
@@ -56,6 +56,5 @@ function Main
     }
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }
 

--- a/src/InstallBuildDependencies.ps1
+++ b/src/InstallBuildDependencies.ps1
@@ -21,5 +21,4 @@ function Main {
     nuget.exe restore AasxPackageExplorer.sln -PackagesDirectory packages
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/InstallDevDependencies.ps1
+++ b/src/InstallDevDependencies.ps1
@@ -169,5 +169,4 @@ function Main
     }
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/InstallDocdevDependencies.ps1
+++ b/src/InstallDocdevDependencies.ps1
@@ -25,5 +25,4 @@ function Main
     nuget install docfx.console -Version 2.56.1 -OutputDirectory $toolsDir
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/InstallToolsForBuildTestInspect.ps1
+++ b/src/InstallToolsForBuildTestInspect.ps1
@@ -40,5 +40,4 @@ function Main {
     dotnet tool restore
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/InstallToolsForStyle.ps1
+++ b/src/InstallToolsForStyle.ps1
@@ -13,5 +13,4 @@ function Main {
     dotnet tool restore
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/Test.ps1
+++ b/src/Test.ps1
@@ -55,5 +55,4 @@ function Main
         -sourcedirs:$srcDir
 }
 
-Push-Location
-try { Main } finally { Pop-Location }
+$previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }


### PR DESCRIPTION
The powershell scripts had a potential bug: the current location was
pushed on stacked and popped in the `finally` block after the `Main`
function has been executed. If the `Main` fiddles with the location
stack, the final location would not be properly restored.

This patch introduces a temporary variable which stores the original
location and restores it in the `finally` block.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.