### PR TITLE
Refer to plug-in licenses in LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxAmlImExport/LICENSE.txt
+++ b/src/AasxAmlImExport/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxCsharpLibrary.Tests/LICENSE.txt
+++ b/src/AasxCsharpLibrary.Tests/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxCsharpLibrary/LICENSE.txt
+++ b/src/AasxCsharpLibrary/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxGenerate/LICENSE.txt
+++ b/src/AasxGenerate/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxIntegrationBase/LICENSE.txt
+++ b/src/AasxIntegrationBase/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxIntegrationBaseWpf/LICENSE.txt
+++ b/src/AasxIntegrationBaseWpf/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxIntegrationEmptySample/LICENSE.txt
+++ b/src/AasxIntegrationEmptySample/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxMqtt/LICENSE.txt
+++ b/src/AasxMqtt/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxMqttClient/LICENSE.txt
+++ b/src/AasxMqttClient/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxOldDataModels/LICENSE.txt
+++ b/src/AasxOldDataModels/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxOpenidClient/LICENSE.txt
+++ b/src/AasxOpenidClient/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPackageExplorer/LICENSE.txt
+++ b/src/AasxPackageExplorer/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPluginBomStructure/LICENSE.txt
+++ b/src/AasxPluginBomStructure/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPluginDocumentShelf/LICENSE.txt
+++ b/src/AasxPluginDocumentShelf/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPluginDocumentShelf/Resources/LICENSE.txt
+++ b/src/AasxPluginDocumentShelf/Resources/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPluginExportTable/LICENSE.txt
+++ b/src/AasxPluginExportTable/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPluginExportTable/Resources/LICENSE.txt
+++ b/src/AasxPluginExportTable/Resources/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPluginGenericForms/LICENSE.txt
+++ b/src/AasxPluginGenericForms/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPluginGenericForms/Resources/LICENSE.txt
+++ b/src/AasxPluginGenericForms/Resources/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPluginTechnicalData/LICENSE.txt
+++ b/src/AasxPluginTechnicalData/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPluginTechnicalData/Resources/LICENSE.txt
+++ b/src/AasxPluginTechnicalData/Resources/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPluginWebBrowser/LICENSE.txt
+++ b/src/AasxPluginWebBrowser/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPluginWebBrowser/Resources/LICENSE.txt
+++ b/src/AasxPluginWebBrowser/Resources/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxPredefinedConcepts/LICENSE.txt
+++ b/src/AasxPredefinedConcepts/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxRestConsoleServer/LICENSE.txt
+++ b/src/AasxRestConsoleServer/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxRestServerLibrary/LICENSE.txt
+++ b/src/AasxRestServerLibrary/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxSignature/LICENSE.txt
+++ b/src/AasxSignature/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxUANodesetImExport/LICENSE.txt
+++ b/src/AasxUANodesetImExport/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/AasxWpfControlLibrary/LICENSE.txt
+++ b/src/AasxWpfControlLibrary/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/LICENSE.txt
+++ b/src/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 

--- a/src/MsaglWpfControl/LICENSE.txt
+++ b/src/MsaglWpfControl/LICENSE.txt
@@ -39,6 +39,11 @@ The implementation uses the concepts of the document "Details of the Asset
 Administration Shell" published on www.plattform-i40.de which is licensed
 under Creative Commons CC BY-ND 3.0 DE.
 
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
 Apache License 2.0 (Apache-2.0)
 ===============================
 


### PR DESCRIPTION
This patch adds references to plug-in licenses in the main
`LICENSE.txt` file so that the readers are informed that
some licenses apply only to plug-ins.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.