### PR TITLE
Test load & save chain with samples

### DIFF
--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -66,6 +66,18 @@ jobs:
         working-directory: src
         run: powershell .\Doctest.ps1 -check
 
+      - name: Cache sample AASXs
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-sample-aasx
+        with:
+          path: sample-aasx
+          key: ${{ env.cache-name }}-${{ hashFiles('src/DownloadSamples.ps1') }}-2020-08-01
+
+      - name: Download samples
+        working-directory: src
+        run: powershell .\DownloadSamples.ps1
+
       - name: Test
         working-directory: src
         run: powershell .\Test.ps1

--- a/src/AasxCsharpLibrary.Tests/AasxCsharpLibrary.Tests.csproj
+++ b/src/AasxCsharpLibrary.Tests/AasxCsharpLibrary.Tests.csproj
@@ -51,6 +51,8 @@
     <Compile Include="DocTestAdminShellUtil.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestAdminShellUtil.cs" />
+    <Compile Include="TestLoadSaveChain.cs" />
+    <Compile Include="TemporaryDirectory.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj">

--- a/src/AasxCsharpLibrary.Tests/TemporaryDirectory.cs
+++ b/src/AasxCsharpLibrary.Tests/TemporaryDirectory.cs
@@ -1,0 +1,23 @@
+using IDisposable = System.IDisposable;
+
+namespace AdminShellNS.Tests
+{
+    class TemporaryDirectory : IDisposable
+    {
+        public readonly string Path;
+
+        public TemporaryDirectory()
+        {
+            this.Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                System.IO.Path.GetRandomFileName());
+
+            System.IO.Directory.CreateDirectory(this.Path);
+        }
+
+        public void Dispose()
+        {
+            System.IO.Directory.Delete(this.Path, true);
+        }
+    }
+}

--- a/src/AasxCsharpLibrary.Tests/TestAdminShellUtil.cs
+++ b/src/AasxCsharpLibrary.Tests/TestAdminShellUtil.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 
-namespace AsminShellNS.Tests
+namespace AdminShellNS.Tests
 {
     // ReSharper disable UnusedType.Global
     public class Test_EvalToNonNullString

--- a/src/AasxCsharpLibrary.Tests/TestLoadSaveChain.cs
+++ b/src/AasxCsharpLibrary.Tests/TestLoadSaveChain.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using InvalidOperationException = System.InvalidOperationException;
+
+namespace AdminShellNS.Tests
+{
+    static class SamplesAasxDir
+    {
+        public static List<string> ListAasxPaths()
+        {
+            var variable = "SAMPLE_AASX_DIR";
+
+            var sampleAasxDir = System.Environment.GetEnvironmentVariable(variable);
+            if (sampleAasxDir == null)
+            {
+                throw new InvalidOperationException(
+                    $"The environment variable {variable} has not been set. " +
+                    "Did you set it manually to the directory containing sample AASXs? " +
+                    "Otherwise, run the test through Test.ps1?");
+            }
+
+            if (!System.IO.Directory.Exists(sampleAasxDir))
+            {
+                throw new InvalidOperationException(
+                    $"The directory containing the sample AASXs does not exist or is not a directory: " +
+                    $"{sampleAasxDir}; did you download the samples with DownloadSamples.ps1?");
+            }
+
+            var result = System.IO.Directory.GetFiles(sampleAasxDir)
+                .Where(p => System.IO.Path.GetExtension(p) == ".aasx")
+                .ToList();
+
+            result.Sort();
+
+            return result;
+        }
+    }
+
+    public class TestLoadSaveChain
+    {
+        private static void AssertFilesEqual(string firstPath, string secondPath, string aasxPath)
+        {
+            string firstContent = System.IO.File.ReadAllText(firstPath);
+            string secondContent = System.IO.File.ReadAllText(secondPath);
+
+            string[] firstLines = firstContent.Split(
+                new[] { "\r\n", "\r", "\n" },
+                System.StringSplitOptions.None
+            );
+
+            string[] secondLines = secondContent.Split(
+                new[] { "\r\n", "\r", "\n" },
+                System.StringSplitOptions.None
+            );
+
+            int min = (firstLines.Length < secondLines.Length)
+                ? firstLines.Length
+                : secondLines.Length;
+
+            for (var i = 0; i < min; i++)
+            {
+                if (firstLines[i] != secondLines[i])
+                {
+                    int start = (i < 20) ? 0 : i - 20;
+                    var sb = new System.Text.StringBuilder();
+                    sb.AppendLine("The first and the second export in the chain differ:");
+
+                    for (var j = start; j < i; j++)
+                    {
+                        sb.AppendLine($"[{i,6}:SAME IN BOTH]{firstLines[j]}");
+                    }
+
+                    sb.AppendLine($"[{i,6}:IN FIRST    ]{firstLines[i]}");
+                    sb.AppendLine($"[{i,6}:IN SECOND   ]{secondLines[i]}");
+
+                    sb.AppendLine($"The AASX sample used was: {aasxPath}");
+                    throw new AssertionException(sb.ToString());
+                }
+            }
+        }
+
+        [TestCase(".xml")]
+        public void Test(string extension)
+        {
+            List<string> aasxPaths = SamplesAasxDir.ListAasxPaths();
+
+            using (var tmpDir = new TemporaryDirectory())
+            {
+                foreach (string aasxPath in aasxPaths)
+                {
+                    /*
+                     * The chain is as follows:
+                     * - First load from AASX (package A)
+                     * - Convert package 1 to `extension` format and save as path 1
+                     * - Load from the path 1 in `extension` format (package B) 
+                     * - Save package B in `extension` format to path 2
+                     *
+                     * We expect the content of the two files (path 1 and path 2, respectively) to be equal.
+                     */
+                    using (var packageA = new AdminShellPackageEnv(aasxPath))
+                    {
+                        string path1 = System.IO.Path.Combine(tmpDir.Path, $"first{extension}");
+                        string path2 = System.IO.Path.Combine(tmpDir.Path, $"second{extension}");
+
+                        packageA.SaveAs(path1, writeFreshly: true);
+
+                        using (var packageB = new AdminShellPackageEnv(path1))
+                        {
+                            packageB.SaveAs(path2, writeFreshly: true);
+                            AssertFilesEqual(path1, path2, aasxPath);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
+++ b/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
@@ -141,7 +141,7 @@ namespace AdminShellNS
     /// This class encapsulates an AdminShellEnvironment and supplementary files into an AASX Package.
     /// Specifically has the capability to load, update and store .XML, .JSON and .AASX packages.
     /// </summary>
-    public class AdminShellPackageEnv
+    public class AdminShellPackageEnv : IDisposable
     {
         private string fn = "New Package";
 
@@ -1037,6 +1037,11 @@ namespace AdminShellNS
             this.openPackage = null;
             this.fn = "";
             this.aasenv = null;
+        }
+
+        public void Dispose()
+        {
+            Close();
         }
 
         public string MakePackageFileAvailableAsTempFile(string packageUri)

--- a/src/AasxPackageExplorer.sln.DotSettings
+++ b/src/AasxPackageExplorer.sln.DotSettings
@@ -157,6 +157,7 @@
 	
 	<!-- again, I do like explicit things --> 
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBaseQualifier/@EntryIndexedValue">HINT</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Aasx/@EntryIndexedValue">True</s:Boolean>
 	
 	
 </wpf:ResourceDictionary>

--- a/src/Common.psm1
+++ b/src/Common.psm1
@@ -247,6 +247,11 @@ function CreateAndGetArtefactsDir
     return $artefactsDir
 }
 
+function GetSamplesDir
+{
+    return Join-Path (Split-Path $PSScriptRoot -Parent) "sample-aasx"
+}
+
 Export-ModuleMember -Function `
     GetToolsDir, `
      AssertDotnet, `
@@ -261,4 +266,5 @@ Export-ModuleMember -Function `
      FindOpenCoverConsole, `
      FindReportGenerator, `
      GetArtefactsDir, `
-     CreateAndGetArtefactsDir
+     CreateAndGetArtefactsDir, `
+     GetSamplesDir

--- a/src/PackageRelease.ps1
+++ b/src/PackageRelease.ps1
@@ -12,7 +12,8 @@ This script packages files to be released.
 $ErrorActionPreference = "Stop"
 
 Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
-    GetArtefactsDir
+    GetArtefactsDir, `
+    GetSamplesDir
 
 function PackageRelease($outputDir)
 {
@@ -26,7 +27,7 @@ function PackageRelease($outputDir)
                 "with BuildForRelease.ps1?")
     }
 
-    $samplesDir = Join-Path (Split-Path $PSScriptRoot -Parent) "sample-aasx"
+    $samplesDir = GetSamplesDir
 
     if (!(Test-Path $samplesDir))
     {


### PR DESCRIPTION
We perform a chain of load & saves to check that the de/serialization
works.

The chain is as follows (for different formats such as XML and JSON):
- First load from AASX (package A)
- Convert package 1 to the format and save as path 1
- Load from the path 1 in the format (package B)
- Save package B in the format to path 2

We expect the content of the two files (path 1 and path 2,
respecitvely) to be equal.

The samples are downloaded from admin-shell-io.com/samples.
The original inspiration was AasxGenerate.