### PR TITLE
Remove uninformative TODOs

### DIFF
--- a/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
@@ -646,7 +646,6 @@ namespace AasxIntegrationBase.AasForms
             var smecSource = this.sourceSme as AdminShell.SubmodelElementCollection;
             if (smecSource != null)
             {
-                // TODO (Michael Hoffmeister, 1970-01-01): take over
                 if (this.PairInstances != null)
                     foreach (var pair in this.PairInstances)
                     {
@@ -766,7 +765,6 @@ namespace AasxIntegrationBase.AasForms
             var pSource = this.sourceSme as AdminShell.Property;
             if (p != null && Touched && pSource != null && editSource)
             {
-                // TODO (Michael Hoffmeister, 1970-01-01): MICHA
                 pSource.valueType = p.valueType;
                 pSource.value = p.value;
                 return false;

--- a/src/AasxWpfControlLibrary/DispEditHelper.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelper.cs
@@ -1302,7 +1302,7 @@ namespace AasxPackageExplorer
                         // save in current context
                         var currentI = 0 + i;
 
-                        // TODO (Michael Hoffmeister, 1970-01-01): Needs to be revisted
+                        // TODO (Michael Hoffmeister, 1970-01-01): Needs to be revisited
 
                         // type
                         var cbType = repo.RegisterControl(

--- a/src/AasxWpfControlLibrary/VisualAasxElements.cs
+++ b/src/AasxWpfControlLibrary/VisualAasxElements.cs
@@ -24,7 +24,6 @@ The QR code generation is under the MIT license (see https://github.com/codebude
 The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
 */
 
-// TODO (Michael Hoffmeister, 1970-01-01): check again
 // ReSharper disable VirtualMemberCallInConstructor
 
 namespace AasxPackageExplorer


### PR DESCRIPTION
This patch removes the TODOs which are too uninformative for the
future developers (*e.g.*, lack context or further explanation).

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.