### PR TITLE
Run workflows on push to master

### DIFF
--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -6,6 +6,10 @@ on:
       - master
     types: [opened, synchronize, reopened, edited]
 
+  push:
+    branches:
+      - master
+
 jobs:
   Build-test-inspect:
     runs-on: windows-latest

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -6,6 +6,10 @@ on:
       - master
     types: [opened, synchronize, reopened, edited]
 
+  push:
+    branches:
+      - master
+
 jobs:
   Check-style:
     runs-on: windows-latest


### PR DESCRIPTION
Previously, the workflows `build-test-inspect` and `check-style` were
run only on pull requests to master, but once squashed & merged, we did
not re-run them since we needed to save computational resources (the
repository was on free plan and private, hence limited computational
hours).

This patch makes them run on every push as the repository is public now
and no limits on computational time are imposed.