### PR TITLE
Upgrade commit message checker to 2.1.2

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v2.0.0-pre4
+        uses: mristin/opinionated-commit-message@v2.1.2
         with:
           path-to-additional-verbs: src/AdditionalVerbsInImperativeMood.txt


### PR DESCRIPTION
This upgrade is necessary so that we can include URLs in the commit
messages. URLs are often longer than 72 characters and can not be broken
into multiple lines.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.