### PR TITLE
Reformat LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxAmlImExport/LICENSE.txt
+++ b/src/AasxAmlImExport/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxCsharpLibrary.Tests/LICENSE.txt
+++ b/src/AasxCsharpLibrary.Tests/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxCsharpLibrary/LICENSE.txt
+++ b/src/AasxCsharpLibrary/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxGenerate/LICENSE.txt
+++ b/src/AasxGenerate/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxIntegrationBase/LICENSE.txt
+++ b/src/AasxIntegrationBase/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxIntegrationBaseWpf/LICENSE.txt
+++ b/src/AasxIntegrationBaseWpf/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxIntegrationEmptySample/LICENSE.txt
+++ b/src/AasxIntegrationEmptySample/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxMqtt/LICENSE.txt
+++ b/src/AasxMqtt/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxMqttClient/LICENSE.txt
+++ b/src/AasxMqttClient/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxOldDataModels/LICENSE.txt
+++ b/src/AasxOldDataModels/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxOpenidClient/LICENSE.txt
+++ b/src/AasxOpenidClient/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxPackageExplorer/LICENSE.txt
+++ b/src/AasxPackageExplorer/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxPredefinedConcepts/LICENSE.txt
+++ b/src/AasxPredefinedConcepts/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxRestConsoleServer/LICENSE.txt
+++ b/src/AasxRestConsoleServer/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxRestServerLibrary/LICENSE.txt
+++ b/src/AasxRestServerLibrary/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxSignature/LICENSE.txt
+++ b/src/AasxSignature/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxUANodesetImExport/LICENSE.txt
+++ b/src/AasxUANodesetImExport/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxUaNetConsoleServer/LICENSE.txt
+++ b/src/AasxUaNetConsoleServer/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxUaNetServer/LICENSE.txt
+++ b/src/AasxUaNetServer/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/AasxWpfControlLibrary/LICENSE.txt
+++ b/src/AasxWpfControlLibrary/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/LICENSE.txt
+++ b/src/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/MsaglWpfControl/LICENSE.txt
+++ b/src/MsaglWpfControl/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/WpfMtpControl/LICENSE.txt
+++ b/src/WpfMtpControl/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml

--- a/src/WpfMtpVisuViewer/LICENSE.txt
+++ b/src/WpfMtpVisuViewer/LICENSE.txt
@@ -661,166 +661,168 @@ CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
 LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
 
-    Definitions.
-        "Articles" means, collectively, all articles written by Author which
-	describes how the Source Code and Executable Files for the Work may
-	be used by a user.
-        "Author" means the individual or entity that offers the Work under
-	the terms of this License.
-        "Derivative Work" means a work based upon the Work or upon the Work
-	and other pre-existing works.
-        "Executable Files" refer to the executables, binary files,
-	configuration and any required data files included in the Work.
-        "Publisher" means the provider of the website, magazine, CD-ROM,
-	DVD or other medium from or by which the Work is obtained by You.
-        "Source Code" refers to the collection of source code and
-	configuration files used to create the Executable Files.
-        "Standard Version" refers to such a Work if it has not been modified,
-	or has been modified in accordance with the consent of the Author,
-	such consent being in the full discretion of the Author.
-        "Work" refers to the collection of files distributed by the Publisher,
-	including the Source Code, Executable Files, binaries, data files,
-	documentation, whitepapers and the Articles.
-        "You" is you, an individual or entity wishing to use the Work and
-	exercise your rights under this License.
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
 
-    Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
-	limit, or restrict any rights arising from fair use, fair dealing,
-	first sale or other limitations on the exclusive rights of the
-	copyright owner under copyright law or other applicable laws.
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
 
-    License Grant. Subject to the terms and conditions of this License, the
-	Author hereby grants You a worldwide, royalty-free, non-exclusive,
-	perpetual (for the duration of the applicable copyright) license
-	to exercise the rights in the Work as stated below:
-        You may use the standard version of the Source Code or Executable
-	Files in Your own applications.
-        You may apply bug fixes, portability fixes and other modifications
-	obtained from the Public Domain or from the Author. A Work modified
-	in such a way shall still be considered the standard version and will
-	be subject to this License.
-        You may otherwise modify Your copy of this Work (excluding the Articles)
-	in any way to create a Derivative Work, provided that You insert a prominent
-	notice in each changed file stating how, when and where You changed that file.
-        You may distribute the standard version of the Executable Files and Source
-	Code or Derivative Work in aggregate with other (possibly commercial)
-	programs as part of a larger (possibly commercial) software distribution.
-        The Articles discussing the Work published in any form by the author may
-	not be distributed or republished without the Author's consent. The author
-	retains copyright to any such Articles. You may use the Executable Files and
-	Source Code pursuant to this License but you may not repost or republish or
-	otherwise distribute or make available the Articles, without the prior written
-	consent of the Author.
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
 
-    Any subroutines or modules supplied by You and linked into the Source Code
-	or Executable Files of this Work shall not be considered part of this Work
-	and will not be subject to the terms of this License.
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
 
-    Patent License. Subject to the terms and conditions of this License, each
-	Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
-	royalty-free, irrevocable (except as stated in this section) patent license
-	to make, have made, use, import, and otherwise transfer the Work.
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
 
-    Restrictions. The license granted in Section 3 above is expressly made subject
-	to and limited by the following restrictions:
-        You agree not to remove any of the original copyright, patent, trademark,
-	and attribution notices and associated disclaimers that may appear in the
-	Source Code or Executable Files.
-        You agree not to advertise or in any way imply that this Work is a product
-	of Your own.
-        The name of the Author may not be used to endorse or promote products
-	derived from the Work without the prior written consent of the Author.
-        You agree not to sell, lease, or rent any part of the Work. This does
-	not restrict you from including the Work or any part of the Work inside
-	a larger software distribution that itself is being sold. The Work by itself,
-	though, cannot be sold, leased or rented.
-        You may distribute the Executable Files and Source Code only under the terms
-	of this License, and You must include a copy of, or the Uniform Resource
-	Identifier for, this License with every copy of the Executable Files or
-	Source Code You distribute and ensure that anyone receiving such Executable
-	Files and Source Code agrees that the terms of this License apply to such
-	Executable Files and/or Source Code. You may not offer or impose any terms
-	on the Work that alter or restrict the terms of this License or the
-	recipients' exercise of the rights granted hereunder. You may not sublicense
-	the Work. You must keep intact all notices that refer to this License and to
-	the disclaimer of warranties. You may not distribute the Executable Files or
-	Source Code with any technological measures that control access or use of the
-	Work in a manner inconsistent with the terms of this License.
-        You agree not to use the Work for illegal, immoral or improper
-	purposes, or on pages containing illegal, immoral or improper material.
-	The Work is subject to applicable export laws. You agree to comply with all
-	such laws and regulations that may apply to the Work after Your receipt of
-	the Work.
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
 
-    Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
-	"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
-	CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
-	INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
-	AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
-	OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
-	OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
-	PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
-	(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
-	YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE WORKS.
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
 
-    Indemnity. You agree to defend, indemnify and hold harmless the Author and the
-	Publisher from and against any claims, suits, losses, damages, liabilities,
-	costs, and expenses (including reasonable legal or attorneys’ fees)
-	resulting from or relating to any use of the Work by You.
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
 
-    Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
-	IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
-	THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
-	DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
-	EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
-	OF SUCH DAMAGES.
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
 
-    Termination.
-        This License and the rights granted hereunder will terminate
-	automatically upon any breach by You of any term of this License.
-	Individuals or entities who have received Derivative Works from You under
-	this License, however, will not have their licenses terminated provided such
-	individuals or entities remain in full compliance with those licenses.
-	Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of this License.
-        If You bring a copyright, trademark, patent or any other infringement
-	claim against any contributor over infringements You claim are made by the
-	Work, your License from such contributor to the Work ends automatically.
-        Subject to the above terms and conditions, this License is perpetual
-	(for the duration of the applicable copyright in the Work).
-	Notwithstanding the above, the Author reserves the right to release the Work
-	under different license terms or to stop distributing the Work at any time;
-	provided, however that any such election will not serve to withdraw this
-	License (or any other license that has been, or is required to be,
-	granted under the terms of this License), and this License will continue
-	in full force and effect unless terminated as stated above.
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
 
-    Publisher. The parties hereby confirm that the Publisher shall not, under
-	any circumstances, be responsible for and shall not have any liability
-	in respect of the subject matter of this License. The Publisher makes no
-	warranty whatsoever in connection with the Work and shall not be liable
-	to You or any party on any legal theory for any damages whatsoever, including
-	without limitation any general, special, incidental or consequential damages
-	arising in connection to this license. The Publisher reserves the right to
-	cease making the Work available to You at any time without notice
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
 
-    Miscellaneous
-        This License shall be governed by the laws of the location of the head
-	office of the Author or if the Author is an individual, the laws of
-	location of the principal place of residence of the Author.
-        If any provision of this License is invalid or unenforceable under
-	applicable law, it shall not affect the validity or enforceability of the
-	remainder of the terms of this License, and without further action by the
-	parties to this License, such provision shall be reformed to the minimum
-	extent necessary to make such provision valid and enforceable.
-        No term or provision of this License shall be deemed waived and no
-	breach consented to unless such waiver or consent shall be in writing
-	and signed by the party to be charged with such waiver or consent.
-        This License constitutes the entire agreement between the parties
-	with respect to the Work licensed herein. There are no understandings,
-	agreements or representations with respect to the Work not specified herein.
-	The Author shall not be bound by any additional provisions that may appear
-	in any communication from You. This License may not be modified without
-	the mutual written agreement of the Author and You.
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
 
 
 With respect to DocumentFormat.OpenXml


### PR DESCRIPTION
This reformats LICENSE.txt to comply to the maximum line length of 80
characters (important when printing!).

The workflow build-test-inspect was intentionally skipped.
The workflow check-release was intentionally skipped.