### PR TITLE
Rename release assets in a separate step

### DIFF
--- a/.github/workflows/build-and-package-release.yml
+++ b/.github/workflows/build-and-package-release.yml
@@ -51,21 +51,23 @@ jobs:
         with:
           dotnet-version: '3.1.100'
 
-      - name: Install build dependencies
+      - name: Install the build dependencies
         working-directory: src
         run: powershell .\InstallBuildDependencies.ps1
 
-      - name: Build for release
+      - name: Build for the release
         working-directory: src
         run: powershell .\BuildForRelease.ps1
 
-      - name: Package
+      - name: Package the release
         working-directory: src
         run: |
           $version = '${{ steps.inferVersion.outputs.version }}'
           Write-Host "Packaging for the release version: $version"
           powershell .\PackageRelease.ps1 -version $version
 
+      - name: Rename the release assets
+        run: |
           # Rename so that the users always know which version they downloaded
 
           $releaseDir = "artefacts\release\$version"
@@ -81,7 +83,7 @@ jobs:
               Move-Item -Path $path -Destination $target
           }
 
-      - name: Upload release assets
+      - name: Upload the release assets
         uses: AButler/upload-release-assets@v2.0
         with:
           files: "artefacts/release/${{ steps.inferVersion.outputs.version }}/*.zip"


### PR DESCRIPTION
This fix separates the renaming from the packaging in the
`build-and-package-release.yml` workflow so that the running directory
is correctly set (and the errors are more localized).

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.