### PR TITLE
Fix version pattern in PackageRelease.ps1

### DIFF
--- a/src/PackageRelease.ps1
+++ b/src/PackageRelease.ps1
@@ -111,8 +111,8 @@ function Main
     }
 
     $versionRe = [Regex]::new(
-            '^[0-9]{4}-(0[1-9]|11|12)-(0[1-9]|1[1-9]|2[1-9]|3[0-1])' +
-                    '(\.(alpha|beta))?$')
+            '^[0-9]{4}-(0[1-9]|10|11|12)-(0[1-9]|1[0-9]|2[0-9]|3[0-1])' +
+            '(\.(alpha|beta))?$')
 
     $latestVersionRe = [Regex]::new('^LATEST(\.(alpha|beta))?$')
 


### PR DESCRIPTION
This patch fixes the omitted 10 (for October) and 10 (for days) in the
regex pattern of the accepted versions in `PackageRelease.ps1`.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.