### PR TITLE
Fix renaming release assets, continued

### DIFF
--- a/.github/workflows/build-and-package-release.yml
+++ b/.github/workflows/build-and-package-release.yml
@@ -81,10 +81,13 @@ jobs:
           }
 
           $archives = Get-ChildItem $releaseDir -Filter *.zip
-          foreach($name in $archives)
+          foreach($archive in $archives)
           {
-              $path = Join-Path $releaseDir $name
+              $path = $archive.FullName
+              Write-Host "The path to the archive is: $path"
+
               $nameWoExt = [io.path]::GetFileNameWithoutExtension($path)
+              Write-Host "The name without extension is: $nameWoExt"
 
               $target = Join-Path $releaseDir ($nameWoExt + "." + $version + ".zip")
 


### PR DESCRIPTION
The renamed assets in release workflow were missing the version so the
renaming silently failed.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.