### PR TITLE
Set up check-release workflow

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,0 +1,55 @@
+name: Check-release-workflow
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [opened, synchronize, reopened, edited]
+
+  push:
+    branches:
+      - master
+
+jobs:
+  Check-release:
+    runs-on: windows-latest
+    if: contains(github.event.pull_request.body, 'The workflow check-release was intentionally skipped.') == false
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.0.0
+        with:
+          vs-version: 15
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.0.2
+
+      - name: Install .NET core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.100'
+
+      - name: Install build dependencies
+        working-directory: src
+        run: powershell .\InstallBuildDependencies.ps1
+
+      - name: Build for release
+        working-directory: src
+        run: powershell .\BuildForRelease.ps1
+
+      - name: Package
+        working-directory: src
+        run: powershell .\PackageRelease.ps1 -version LATEST.alpha
+
+      - name: Upload latest-portable
+        uses: actions/upload-artifact@v2
+        with:
+          name: portable.LATEST.alpha
+          path: artefacts/release/LATEST.alpha/portable.zip
+
+      - name: Upload latest-portable-small
+        uses: actions/upload-artifact@v2
+        with:
+          name: portable-small.LATEST.alpha
+          path: artefacts/release/LATEST.alpha/portable-small.zip

--- a/docdev/docfx_project/getting-started/development-workflow.md
+++ b/docdev/docfx_project/getting-started/development-workflow.md
@@ -32,7 +32,8 @@ Please note that running the Github actions consumes limited resources (we have 
 per month available for CI on our current Github plan). You can manually disable workflows
 by appending the following lines to the body of the pull request:
 * `The workflow build-test-inspect was intentionally skipped.`
-* `The workflow check-style was intentionally skipped.`.
+* `The workflow check-style was intentionally skipped.`
+* `The workflow check-release was intentionally skipped.`
 
 For an example, see [this pull request](
 https://github.com/admin-shell-io/aasx-package-explorer/pull/94

--- a/docdev/docfx_project/getting-started/releasing.md
+++ b/docdev/docfx_project/getting-started/releasing.md
@@ -2,9 +2,14 @@
 
 ## Versioning
 
-We version based on the date of the release (*e.g.*, `19-10-21`).
-The pre-releases are marked with `pre` (*e.g.*, `19-10-21.pre3`) and 
-post-releases with `post` (*e.g.*, `19-10-21.post2`). 
+We version based on the date of the release (*e.g.*, `2019-10-21`).
+The suffixes `alpha` and `beta` indicate the testing maturity of the release: 
+* `Alpha` releases have not been manually tested (only automatic tests were 
+  performed).
+* `Beta` releases underwent only a bit of manual testing, but no thorough manual
+  testing has been performed.
+* A release without suffix implies that a couple of users tested the release and
+  were satisfied with the quality of the software.
 
 While we admit that such a versioning scheme is uninformative with respect to 
 number of new features, bugs fixed or critical changes, we found it too hard to 
@@ -15,16 +20,7 @@ changes and extensions are well-defined. However, a breaking change in a GUI is
 not as easily defined and much more subjective (*e.g.*, a breaking change for 
 one user is a minor improvement to another user).
 
-## Artefacts
-
-Before you can release, you need the following artefacts:
-1) Solution release build
-2) AASX samples and
-3) ecl@ss definitions.
-
-Once these are set, you can package the release.
-
-### Build Solution for Release
+## Build Solution for Release
 
 To build the solution for release, invoke:
 
@@ -40,33 +36,14 @@ If you want to clean a previous build, call:
 
 This will produce the solution build in `artefacts/` directory.
 
-### AASX Samples
+## Package the Release
 
-Tha AASX samples live at http://admin-shell-io.com/samples/. They are 
-intentionally not included in the repository in order to avoid mangaing multiple
-sites.
-
-To download the samples to their expected directory, invoke:
+The release is now ready to be packaged. Call `PackageRelease.ps` with the
+desired version:
 
 ```powershell
-.\src\DownloadSamples.ps1
+.\src\PackageRelease.ps1 -version 2020-08-14.alpha
 ```
 
-### Ecl@ss Definitions
-
-We can not check in ecl@ss definitions due to their restrictive license, but we
-need to include them in the release. Hence you need to manually copy them to 
-`eclass/` directory.
-
-### Package
-
-The release is now ready to be packaged. Call:
-
-```powershell
-.\src\PackageRelease.ps1
-```
-
-Multiple release packages will be produced (small, with or without ecl@ss 
-*etc*.). 
-
-You can now go to Github, create a release and attach the files.
+Multiple release packages will be produced (with web browser integrated, small 
+*etc*.).

--- a/src/PackageRelease.ps1
+++ b/src/PackageRelease.ps1
@@ -111,15 +111,19 @@ function Main
     }
 
     $versionRe = [Regex]::new(
-            '^[0-9]{2}-(0[1-9]|11|12)-(0[1-9]|1[1-9]|2[1-9]|3[0-1])' +
-                    '(\.(pre|post)[0-9]+)?$')
+            '^[0-9]{4}-(0[1-9]|11|12)-(0[1-9]|1[1-9]|2[1-9]|3[0-1])' +
+                    '(\.(alpha|beta))?$')
 
-    if (!$versionRe.IsMatch($version))
+    $latestVersionRe = [Regex]::new('^LATEST(\.(alpha|beta))?$')
+
+    if ((!$latestVersionRe.IsMatch($version)) -and
+            (!$versionRe.IsMatch($version)))
     {
         throw ("Unexpected version; " +
-                "expected year-month-day (*e.g.*, 19-10-23) followed by " +
-                "an optional pre/post tag (*e.g.*, 19-10-23.pre3), " +
-                "but got: $version")
+                "expected either year-month-day (*e.g.*, 2019-10-23) " +
+                "followed by an optional maturity tag " +
+                "(*e.g.*, 2019-10-23.alpha) " +
+                "or LATEST, but got: $version")
     }
 
     $outputDir = Join-Path $( GetArtefactsDir ) "release" `


### PR DESCRIPTION
This patch sets up a workflow to build the solution for release and
package it. Finally, the release is uploaded as artifact.

Additionally, we had to change the versioning so that it is more in line
with our release policy and at-will release cycle:

* LATEST is needed for the automatic release through the check-release
  workflow.

* `Alpha` and `beta` releases indicate the level of manual testing
  preceding the release (instead of `pre` and `post` releases which
  imply fixed release deadlines).

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.