### PR TITLE
Upgrade bite-sized to 1.0.0-beta3

### DIFF
--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "bitesized": {
-      "version": "1.0.0-beta2",
+      "version": "1.0.0-beta3",
       "commands": [
         "bite-sized"
       ]

--- a/src/CheckBiteSized.ps1
+++ b/src/CheckBiteSized.ps1
@@ -8,7 +8,7 @@ Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
     AssertDotnetToolVersion
 
 function Main {
-    AssertDotnetToolVersion -PackageID "BiteSized" -ExpectedVersion "1.0.0-beta2"
+    AssertDotnetToolVersion -PackageID "BiteSized" -ExpectedVersion "1.0.0-beta3"
 
     Set-Location $PSScriptRoot
 


### PR DESCRIPTION
Bite-sized is upgraded since this version gives more informative failure
messages (such as original command-line arguments).