### PR TITLE
Point to StackOverflow for rulers in Visual Studio

### DIFF
--- a/docdev/docfx_project/getting-started/troubleshooting.md
+++ b/docdev/docfx_project/getting-started/troubleshooting.md
@@ -52,3 +52,13 @@ Studio's MSBuild executable instead of installing MSBuild using the
 `C:\Program Files (x86)\Microsoft Visual Studio\<Release>\<Edition>\MSBuild\Current\Bin`.  
 Make sure that this directory is listed in your `PATH` environment variable.
 
+## Using rulers in Visual Studio
+
+Please see this Stack Overflow question and answers if you want Visual Studio
+to show rulers (*e.g.*, at 120 characters):
+
+https://stackoverflow.com/questions/5887107/ruler-in-visual-studio
+
+In particular, we endorse this answer:
+
+https://stackoverflow.com/a/57904374/1600678


### PR DESCRIPTION
This patch mentions a relevant StackOverflow question related to rulers
in Visual Studio and highlights which Visual Studio plug-in we endorse.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.