### PR TITLE
Check commit messages only on pull requests

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -1,10 +1,6 @@
 name: Check-commit-messages-workflow
 
 on: 
-  push:
-    branches:
-    - '*'
-
   pull_request:
     types: [opened, synchronize, reopened, edited]
 


### PR DESCRIPTION
Since we are always squashing & merging, we inspect only the description
of the pull request and neglect the individual commits (since they are
going to be squashed anyways). Additionally, changing commit messages is
tedious (as such changes require git rebasing) while changing the
description of the pull request is trivial (one click in the browser).

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.