### PR TITLE
Fix "Articles" rename in docdev

### DIFF
--- a/docdev/docfx_project/docfx.json
+++ b/docdev/docfx_project/docfx.json
@@ -29,8 +29,8 @@
       },
       {
         "files": [
-          "articles/**.md",
-          "articles/**/toc.yml",
+          "getting-started/**.md",
+          "getting-started/**/toc.yml",
           "toc.yml",
           "*.md"
         ]


### PR DESCRIPTION
The section "Articles" was renamed to "Getting started". However, the
docfx.json was not adjusted accordingly. Since the gh-pages was not
visible before, the mistake went unnoticed.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.