### PR TITLE
Set up workflow to attach release assets (part 4)

### DIFF
--- a/.github/workflows/build-and-package-release.yml
+++ b/.github/workflows/build-and-package-release.yml
@@ -74,3 +74,4 @@ jobs:
         with:
           files: "artefacts/release/${{ steps.inferVersion.outputs.version }}/*.zip"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          release-tag: "v${{ steps.inferVersion.outputs.version }}"


### PR DESCRIPTION
This is an unfinished commit merged so that we can debug inferring the
version from GITHUB_REF and uploading the releases to Github
automatically.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.