### PR TITLE
Make histogram of issues in InspectCode.ps1

### DIFF
--- a/src/InspectCode.ps1
+++ b/src/InspectCode.ps1
@@ -34,14 +34,43 @@ function Main
         AasxPackageExplorer.sln
 
     [xml]$inspection = Get-Content $codeInspectionPath
+
     $issues = $inspection.SelectNodes('//Issue')
     if ($issues.Count -ne 0)
     {
-        $take = 50
+        # Compute histogram of the issues
+
+        $histogram = @{}
+        foreach($issue in $issues)
+        {
+            $typeId = $issue.TypeId
+            if($histogram.ContainsKey($typeId))
+            {
+                $histogram[$typeId]++
+            }
+            else
+            {
+                $histogram[$typeId] = 1
+            }
+        }
+
+        Write-Host
+        Write-Host "The distribution of the issues:"
+        foreach($kv in $histogram.GetEnumerator()|Sort-Object Value -Descending)
+        {
+            Write-Host (" * {0,-60} {1,6}" -f ($kv.Key + ":"), $kv.Value)
+        }
+
+        # Display a couple of the issues
+
+        $take = 20
         if ($issues.Count -lt $take)
         {
             $take = $issues.Count
         }
+
+        Write-Host
+        Write-Host "The first $take issue(s):"
         for($i = 0; $i -lt $take; $i++)
         {
             Write-Host "Issue $( $i + 1 ) / $( $issues.Count ): $( $issues.Item($i).OuterXml )"


### PR DESCRIPTION
A histogram of issues in code inspection helps us set the warning
severity level in the IDE (*e.g.*, JetBrains Rider) when we need to fix
a lot of them.

For example, we can pick a single issue type, turn off all the other
warnings and focus on fixing only that particular issue type. This is
both more efficient and less error-prone as we can consider the whole
code base under that single aspect.