### PR TITLE
Upgrade coveralls.net to 2.0.0-beta0002

### DIFF
--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install coveralls.net (to send test coverage)
         working-directory: src
-        run: dotnet tool install coveralls.net
+        run: dotnet tool install coveralls.net --version 2.0.0-beta0002
 
       - name: Build
         working-directory: src


### PR DESCRIPTION
This upgrade is necessary so that coveralls.net runs on .NET >= 3.