### PR TITLE
Upgrade dead-csharp to 1.0.0-beta5

### DIFF
--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "deadcsharp": {
-      "version": "1.0.0-beta4",
+      "version": "1.0.0-beta5",
       "commands": [
         "dead-csharp"
       ]

--- a/src/Common.psm1
+++ b/src/Common.psm1
@@ -159,7 +159,7 @@ Check the version of dead-csharp so that the dead code is always detected in the
 #>
 function AssertDeadCsharpVersion
 {
-    AssertDotnetToolVersion -packageID "deadcsharp" -expectedVersion "1.0.0-beta4"
+    AssertDotnetToolVersion -packageID "deadcsharp" -expectedVersion "1.0.0-beta5"
 }
 
 <#


### PR DESCRIPTION
This version of dead-csharp gives more precise cues about why it
detected certain comments as dead code. This makes it easier for the
developer to transform the comments (or to decide to mark them for
skipping altogether).

The workflow build-test-inspect was intentionally skipped.