### PR TITLE
Verbosify CopyLicense.ps1 and exclude directories

### DIFF
--- a/src/AdditionalVerbsInImperativeMood.txt
+++ b/src/AdditionalVerbsInImperativeMood.txt
@@ -9,3 +9,4 @@ inline
 in-line
 assign
 standardize
+verbosify

--- a/src/CopyLicense.ps1
+++ b/src/CopyLicense.ps1
@@ -18,7 +18,10 @@ function Main
 
     $excludes = @{
     # Example:
-    # $( Join-Path $srcDir "AasxPluginBomStructure" ) = true
+    $( Join-Path $srcDir ".config" ) = $true
+    $( Join-Path $srcDir ".idea" ) = $true
+    $( Join-Path $srcDir "packages" ) = $true
+    $( Join-Path $srcDir "bin" ) = $true
     }
 
     $includes = @(
@@ -30,7 +33,7 @@ function Main
     )
 
     $acceptedDirs = @( )
-    foreach ($dir in $( Dir -Directory $srcDir|Select -Expand FullName ))
+    foreach ($dir in $( Get-ChildItem -Directory $srcDir|Select-Object -Expand FullName ))
     {
         if (!$excludes.ContainsKey($dir) -or !$excludes[$dir])
         {
@@ -52,11 +55,12 @@ function Main
         }
     }
 
-    Write-Host "Copying the license to:"
+    Write-Host "Copying the license from $licenseTxt to:"
     foreach ($dir in $acceptedDirs)
     {
-        Write-Host $dir
-        Copy-Item $licenseTxt -Destination $dir
+        $destination = Join-Path $dir "LICENSE.txt"
+        Write-Host $destination
+        Copy-Item $licenseTxt -Destination $destination
     }
 }
 


### PR DESCRIPTION
This patch makes CopyLicense.ps1 more verbose. This revealed that some
directories should have been excluded from copying the licenses.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.