### PR TITLE
Write copyright for OpenID client

### DIFF
--- a/src/AasxOpenidClient/ConsoleExtensions.cs
+++ b/src/AasxOpenidClient/ConsoleExtensions.cs
@@ -1,6 +1,12 @@
 ﻿using System;
 using System.Diagnostics;
 
+/*
+Copyright (c) 2020 see https://github.com/IdentityServer/IdentityServer4
+
+We adapted the code marginally and removed the parts that we do not use.
+*/
+
 // ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
 
 namespace AasxOpenIdClient

--- a/src/AasxOpenidClient/Constants.cs
+++ b/src/AasxOpenidClient/Constants.cs
@@ -1,5 +1,11 @@
 ﻿// ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
 
+/*
+Copyright (c) 2020 see https://github.com/IdentityServer/IdentityServer4
+
+We adapted the code marginally and removed the parts that we do not use.
+*/
+
 namespace AasxOpenIdClient
 {
     public class Constants

--- a/src/AasxOpenidClient/OpenIDCLient.cs
+++ b/src/AasxOpenidClient/OpenIDCLient.cs
@@ -18,6 +18,12 @@ using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+/*
+Copyright (c) 2020 see https://github.com/IdentityServer/IdentityServer4
+
+We adapted the code marginally and removed the parts that we do not use.
+*/
+
 // ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
 
 namespace AasxOpenIdClient

--- a/src/AasxOpenidClient/TokenResponseExtensions.cs
+++ b/src/AasxOpenidClient/TokenResponseExtensions.cs
@@ -4,6 +4,12 @@ using IdentityModel;
 using IdentityModel.Client;
 using Newtonsoft.Json.Linq;
 
+/*
+Copyright (c) 2020 see https://github.com/IdentityServer/IdentityServer4
+
+We adapted the code marginally and removed the parts that we do not use.
+*/
+
 namespace AasxOpenIdClient
 {
     public static class TokenResponseExtensions


### PR DESCRIPTION
We adapted the code of OpenID client provided in Identity Server 4 which
lacked the copyright header. We refer to the original repository so that
the original copyright can be found.

The workflow build-test-inspect was intentionally skipped.