### PR TITLE
Update LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxAmlImExport/LICENSE.txt
+++ b/src/AasxAmlImExport/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxCsharpLibrary.Tests/LICENSE.txt
+++ b/src/AasxCsharpLibrary.Tests/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxCsharpLibrary/LICENSE.txt
+++ b/src/AasxCsharpLibrary/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxGenerate/LICENSE.txt
+++ b/src/AasxGenerate/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxIntegrationBase/LICENSE.txt
+++ b/src/AasxIntegrationBase/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxIntegrationBaseWpf/LICENSE.txt
+++ b/src/AasxIntegrationBaseWpf/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxIntegrationEmptySample/LICENSE.txt
+++ b/src/AasxIntegrationEmptySample/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxMqtt/LICENSE.txt
+++ b/src/AasxMqtt/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxMqttClient/LICENSE.txt
+++ b/src/AasxMqttClient/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxOldDataModels/LICENSE.txt
+++ b/src/AasxOldDataModels/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxOpenidClient/LICENSE.txt
+++ b/src/AasxOpenidClient/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxPackageExplorer/LICENSE.txt
+++ b/src/AasxPackageExplorer/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxPredefinedConcepts/LICENSE.txt
+++ b/src/AasxPredefinedConcepts/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxRestConsoleServer/LICENSE.txt
+++ b/src/AasxRestConsoleServer/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxRestServerLibrary/LICENSE.txt
+++ b/src/AasxRestServerLibrary/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxSignature/LICENSE.txt
+++ b/src/AasxSignature/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxUANodesetImExport/LICENSE.txt
+++ b/src/AasxUANodesetImExport/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxUaNetConsoleServer/LICENSE.txt
+++ b/src/AasxUaNetConsoleServer/LICENSE.txt
@@ -1,1 +1,906 @@
-Please see LICENSE.txt of the AASX Package Explorer main application.
+Copyright (c) 2018-2020 Festo AG & Co. KG
+<https://www.festo.com/net/de_de/Forms/web/contact_international>,
+author: Michael Hoffmeister
+
+Copyright (c) 2019-2020 PHOENIX CONTACT GmbH & Co. KG
+<opensource@phoenixcontact.com>,
+author: Andreas Orzelski
+
+Copyright (c) 2019-2020 Fraunhofer IOSB-INA Lemgo,
+    eine rechtlich nicht selbstaendige Einrichtung der Fraunhofer-Gesellschaft
+    zur Foerderung der angewandten Forschung e.V.
+
+Copyright (c) 2020 Schneider Electric Automation GmbH
+<marco.mendes@se.com>,
+author: Marco Mendes
+
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
+
+The browser functionality is licensed under the cefSharp license (see below).
+
+The Newtonsoft.JSON serialization is licensed under the MIT License
+(MIT, see below).
+
+The QR code generation is licensed under the MIT license (MIT, see below).
+
+The Zxing.Net Dot Matrix Code (DMC) generation is licensed under
+the Apache License 2.0 (Apache-2.0, see below).
+
+The Grapevine REST server framework is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The AutomationML.Engine is licensed under the MIT license (MIT, see below).
+
+The MQTT server and client is licensed under the MIT license (MIT, see below).
+
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
+
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
+
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
+
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to cefSharp
+========================
+
+(https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
+
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+With respect to Newtonsoft.Json
+===============================
+
+(https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md)
+
+The MIT License (MIT)
+
+Copyright (c) 2007 James Newton-King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to QRcoder
+=======================
+
+(https://github.com/codebude/QRCoder/blob/master/LICENSE.txt)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2018 Raffael Herrmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to ZXing.Net
+=========================
+With respect to Grapevine
+=========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to AutomationML.Engine
+===================================
+
+(https://raw.githubusercontent.com/AutomationML/AMLEngine2.1/master/license.txt)
+
+The MIT License (MIT)
+
+Copyright 2017 AutomationML e.V.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+With respect to MQTTnet
+=======================
+
+(https://github.com/chkr1011/MQTTnet/blob/master/LICENSE)
+
+MIT License
+
+MQTTnet Copyright (c) 2016-2019 Christian Kratky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxUaNetServer/LICENSE.txt
+++ b/src/AasxUaNetServer/LICENSE.txt
@@ -1,1 +1,906 @@
-Please see LICENSE.txt of the AASX Package Explorer main application.
+Copyright (c) 2018-2020 Festo AG & Co. KG
+<https://www.festo.com/net/de_de/Forms/web/contact_international>,
+author: Michael Hoffmeister
+
+Copyright (c) 2019-2020 PHOENIX CONTACT GmbH & Co. KG
+<opensource@phoenixcontact.com>,
+author: Andreas Orzelski
+
+Copyright (c) 2019-2020 Fraunhofer IOSB-INA Lemgo,
+    eine rechtlich nicht selbstaendige Einrichtung der Fraunhofer-Gesellschaft
+    zur Foerderung der angewandten Forschung e.V.
+
+Copyright (c) 2020 Schneider Electric Automation GmbH
+<marco.mendes@se.com>,
+author: Marco Mendes
+
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
+
+The browser functionality is licensed under the cefSharp license (see below).
+
+The Newtonsoft.JSON serialization is licensed under the MIT License
+(MIT, see below).
+
+The QR code generation is licensed under the MIT license (MIT, see below).
+
+The Zxing.Net Dot Matrix Code (DMC) generation is licensed under
+the Apache License 2.0 (Apache-2.0, see below).
+
+The Grapevine REST server framework is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The AutomationML.Engine is licensed under the MIT license (MIT, see below).
+
+The MQTT server and client is licensed under the MIT license (MIT, see below).
+
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
+
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
+
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
+
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to cefSharp
+========================
+
+(https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
+
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+With respect to Newtonsoft.Json
+===============================
+
+(https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md)
+
+The MIT License (MIT)
+
+Copyright (c) 2007 James Newton-King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to QRcoder
+=======================
+
+(https://github.com/codebude/QRCoder/blob/master/LICENSE.txt)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2018 Raffael Herrmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to ZXing.Net
+=========================
+With respect to Grapevine
+=========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to AutomationML.Engine
+===================================
+
+(https://raw.githubusercontent.com/AutomationML/AMLEngine2.1/master/license.txt)
+
+The MIT License (MIT)
+
+Copyright 2017 AutomationML e.V.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+With respect to MQTTnet
+=======================
+
+(https://github.com/chkr1011/MQTTnet/blob/master/LICENSE)
+
+MIT License
+
+MQTTnet Copyright (c) 2016-2019 Christian Kratky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxWpfControlLibrary/LICENSE.txt
+++ b/src/AasxWpfControlLibrary/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/CopyLicense.ps1
+++ b/src/CopyLicense.ps1
@@ -23,11 +23,14 @@ function Main
     $( Join-Path $srcDir "bin" ) = $true
 
     $( Join-Path $srcDir "AasxPluginBomStructure" ) = $true
-    $( Join-Path $srcDir "AasxPluginWebBrowser" ) = $true
-    $( Join-Path $srcDir "AasxPluginTechnicalData" ) = $true
+    $( Join-Path $srcDir "AasxPluginDocumentShelf" ) = $true
     $( Join-Path $srcDir "AasxPluginExportTable" ) = $true
     $( Join-Path $srcDir "AasxPluginGenericForms" ) = $true
-    $( Join-Path $srcDir "AasxPluginDocumentShelf" ) = $true
+    $( Join-Path $srcDir "AasxPluginMtpViewer" ) = $true
+    $( Join-Path $srcDir "AasxPluginTechnicalData" ) = $true
+    $( Join-Path $srcDir "AasxPluginUaNetClient" ) = $true
+    $( Join-Path $srcDir "AasxPluginUaNetServer" ) = $true
+    $( Join-Path $srcDir "AasxPluginWebBrowser" ) = $true
     }
 
     $includes = @(

--- a/src/LICENSE.txt
+++ b/src/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/MsaglWpfControl/LICENSE.txt
+++ b/src/MsaglWpfControl/LICENSE.txt
@@ -14,7 +14,24 @@ Copyright (c) 2020 Schneider Electric Automation GmbH
 <marco.mendes@se.com>,
 author: Marco Mendes
 
-This software is licensed under the Apache License 2.0 (Apache-2.0, see below).
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
 
 The browser functionality is licensed under the cefSharp license (see below).
 
@@ -33,19 +50,32 @@ The AutomationML.Engine is licensed under the MIT license (MIT, see below).
 
 The MQTT server and client is licensed under the MIT license (MIT, see below).
 
-This application is a sample application for demonstration of the features of
-the Administration Shell. It is not allowed for productive use.
-The implementation uses the concepts of the document "Details of the Asset
-Administration Shell" published on www.plattform-i40.de which is licensed
-under Creative Commons CC BY-ND 3.0 DE.
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
 
-Some licenses may only apply to their related plugins.
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
 
-When using eCl@ss or IEC CDD data, please check the corresponding license
-conditions.
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
 
-Apache License 2.0 (Apache-2.0)
-===============================
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -232,36 +262,36 @@ With respect to cefSharp
 
 (https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
 
-// Copyright © The CefSharp Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above
-//      copyright notice, this list of conditions and the following disclaimer
-//      in the documentation and/or other materials provided with the
-//      distribution.
-//
-//    * Neither the name of Google Inc. nor the name Chromium Embedded
-//      Framework nor the name CefSharp nor the names of its contributors
-//      may be used to endorse or promote products derived from this software
-//      without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 With respect to Newtonsoft.Json
 ===============================
@@ -319,6 +349,10 @@ With respect to ZXing.Net
 =========================
 With respect to Grapevine
 =========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
 
 (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -509,23 +543,24 @@ The MIT License (MIT)
 
 Copyright 2017 AutomationML e.V.
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in 
+The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
 
 With respect to MQTTnet
 =======================
@@ -553,3 +588,319 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/WpfMtpControl/LICENSE.txt
+++ b/src/WpfMtpControl/LICENSE.txt
@@ -1,1 +1,906 @@
-Please see LICENSE.txt of the AASX Package Explorer main application.
+Copyright (c) 2018-2020 Festo AG & Co. KG
+<https://www.festo.com/net/de_de/Forms/web/contact_international>,
+author: Michael Hoffmeister
+
+Copyright (c) 2019-2020 PHOENIX CONTACT GmbH & Co. KG
+<opensource@phoenixcontact.com>,
+author: Andreas Orzelski
+
+Copyright (c) 2019-2020 Fraunhofer IOSB-INA Lemgo,
+    eine rechtlich nicht selbstaendige Einrichtung der Fraunhofer-Gesellschaft
+    zur Foerderung der angewandten Forschung e.V.
+
+Copyright (c) 2020 Schneider Electric Automation GmbH
+<marco.mendes@se.com>,
+author: Marco Mendes
+
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
+
+The browser functionality is licensed under the cefSharp license (see below).
+
+The Newtonsoft.JSON serialization is licensed under the MIT License
+(MIT, see below).
+
+The QR code generation is licensed under the MIT license (MIT, see below).
+
+The Zxing.Net Dot Matrix Code (DMC) generation is licensed under
+the Apache License 2.0 (Apache-2.0, see below).
+
+The Grapevine REST server framework is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The AutomationML.Engine is licensed under the MIT license (MIT, see below).
+
+The MQTT server and client is licensed under the MIT license (MIT, see below).
+
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
+
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
+
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
+
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to cefSharp
+========================
+
+(https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
+
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+With respect to Newtonsoft.Json
+===============================
+
+(https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md)
+
+The MIT License (MIT)
+
+Copyright (c) 2007 James Newton-King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to QRcoder
+=======================
+
+(https://github.com/codebude/QRCoder/blob/master/LICENSE.txt)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2018 Raffael Herrmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to ZXing.Net
+=========================
+With respect to Grapevine
+=========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to AutomationML.Engine
+===================================
+
+(https://raw.githubusercontent.com/AutomationML/AMLEngine2.1/master/license.txt)
+
+The MIT License (MIT)
+
+Copyright 2017 AutomationML e.V.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+With respect to MQTTnet
+=======================
+
+(https://github.com/chkr1011/MQTTnet/blob/master/LICENSE)
+
+MIT License
+
+MQTTnet Copyright (c) 2016-2019 Christian Kratky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/WpfMtpVisuViewer/LICENSE.txt
+++ b/src/WpfMtpVisuViewer/LICENSE.txt
@@ -1,1 +1,906 @@
-Please see LICENSE.txt of the AASX Package Explorer main application.
+Copyright (c) 2018-2020 Festo AG & Co. KG
+<https://www.festo.com/net/de_de/Forms/web/contact_international>,
+author: Michael Hoffmeister
+
+Copyright (c) 2019-2020 PHOENIX CONTACT GmbH & Co. KG
+<opensource@phoenixcontact.com>,
+author: Andreas Orzelski
+
+Copyright (c) 2019-2020 Fraunhofer IOSB-INA Lemgo,
+    eine rechtlich nicht selbstaendige Einrichtung der Fraunhofer-Gesellschaft
+    zur Foerderung der angewandten Forschung e.V.
+
+Copyright (c) 2020 Schneider Electric Automation GmbH
+<marco.mendes@se.com>,
+author: Marco Mendes
+
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
+
+The browser functionality is licensed under the cefSharp license (see below).
+
+The Newtonsoft.JSON serialization is licensed under the MIT License
+(MIT, see below).
+
+The QR code generation is licensed under the MIT license (MIT, see below).
+
+The Zxing.Net Dot Matrix Code (DMC) generation is licensed under
+the Apache License 2.0 (Apache-2.0, see below).
+
+The Grapevine REST server framework is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The AutomationML.Engine is licensed under the MIT license (MIT, see below).
+
+The MQTT server and client is licensed under the MIT license (MIT, see below).
+
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
+
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
+
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
+
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to cefSharp
+========================
+
+(https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
+
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+With respect to Newtonsoft.Json
+===============================
+
+(https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md)
+
+The MIT License (MIT)
+
+Copyright (c) 2007 James Newton-King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to QRcoder
+=======================
+
+(https://github.com/codebude/QRCoder/blob/master/LICENSE.txt)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2018 Raffael Herrmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to ZXing.Net
+=========================
+With respect to Grapevine
+=========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to AutomationML.Engine
+===================================
+
+(https://raw.githubusercontent.com/AutomationML/AMLEngine2.1/master/license.txt)
+
+The MIT License (MIT)
+
+Copyright 2017 AutomationML e.V.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+With respect to MQTTnet
+=======================
+
+(https://github.com/chkr1011/MQTTnet/blob/master/LICENSE)
+
+MIT License
+
+MQTTnet Copyright (c) 2016-2019 Christian Kratky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+    Definitions.
+        "Articles" means, collectively, all articles written by Author which
+	describes how the Source Code and Executable Files for the Work may
+	be used by a user.
+        "Author" means the individual or entity that offers the Work under
+	the terms of this License.
+        "Derivative Work" means a work based upon the Work or upon the Work
+	and other pre-existing works.
+        "Executable Files" refer to the executables, binary files,
+	configuration and any required data files included in the Work.
+        "Publisher" means the provider of the website, magazine, CD-ROM,
+	DVD or other medium from or by which the Work is obtained by You.
+        "Source Code" refers to the collection of source code and
+	configuration files used to create the Executable Files.
+        "Standard Version" refers to such a Work if it has not been modified,
+	or has been modified in accordance with the consent of the Author,
+	such consent being in the full discretion of the Author.
+        "Work" refers to the collection of files distributed by the Publisher,
+	including the Source Code, Executable Files, binaries, data files,
+	documentation, whitepapers and the Articles.
+        "You" is you, an individual or entity wishing to use the Work and
+	exercise your rights under this License.
+
+    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+	limit, or restrict any rights arising from fair use, fair dealing,
+	first sale or other limitations on the exclusive rights of the
+	copyright owner under copyright law or other applicable laws.
+
+    License Grant. Subject to the terms and conditions of this License, the
+	Author hereby grants You a worldwide, royalty-free, non-exclusive,
+	perpetual (for the duration of the applicable copyright) license
+	to exercise the rights in the Work as stated below:
+        You may use the standard version of the Source Code or Executable
+	Files in Your own applications.
+        You may apply bug fixes, portability fixes and other modifications
+	obtained from the Public Domain or from the Author. A Work modified
+	in such a way shall still be considered the standard version and will
+	be subject to this License.
+        You may otherwise modify Your copy of this Work (excluding the Articles)
+	in any way to create a Derivative Work, provided that You insert a prominent
+	notice in each changed file stating how, when and where You changed that file.
+        You may distribute the standard version of the Executable Files and Source
+	Code or Derivative Work in aggregate with other (possibly commercial)
+	programs as part of a larger (possibly commercial) software distribution.
+        The Articles discussing the Work published in any form by the author may
+	not be distributed or republished without the Author's consent. The author
+	retains copyright to any such Articles. You may use the Executable Files and
+	Source Code pursuant to this License but you may not repost or republish or
+	otherwise distribute or make available the Articles, without the prior written
+	consent of the Author.
+
+    Any subroutines or modules supplied by You and linked into the Source Code
+	or Executable Files of this Work shall not be considered part of this Work
+	and will not be subject to the terms of this License.
+
+    Patent License. Subject to the terms and conditions of this License, each
+	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+	royalty-free, irrevocable (except as stated in this section) patent license
+	to make, have made, use, import, and otherwise transfer the Work.
+
+    Restrictions. The license granted in Section 3 above is expressly made subject
+	to and limited by the following restrictions:
+        You agree not to remove any of the original copyright, patent, trademark,
+	and attribution notices and associated disclaimers that may appear in the
+	Source Code or Executable Files.
+        You agree not to advertise or in any way imply that this Work is a product
+	of Your own.
+        The name of the Author may not be used to endorse or promote products
+	derived from the Work without the prior written consent of the Author.
+        You agree not to sell, lease, or rent any part of the Work. This does
+	not restrict you from including the Work or any part of the Work inside
+	a larger software distribution that itself is being sold. The Work by itself,
+	though, cannot be sold, leased or rented.
+        You may distribute the Executable Files and Source Code only under the terms
+	of this License, and You must include a copy of, or the Uniform Resource
+	Identifier for, this License with every copy of the Executable Files or
+	Source Code You distribute and ensure that anyone receiving such Executable
+	Files and Source Code agrees that the terms of this License apply to such
+	Executable Files and/or Source Code. You may not offer or impose any terms
+	on the Work that alter or restrict the terms of this License or the
+	recipients' exercise of the rights granted hereunder. You may not sublicense
+	the Work. You must keep intact all notices that refer to this License and to
+	the disclaimer of warranties. You may not distribute the Executable Files or
+	Source Code with any technological measures that control access or use of the
+	Work in a manner inconsistent with the terms of this License.
+        You agree not to use the Work for illegal, immoral or improper
+	purposes, or on pages containing illegal, immoral or improper material.
+	The Work is subject to applicable export laws. You agree to comply with all
+	such laws and regulations that may apply to the Work after Your receipt of
+	the Work.
+
+    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+
+    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+	Publisher from and against any claims, suits, losses, damages, liabilities,
+	costs, and expenses (including reasonable legal or attorneys’ fees)
+	resulting from or relating to any use of the Work by You.
+
+    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGES.
+
+    Termination.
+        This License and the rights granted hereunder will terminate
+	automatically upon any breach by You of any term of this License.
+	Individuals or entities who have received Derivative Works from You under
+	this License, however, will not have their licenses terminated provided such
+	individuals or entities remain in full compliance with those licenses.
+	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
+        If You bring a copyright, trademark, patent or any other infringement
+	claim against any contributor over infringements You claim are made by the
+	Work, your License from such contributor to the Work ends automatically.
+        Subject to the above terms and conditions, this License is perpetual
+	(for the duration of the applicable copyright in the Work).
+	Notwithstanding the above, the Author reserves the right to release the Work
+	under different license terms or to stop distributing the Work at any time;
+	provided, however that any such election will not serve to withdraw this
+	License (or any other license that has been, or is required to be,
+	granted under the terms of this License), and this License will continue
+	in full force and effect unless terminated as stated above.
+
+    Publisher. The parties hereby confirm that the Publisher shall not, under
+	any circumstances, be responsible for and shall not have any liability
+	in respect of the subject matter of this License. The Publisher makes no
+	warranty whatsoever in connection with the Work and shall not be liable
+	to You or any party on any legal theory for any damages whatsoever, including
+	without limitation any general, special, incidental or consequential damages
+	arising in connection to this license. The Publisher reserves the right to
+	cease making the Work available to You at any time without notice
+
+    Miscellaneous
+        This License shall be governed by the laws of the location of the head
+	office of the Author or if the Author is an individual, the laws of
+	location of the principal place of residence of the Author.
+        If any provision of this License is invalid or unenforceable under
+	applicable law, it shall not affect the validity or enforceability of the
+	remainder of the terms of this License, and without further action by the
+	parties to this License, such provision shall be reformed to the minimum
+	extent necessary to make such provision valid and enforceable.
+        No term or provision of this License shall be deemed waived and no
+	breach consented to unless such waiver or consent shall be in writing
+	and signed by the party to be charged with such waiver or consent.
+        This License constitutes the entire agreement between the parties
+	with respect to the Work licensed herein. There are no understandings,
+	agreements or representations with respect to the Work not specified herein.
+	The Author shall not be bound by any additional provisions that may appear
+	in any communication from You. This License may not be modified without
+	the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Andreas and Michael inspected the list of nuget packages and extended
the necessary references in LICENSE.txt.

Additionally, this LICENSE.txt clarifies the licensing of the AASX
Package Explorer itself.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.