### PR TITLE
Fix missing coverage in coveralls

### DIFF
--- a/src/Test.ps1
+++ b/src/Test.ps1
@@ -72,7 +72,7 @@ function Main
             ) `
             -targetdir:$targetDir `
             -output:$coverageResultsPath `
-            -register:user `
+            -register:Path64 `
             -filter:"+[Aasx*]*" `
             -returntargetcode
 


### PR DESCRIPTION
This fixes a regression where `-register` in OpenCover was mistakenly
revert to `user` (instead of `Path64`).