### PR TITLE
Ignore bite-sized for URLs

### DIFF
--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "bitesized": {
-      "version": "1.0.0-beta1",
+      "version": "1.0.0-beta2",
       "commands": [
         "bite-sized"
       ]

--- a/src/CheckBiteSized.ps1
+++ b/src/CheckBiteSized.ps1
@@ -8,7 +8,7 @@ Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
     AssertDotnetToolVersion
 
 function Main {
-    AssertDotnetToolVersion -PackageID "BiteSized" -ExpectedVersion "1.0.0-beta1"
+    AssertDotnetToolVersion -PackageID "BiteSized" -ExpectedVersion "1.0.0-beta2"
 
     Set-Location $PSScriptRoot
 
@@ -30,7 +30,8 @@ function Main {
             "MsaglWpfControl/VEdge.cs" `
             "MsaglWpfControl/VNode.cs" `
         --max-lines-in-file 100000 `
-        --max-line-length 120
+        --max-line-length 120 `
+        --ignore-lines-matching '[a-z]+://[^ \t]+$'
 
     if($LASTEXITCODE -ne 0)
     {


### PR DESCRIPTION
Bite-sized hit all the lines which were longer than 120. However, there
are certain strings in comments which we can not break such as URLs.

This patch makes bite-size ignore all the lines matching a (very
conservative) URL scheme followed by a delimiter (`://`).