### PR TITLE
Rename workflow jobs to proper names

### DIFF
--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -1,4 +1,4 @@
-name: Build-test-inspect
+name: Build-test-inspect-workflow
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
-  Execute:
+  Build-test-inspect:
     runs-on: windows-latest
     if: contains(github.event.pull_request.body, 'The workflow build-test-inspect was intentionally skipped.') == false
     steps:

--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -1,4 +1,4 @@
-name: Check-commit-messages
+name: Check-commit-messages-workflow
 
 on: 
   push:
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
-  Execute:
+  Check-commit-messages:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -1,4 +1,4 @@
-name: Check-style
+name: Check-style-workflow
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
-  Execute:
+  Check-style:
     runs-on: windows-latest
     if: contains(github.event.pull_request.body, 'The workflow check-style was intentionally skipped.') == false
     steps:

--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -1,4 +1,4 @@
-name: Generate-doc
+name: Generate-doc-workflow
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  Execute:
+  Generate-doc:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
Github workflow statuses are based on job names. Previously, all jobs
were called "Execute" which does not allow us to distinguish which
checks should run before allowing the merge to the master.