### PR TITLE
Update link to AAS in Detail in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ http://admin-shell-io.com/screencasts/.
 
 For further information about the Asset Administration Shell, see the 
 publication [Details of the Asset Administration Shell](
-https://www.plattform-i40.de/I40/Redaktion/EN/Downloads/Publikation/2018-details-of-the-asset-administration-shell.html
-) by Platform I4.0.
+https://www.plattform-i40.de/PI40/Redaktion/EN/Downloads/Publikation/Details-of-the-Asset-Administration-Shell-Part1.html
+) by Plattform Industrie 4.0.
 
 We provide a couple of sample admin shells (packaged as .aasx) for you to 
 test and play with the software at:


### PR DESCRIPTION
Previously, the link pointed to version 1.0 of AAS in Detail book. This
patch refers the reader to the version 2.0 of the book.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.