### PR TITLE
Fix typo in InspectCode.ps1

### DIFF
--- a/src/InspectCode.ps1
+++ b/src/InspectCode.ps1
@@ -48,7 +48,7 @@ function Main
         }
         if ($take -lt $issues.Count)
         {
-            Write-Hose "... and some more issues ($( $issues.Count ) in total)."
+            Write-Host "... and some more issues ($( $issues.Count ) in total)."
         }
 
         throw "There are $( $issues.Count ) InspectCode issue(s). " +      `


### PR DESCRIPTION
This patch fixes a typo (Write-Hose vs. Write-Host) in the
InspectCode.ps1 script.