### PR TITLE
Remove CLA badge from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ https://github.com/admin-shell-io/aasx-package-explorer/workflows/Check-style/ba
 https://github.com/admin-shell-io/aasx-package-explorer/workflows/Check-commit-messages/badge.svg
 ) ![Generate-docdev](
 https://github.com/admin-shell-io/aasx-package-explorer/workflows/Generate-docdev/badge.svg
-) [![CLA assistant](
-https://cla-assistant.io/readme/badge/admin-shell-io/aasx-package-explorer
-)](https://cla-assistant.io/admin-shell-io/aasx-package-explorer
 )
 
 [![TODOs](


### PR DESCRIPTION
CLA badge was confusing since it linked to the page for signing the CLA
instead of showing the information *who* signed the CLA. Since this
information is private anyhow, we decided to hide the badge altogether.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.