### PR TITLE
Send test coverage to coveralls

### DIFF
--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -17,11 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Debug
-        env:
-          COMMIT_MESSAGE: ${{ toJson(github.event.pull_request) }}
-        run: Write-Host $env:COMMIT_MESSAGE
-
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.0
         with:
@@ -59,6 +54,10 @@ jobs:
         working-directory: src
         run: powershell .\InstallBuildDependencies.ps1
 
+      - name: Install coveralls.net (to send test coverage)
+        working-directory: src
+        run: dotnet tool install coveralls.net
+
       - name: Build
         working-directory: src
         run: powershell .\BuildForDebug.ps1
@@ -70,6 +69,28 @@ jobs:
       - name: Test
         working-directory: src
         run: powershell .\Test.ps1
+
+      - name: Send to Coveralls
+        working-directory: src
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: |
+          $headRef = ${env:HEAD_REF}
+          if (${env:GITHUB_REF}.StartsWith("refs/pull/"))
+          {
+            $branch = $headRef -Replace 'refs/heads/', ''
+          }
+          else
+          {
+            $branch = ${env:GITHUB_REF} -replace 'refs/heads/', ''
+          }
+
+          $commit = $env:GITHUB_SHA
+
+          echo "Branch is: $branch"
+          echo "Commit is: $commit"
+          dotnet tool run csmacnz.Coveralls --opencover -i ..\artefacts\CoverageResults.xml --useRelativePaths --repoToken $env:COVERALLS_REPO_TOKEN --commitId $commit --commitBranch $branch
 
       - name: Cache inspect code
         uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ https://github.com/admin-shell-io/aasx-package-explorer/workflows/Check-style/ba
 https://github.com/admin-shell-io/aasx-package-explorer/workflows/Check-commit-messages/badge.svg
 ) ![Generate-docdev](
 https://github.com/admin-shell-io/aasx-package-explorer/workflows/Generate-docdev/badge.svg
+) [![Coverage Status](
+https://coveralls.io/repos/github/admin-shell-io/aasx-package-explorer/badge.svg?branch=master
+)](
+https://coveralls.io/github/admin-shell-io/aasx-package-explorer?branch=master
 )
 
 [![TODOs](

--- a/src/Test.ps1
+++ b/src/Test.ps1
@@ -6,10 +6,10 @@ This script runs all the unit tests specified in the testDlls variable below.
 $ErrorActionPreference = "Stop"
 
 Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
-    FindNunit3Console,  `
-     FindOpenCoverConsole,  `
-     CreateAndGetArtefactsDir,  `
-     FindReportGenerator
+    FindNunit3Console,     `
+        FindOpenCoverConsole,     `
+        CreateAndGetArtefactsDir,     `
+        FindReportGenerator
 
 function Main
 {
@@ -42,13 +42,14 @@ function Main
     & $openCoverConsole `
         -target:$nunit3Console `
         -targetargs:( `
-            "--noheader --shadowcopy=false " +  `
-             "--result=$testResultsPath " +  `
-             ($testDlls -Join " ")
-    ) `
+            "--noheader " +
+            "--shadowcopy=false " +
+            "--result=$testResultsPath " +
+            ($testDlls -Join " ") `
+        ) `
         -targetdir:$targetDir `
         -output:$coverageResultsPath `
-        -register:user `
+        -register:Path64 `
         -filter:"+[Aasx*]*"
 
     if ($LASTEXITCODE -ne 0)


### PR DESCRIPTION
This integrates coveralls client to the build-test-inspect workflow and
sends the coverage report to coveralls.io.