### PR TITLE
Add generic import interface and IEC CDD importer

### DIFF
--- a/src/AasxDictionaryImport/AasxDictionaryImport.csproj
+++ b/src/AasxDictionaryImport/AasxDictionaryImport.csproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DEC389BC-59BC-48E5-B163-6E44CE782C4A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AasxDictionaryImport</RootNamespace>
+    <AssemblyName>AasxDictionaryImport</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <Nullable>Enable</Nullable>
+    <LangVersion>8.0</LangVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ExcelDataReader, Version=3.6.0.0, Culture=neutral, PublicKeyToken=93517dbe6a4012fa, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExcelDataReader.3.6.0\lib\net45\ExcelDataReader.dll</HintPath>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Cdd\Data.cs" />
+    <Compile Include="Cdd\Model.cs" />
+    <Compile Include="Cdd\Parser.cs" />
+    <Compile Include="ImportDialog.xaml.cs">
+      <DependentUpon>ImportDialog.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Cdd\Importer.cs" />
+    <Compile Include="Model.cs" />
+    <Compile Include="ElementDetailsDialog.xaml.cs">
+      <DependentUpon>ElementDetailsDialog.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Import.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Iec61360Utils.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj">
+      <Project>{9863799b-4e44-4da2-9120-c85c7985bc6d}</Project>
+      <Name>AasxCsharpLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj">
+      <Project>{5a05df78-216b-4a0b-9e30-7b2557c7e867}</Project>
+      <Name>AasxIntegrationBase</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\AasxWpfControlLibrary\AasxWpfControlLibrary.csproj">
+      <Project>{ebae658a-3ece-4c98-89bc-f79809ab4a5e}</Project>
+      <Name>AasxWpfControlLibrary</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="ImportDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="ElementDetailsDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/AasxDictionaryImport/Cdd/Data.cs
+++ b/src/AasxDictionaryImport/Cdd/Data.cs
@@ -1,0 +1,792 @@
+﻿/*
+ * Copyright (c) 2020 SICK AG <info@sick.de>
+ *
+ * This software is licensed under the Apache License 2.0 (Apache-2.0).
+ * The ExcelDataReder dependency is licensed under the MIT license
+ * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
+ */
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace AasxDictionaryImport.Cdd
+{
+    /// <summary>
+    /// Base class for all elements in the CDD hierarchy.
+    /// <para>
+    /// This class defines the common attributes for all elements in the CDD hierarchy (Code, PreferredName, Definition)
+    /// and provides helper methods to access the data stored in the element.  The data is stored as a dictionary that
+    /// maps the attribute codes to the attribute values, for example {"MDC_P001_12" => "0112/2///62683#ACI081"}.
+    /// </para>
+    /// </summary>
+    public abstract class Element
+    {
+        private const string BaseUrl = "https://cdd.iec.ch/cdd/";
+        private const string UrlPathPattern = "iec{0}/iec{0}.nsf/{2}/{1}";
+        private static readonly Regex CodeRegex = new Regex("^0112/2///([0-9]+)(_[0-9]+)?#.*$");
+        private readonly Dictionary<string, string> _data;
+
+        /// <summary>
+        /// The ID of the element.
+        /// </summary>
+        public abstract string Code { get; }
+
+        /// <summary>
+        /// The version of the element.
+        /// </summary>
+        public String Version => GetString("MDC_P002_1");
+
+        /// <summary>
+        /// The revision of the element.
+        /// </summary>
+        public String Revision => GetString("MDC_P002_2");
+
+        /// <summary>
+        /// The preferred name of the element in multiple languages.
+        /// </summary>
+        public MultiString PreferredName => GetMultiString("MDC_P004_1");
+
+        /// <summary>
+        /// The definition of the element in multiple languages.
+        /// </summary>
+        public MultiString Definition => GetMultiString("MDC_P005");
+
+        /// <summary>
+        /// Creates a new Element object based on the given data.
+        /// </summary>
+        /// <param name="data">The element data as a mapping from attribute codes to attribute values</param>
+        protected Element(Dictionary<string, string> data)
+        {
+            _data = data;
+        }
+
+        /// <summary>
+        /// Creates a new Element object, copying the data from the given element.
+        /// </summary>
+        /// <param name="element">The element to copy the data from</param>
+        protected Element(Element element)
+        {
+            _data = new Dictionary<string, string>(element._data);
+        }
+
+        /// <summary>
+        /// Returns the IEC 61360 attributes for this element.
+        /// </summary>
+        /// <returns>The IEC 61360 data for this element</returns>
+        public virtual Iec61360Data GetIec61360Data()
+        {
+            return new Iec61360Data(FormatIrdi(Code, Version))
+            {
+                PreferredName = PreferredName,
+                Definition = Definition
+            };
+        }
+
+        /// <summary>
+        /// Returns the IEC CDD domain for this element, or null if the domain could not be determined.  The domain is
+        /// extracted from the element code, assuming that it has the format "0112/2///{domain}#{id}".
+        /// </summary>
+        /// <returns>The IEC CDD domain for this element, or null if it can't be extracted</returns>
+        private string? GetDomain()
+        {
+            var match = CodeRegex.Match(Code);
+            if (!match.Success)
+                return null;
+            return match.Groups[1].Value;
+        }
+
+        /// <summary>
+        /// Returns the URL to the IEC CDD web page for this element, or null if the URL could not be determined.
+        /// </summary>
+        /// <returns>The URL for the IEC CDD web page for this element, or null if it could not be determined</returns>
+        public Uri? GetDetailsUrl()
+        {
+            var baseUri = new Uri(BaseUrl);
+            var domain = GetDomain();
+            var code = EncodeCode();
+            var endpoint = GetEndpoint();
+            var path = String.Format(UrlPathPattern, domain, code, endpoint);
+            return new Uri(baseUri, path);
+        }
+
+        /// <summary>
+        /// Returns the URL-encoded code for this element.
+        /// </summary>
+        /// <returns>The URL-encoded code for this element</returns>
+        private string EncodeCode()
+        {
+            return Code.Replace('/', '-').Replace("#", "%23");
+        }
+
+        /// <summary>
+        /// Returns the endpoint to use when constructing the IEC CDD URL for this element.  See the URL pattern in <see
+        /// cref="UrlPathPattern"/> for more information.
+        /// </summary>
+        /// <returns>The endpoint to use in the details URL for this element</returns>
+        protected abstract string GetEndpoint();
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return Code + ": " + PreferredName;
+        }
+
+        protected string GetString(string key)
+        {
+            return _data[key];
+        }
+
+        protected MultiString GetMultiString(string key)
+        {
+            var data = new Dictionary<string, string>();
+            var prefix = key + ".";
+            foreach (var s in _data.Keys)
+            {
+                if (s.StartsWith(prefix))
+                    data.Add(s.Substring(prefix.Length), _data[s]);
+            }
+            return new MultiString(data);
+        }
+
+        protected Reference<T> GetReference<T>(string key)
+            where T : Element
+        {
+            return new Reference<T>(GetString(key));
+        }
+
+        private List<string> GetList(string key)
+        {
+            var list = new List<string>();
+            var value = GetString(key).TrimStart('(', '{').TrimEnd(')', '}');
+            foreach (var part in value.Split(','))
+            {
+                var trimmedPart = part.Trim();
+                if (trimmedPart.Length > 0)
+                    list.Add(trimmedPart);
+            }
+            return list;
+        }
+
+        protected ReferenceList<T> GetReferenceList<T>(string key)
+            where T : Element
+        {
+            var list = new ReferenceList<T>();
+            foreach (var id in GetList(key))
+            {
+                list.Add(new Reference<T>(id));
+            }
+            return list;
+        }
+
+        protected static string FormatIrdi(string code, string version) => $"{code}#{version.PadLeft(3, '0')}";
+    }
+
+    /// <summary>
+    /// Reference to an element in the CDD hierarchy.
+    /// </summary>
+    /// <typeparam name="T">The type of the referenced element</typeparam>
+    public class Reference<T> where T : Element
+    {
+        public string Code { get; }
+
+        public bool IsSet => Code.Length > 0;
+
+        public Reference(string code)
+        {
+            Code = code;
+        }
+
+        public T? Get(Context context)
+        {
+            return context.GetElement<T>(Code);
+        }
+
+        public override string ToString()
+        {
+            return Code;
+        }
+    }
+
+    /// <summary>
+    /// A list of references to elements in the CDD hierarchy.
+    /// </summary>
+    /// <typeparam name="T">The type of the referenced elements</typeparam>
+    public class ReferenceList<T> : List<Reference<T>> where T : Element
+    {
+        public List<T> Get(Context context)
+        {
+            var list = new List<T>();
+            foreach (var r in this)
+            {
+                var value = r.Get(context);
+                if (value != null)
+                    list.Add(value);
+            }
+            return list;
+        }
+    }
+
+    /// <summary>
+    /// CDD class, a collection of CDD properties.
+    /// </summary>
+    // Instances of this type are created using reflection in Parser.ParseElement.
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class Class : Element
+    {
+        public override string Code => GetString("MDC_P001_5");
+
+        public string DefinitionSource => GetString("MDC_P006_1");
+
+        public Reference<Class> Superclass => GetReference<Class>("MDC_P010");
+
+        public ReferenceList<Property> Properties
+            => GetReferenceList<Property>("MDC_P014");
+
+        public ReferenceList<Property> ImportedProperties
+            => GetReferenceList<Property>("MDC_P090");
+
+        public Class(Dictionary<string, string> data) : base(data)
+        {
+        }
+
+        public ReferenceList<Property> GetAllProperties(Context context)
+        {
+            var properties = new ReferenceList<Property>();
+            properties.AddRange(Properties);
+            properties.AddRange(ImportedProperties);
+            var superclass = Superclass.Get(context);
+            if (superclass != null)
+            {
+                properties.AddRange(superclass.GetAllProperties(context));
+            }
+            return properties;
+        }
+
+        public override Iec61360Data GetIec61360Data()
+        {
+            var data = base.GetIec61360Data();
+            data.DefinitionSource = DefinitionSource;
+            return data;
+        }
+
+        protected override string GetEndpoint()
+        {
+            return "classes";
+        }
+    }
+
+    /// <summary>
+    /// CDD property, either an actual property or a reference to a class that holds more properties.
+    /// </summary>
+    // Instances of this type are created using reflection in Parser.ParseElement.
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class Property : Element
+    {
+        private readonly DataType? _overrideDataType;
+
+        public override string Code => GetString("MDC_P001_6");
+
+        public MultiString ShortName => GetMultiString("MDC_P004_3");
+
+        public string DefinitionSource => GetString("MDC_P006_1");
+
+        public string Symbol => GetString("MDC_P025_1");
+
+        public string PrimaryUnit => GetString("MDC_P023");
+
+        public string UnitCode => GetString("MDC_P041");
+
+        public string RawDataType => GetString("MDC_P022");
+
+        public DataType DataType
+        {
+            get
+            {
+                if (_overrideDataType != null)
+                    return _overrideDataType;
+                return DataType.ParseType(RawDataType);
+            }
+        }
+
+        public string Format => GetString("MDC_P024");
+
+        public Property(Dictionary<string, string> data) : base(data)
+        {
+        }
+
+        private Property(Property property, DataType dataType) : base(property)
+        {
+            _overrideDataType = dataType;
+        }
+
+        public Property ReplaceDataType(DataType dataType)
+        {
+            return new Property(this, dataType);
+        }
+
+        public override Iec61360Data GetIec61360Data()
+        {
+            var data = base.GetIec61360Data();
+            data.ShortName = ShortName;
+            data.DefinitionSource = DefinitionSource;
+            data.Symbol = Symbol;
+            data.Unit = PrimaryUnit;
+            data.UnitIrdi = UnitCode;
+            data.DataType = RawDataType;
+            data.DataFormat = Format;
+            return data;
+        }
+
+        protected override string GetEndpoint()
+        {
+            return "PropertiesAllVersions";
+        }
+    }
+
+    public abstract class DataType
+    {
+        private const string TypeSuffix = "_TYPE";
+        private static readonly Regex TypeRegex = new Regex(@"^([^\(\)]+)(?:\((.+)\))?$");
+        private static readonly Regex CompositeTypeRegex = new Regex(@"^(.*) OF (.*)$");
+
+        public virtual Reference<Class>? GetClassReference()
+        {
+            return null;
+        }
+
+        public static DataType ParseType(string s)
+        {
+            var match = CompositeTypeRegex.Match(s);
+            if (match.Success)
+            {
+                var subtype = ParseType(match.Groups[2].Value);
+                return ParseCompositeType(match.Groups[1].Value, subtype);
+            }
+
+            return ParseBasicType(s);
+        }
+
+        private static Tuple<string, string[]>? ParseTypeNameArgs(string s)
+        {
+            var match = TypeRegex.Match(s);
+            if (!match.Success)
+                return null;
+
+            var typeName = match.Groups[1].Value.ToUpperInvariant();
+            var typeArgs = new string[] { };
+            if (match.Groups[2].Value.Length > 0)
+                typeArgs = match.Groups[2].Value.Split(',').Select(p => p.Trim()).ToArray();
+
+            if (typeName.EndsWith(TypeSuffix))
+                typeName = typeName.Substring(0, typeName.Length - TypeSuffix.Length);
+
+            return Tuple.Create(typeName, typeArgs);
+        }
+
+        private static DataType ParseBasicType(string s)
+        {
+            var typeTuple = ParseTypeNameArgs(s);
+            DataType? dataType = null;
+            if (typeTuple != null)
+            {
+                var typeName = typeTuple.Item1;
+                var typeArgs = typeTuple.Item2;
+
+                dataType ??= SimpleType.ParseType(typeName, typeArgs);
+                dataType ??= EnumType.ParseType(typeName, typeArgs);
+                dataType ??= ClassInstanceType.ParseType(typeName, typeArgs);
+                dataType ??= ClassReferenceType.ParseType(typeName, typeArgs);
+                dataType ??= LargeObjectType.ParseType(typeName, typeArgs);
+                dataType ??= PlacementType.ParseType(typeName, typeArgs);
+            }
+            return dataType ?? new UnknownType(s);
+        }
+
+        private static DataType ParseCompositeType(string s, DataType subtype)
+        {
+            var typeTuple = ParseTypeNameArgs(s);
+            DataType? dataType = null;
+            if (typeTuple != null)
+            {
+                var typeName = typeTuple.Item1;
+                var typeArgs = typeTuple.Item2;
+
+                dataType ??= AggregateType.ParseType(typeName, typeArgs, subtype);
+                dataType ??= LevelType.ParseType(typeName, typeArgs, subtype);
+            }
+            return dataType ?? new UnknownType(s);
+        }
+
+        protected static bool ParseTypeEnum<TEnum>(string s, out TEnum result) where TEnum : struct
+        {
+            return Enum.TryParse(s.Replace("_", String.Empty), true, out result);
+        }
+    }
+
+    public class SimpleType : DataType, IEquatable<SimpleType>
+    {
+        public Type TypeValue { get; }
+
+
+        public SimpleType(Type typeValue)
+        {
+            TypeValue = typeValue;
+        }
+
+        public bool Equals(SimpleType? type)
+        {
+            return type != null && type.TypeValue == TypeValue;
+        }
+
+        public override bool Equals(object? o)
+        {
+            return Equals(o as SimpleType);
+        }
+
+        public override int GetHashCode()
+        {
+            return TypeValue.GetHashCode();
+        }
+
+        public static SimpleType? ParseType(string typeName, string[] typeArgs)
+        {
+            if (typeArgs.Length != 0)
+                return null;
+
+            if (ParseTypeEnum(typeName, out Type innerType))
+                return new SimpleType(innerType);
+
+            return null;
+        }
+
+        public enum Type
+        {
+            Boolean,
+            Binary,
+            String,
+            TranslatableString,
+            NonTranslatableString,
+            DateTime,
+            Date,
+            Time,
+            Irdi,
+            Icid,
+            Iso29002Irdi,
+            Uri,
+            Html5,
+            Number,
+            Int,
+            IntMeasure,
+            IntCurrency,
+            Rational,
+            RationalMeasure,
+            Real,
+            RealMeasure,
+            RealCurrency,
+        }
+    }
+
+    public class EnumType : DataType
+    {
+        private const string EnumPrefix = "ENUM_";
+
+        public Type TypeValue { get; }
+
+        public string ReferenceCode { get; }
+
+        public EnumType(Type typeValue, string referenceCode)
+        {
+            TypeValue = typeValue;
+            ReferenceCode = referenceCode;
+        }
+
+        public static EnumType? ParseType(string typeName, string[] typeArgs)
+        {
+            if (!typeName.StartsWith(EnumPrefix))
+                return null;
+            typeName = typeName.Substring(EnumPrefix.Length);
+            if (typeArgs.Length != 1)
+                return null;
+            if (ParseTypeEnum(typeName, out Type innerType))
+                return new EnumType(innerType, typeArgs[0]);
+            return null;
+        }
+
+        public enum Type
+        {
+            Code,
+            Int,
+            Real,
+            String,
+            Rational,
+            Reference,
+            Instance,
+            Boolean,
+        }
+    }
+
+    public class ClassInstanceType : DataType
+    {
+        public Reference<Class> Class { get; }
+
+        public ClassInstanceType(string irdi)
+        {
+            Class = new Reference<Class>(irdi);
+        }
+
+        public override Reference<Class>? GetClassReference() => Class;
+
+        public static ClassInstanceType? ParseType(string typeName, string[] typeArgs)
+        {
+            if (typeName == "CLASS_INSTANCE" && typeArgs.Length == 1)
+            {
+                return new ClassInstanceType(typeArgs[0]);
+            }
+            return null;
+        }
+    }
+
+    public class ClassReferenceType : DataType
+    {
+        public Reference<Class> Class { get; }
+
+        public ClassReferenceType(string irdi)
+        {
+            Class = new Reference<Class>(irdi);
+        }
+
+        public override Reference<Class>? GetClassReference() => Class;
+
+        public static ClassReferenceType? ParseType(string typeName, string[] typeArgs)
+        {
+            if (typeName == "CLASS_REFERENCE" && typeArgs.Length == 1)
+            {
+                return new ClassReferenceType(typeArgs[0]);
+            }
+            return null;
+        }
+    }
+
+    public class AggregateType : DataType
+    {
+        /// <summary>
+        /// The lower bound of this aggregate type.  The meaning of this value
+        /// depends on the TypeValue:
+        /// - for Bag, List, UniqueList, Set and ConstrainedSet:  The lower
+        ///   bound is the minimum number of elements in the aggregate type.
+        /// - for all Array types:  The lower bound is the index of the first
+        ///   element in this aggregate type.  This means that there are
+        ///   exactly UpperBound - LowerBound + 1 elements.
+        /// </summary>
+        public int LowerBound { get; }
+
+        /// <summary>
+        /// The upper bound of this aggregate type.  The meaning of this value
+        /// depends on the TypeValue:
+        /// - for Bag, List, UniqueList, Set and ConstrainedSet:  The upper
+        ///   bound is the maximum number of elements in the aggregate type.
+        ///   If it is set to null, there is no upper bound.
+        /// - for all Array types: The upper bound is the index of the last
+        ///   element in this aggregate type.  This means that there are
+        ///   exactly UpperBound - LowerBound + 1 elements.  It may not be null.
+        /// </summary>
+        public int? UpperBound { get; }
+
+        /// <summary>
+        /// The minimum number of elements in this aggregate type, or zero if
+        /// there is no lower bound for the number of elements.
+        /// </summary>
+        public int MinimumElementCount
+        {
+            get
+            {
+                switch (TypeValue)
+                {
+                    case Type.Bag:
+                    case Type.List:
+                    case Type.UniqueList:
+                    case Type.Set:
+                        return LowerBound;
+                    case Type.ConstrainedSet:
+                        return 0;
+                    case Type.Array:
+                    case Type.OptionalArray:
+                    case Type.UniqueArray:
+                    case Type.UniqueOptionalArray:
+                        // UpperBound may not be null for array types
+                        if (UpperBound == null)
+                            return 0;
+                        return UpperBound.Value - LowerBound + 1;
+                    default:
+                        return 0;
+                }
+            }
+        }
+
+        public Type TypeValue { get; }
+
+        /// <summary>
+        /// The type of the elements in this aggregate type.
+        /// </summary>
+        public DataType Subtype { get; }
+
+        public AggregateType(Type typeValue, DataType subtype, int lowerBound, int? upperBound)
+        {
+            TypeValue = typeValue;
+            Subtype = subtype;
+            LowerBound = lowerBound;
+            UpperBound = upperBound;
+        }
+
+        public static AggregateType? ParseType(string typeName, string[] typeArgs, DataType subtype)
+        {
+            // We need at least the lower and upper bound as arguments.
+            if (typeArgs.Length < 2)
+                return null;
+
+            if (!Int32.TryParse(typeArgs[0], out int lowerBound))
+                return null;
+
+            int? upperBound = null;
+            if (typeArgs[1] != "?")
+            {
+                if (!Int32.TryParse(typeArgs[1], out int upperBoundValue))
+                    return null;
+                upperBound = upperBoundValue;
+            }
+
+            if (ParseTypeEnum(typeName, out Type typeValue))
+                return new AggregateType(typeValue, subtype, lowerBound, upperBound);
+
+            return null;
+        }
+
+        public enum Type
+        {
+            Bag,
+            List,
+            UniqueList,
+            Set,
+            ConstrainedSet,
+            Array,
+            OptionalArray,
+            UniqueArray,
+            UniqueOptionalArray,
+        }
+    }
+
+    public class LevelType : DataType
+    {
+        /// <summary>
+        /// The types of this level property, for example {Minimum, Maximum}
+        /// for LEVEL(MIN,MAX) OF INT_TYPE.  May not be empty.
+        /// </summary>
+        public ISet<Type> Types { get; }
+
+        /// <summary>
+        /// The type of the underlying property, for example
+        /// SimpleType(Type.Integer) for LEVEL(MIN,MAX) OF INT_TYPE.
+        /// </summary>
+        public DataType Subtype { get; }
+
+        public LevelType(ISet<Type> types, DataType subtype)
+        {
+            Types = types;
+            Subtype = subtype;
+        }
+
+        public static LevelType? ParseType(string typeName, string[] typeArgs, DataType subtype)
+        {
+            if (typeName != "LEVEL")
+                return null;
+            var types = new HashSet<Type>();
+            foreach (var arg in typeArgs)
+            {
+                var typeValue = ParseTypeValue(arg);
+                if (typeValue == null)
+                    return null;
+                types.Add((Type)typeValue);
+            }
+            if (types.Count > 0)
+                return new LevelType(types, subtype);
+            return null;
+        }
+
+        private static Type? ParseTypeValue(string s)
+        {
+            switch (s.ToLowerInvariant())
+            {
+                case "min":
+                    return Type.Minimum;
+                case "max":
+                    return Type.Maximum;
+                case "typ":
+                    return Type.Typical;
+                case "nom":
+                    return Type.Nominal;
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// The type of a level value.
+        /// </summary>
+        public enum Type
+        {
+            Minimum,
+            Maximum,
+            Nominal,
+            Typical,
+        }
+    }
+
+    public class LargeObjectType : DataType
+    {
+        public static LargeObjectType? ParseType(string typeName, string[] typeArgs)
+        {
+            if (typeName == "LOB")
+                return new LargeObjectType();
+            return null;
+        }
+    }
+
+    public class PlacementType : DataType
+    {
+        public Type TypeValue { get; }
+
+        public PlacementType(Type typeValue)
+        {
+            TypeValue = typeValue;
+        }
+
+        public static PlacementType? ParseType(string typeName, string[] typeArgs)
+        {
+            if (ParseTypeEnum(typeName, out Type type))
+                return new PlacementType(type);
+            return null;
+        }
+
+        public enum Type
+        {
+            Axis1Placement2D,
+            Axis1Placement3D,
+            Axis2Placement2D,
+            Axis2Placement3D,
+        }
+    }
+
+    public class UnknownType : DataType
+    {
+        public UnknownType(string typeValue)
+        {
+            TypeValue = typeValue;
+        }
+
+        public string TypeValue { get; }
+    }
+}

--- a/src/AasxDictionaryImport/Cdd/Importer.cs
+++ b/src/AasxDictionaryImport/Cdd/Importer.cs
@@ -1,0 +1,254 @@
+﻿/*
+ * Copyright (c) 2020 SICK AG <info@sick.de>
+ *
+ * This software is licensed under the Apache License 2.0 (Apache-2.0).
+ * The ExcelDataReder dependency is licensed under the MIT license
+ * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
+ */
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AdminShellNS;
+
+namespace AasxDictionaryImport.Cdd
+{
+    /// <summary>
+    /// Converts a IEC CDD class into a AAS submodel and imports it into an administration shell.
+    /// <para>
+    /// The importer performs the following mappings (IEC CDD to AAS):
+    /// <code>
+    /// Class    --> Submodel (top-level)
+    ///              SubmodelElementCollection (property with CLASS_REFERENCE/CLASS_INSTANCE)
+    /// Property --> SubmodelElement (default)
+    ///              SubmodelElementCollection (aggregate or level type)
+    /// </code>
+    /// It also generates concept descriptions using the IEC CDD metadata.
+    /// </para>
+    /// </summary>
+    internal class Importer
+    {
+        private readonly AdminShellV20.AdministrationShellEnv _env;
+        private readonly Context _context;
+
+        /// <summary>
+        /// Creates a new IEC CDD Importer.
+        /// </summary>
+        /// <param name="env">The environment to import the data into</param>
+        /// <param name="context">The data context of the IEC CDD data</param>
+        public Importer(AdminShellV20.AdministrationShellEnv env, Context context)
+        {
+            _env = env;
+            _context = context;
+        }
+
+        /// <summary>
+        /// Import the given IEC CDD class as a submodel into the given admin shell.
+        /// </summary>
+        /// <param name="cls">The IEC CDD class to import</param>
+        /// <param name="adminShell">The admin shell to import the submodel into</param>
+        /// <returns>true if the class was imported successfully</returns>
+        public bool ImportSubmodel(ClassWrapper cls, AdminShellV20.AdministrationShell adminShell)
+        {
+            if (!cls.IsSelected)
+                return false;
+
+            var submodel = Iec61360Utils.CreateSubmodel(_env, adminShell, cls.Element.GetIec61360Data());
+            AddProperties(submodel, cls.Children);
+            return true;
+        }
+
+        private void AddProperties<T>(T elements, IEnumerable<Model.IElement> properties)
+            where T : AdminShellV20.IManageSubmodelElements
+        {
+            foreach (var property in properties)
+            {
+                if (!property.IsSelected)
+                    continue;
+
+                var element = CreateSubmodelElement(property);
+                if (element != null)
+                    elements.Add(element);
+            }
+        }
+
+        private AdminShellV20.SubmodelElement? CreateSubmodelElement(Model.IElement e)
+        {
+            if (e is ClassWrapper cls)
+                return CreatePropertyCollection(cls.Element, cls.Children);
+            else if (e is PropertyWrapper property)
+                return CreatePropertySubmodelElement(property);
+            return null;
+        }
+
+        private AdminShellV20.SubmodelElementCollection CreatePropertyCollection(Class cls,
+            IEnumerable<Model.IElement> properties)
+        {
+            var collection = Iec61360Utils.CreateCollection(_env, cls.GetIec61360Data());
+            AddProperties(collection, properties);
+            return collection;
+        }
+
+        private AdminShellV20.SubmodelElement? CreatePropertySubmodelElement(PropertyWrapper wrapper)
+        {
+            var reference = wrapper.Element.DataType.GetClassReference();
+            if (reference != null)
+            {
+                var cls = reference.Get(_context);
+                if (cls != null)
+                    return CreatePropertyCollection(cls, wrapper.Children);
+            }
+            else if (wrapper.Element.DataType is AggregateType aggregateType)
+                return CreateAggregateCollection(wrapper, aggregateType);
+            else if (wrapper.Element.DataType is LevelType levelType)
+                return CreateLevelCollection(wrapper.Element, levelType);
+            return CreateProperty(wrapper.Element);
+        }
+
+        private AdminShellV20.SubmodelElementCollection CreateAggregateCollection(
+            PropertyWrapper wrapper, AggregateType aggregateType)
+        {
+            var collection = Iec61360Utils.CreateCollection(_env, wrapper.Element.GetIec61360Data());
+
+            if (wrapper.Children.Count == 1)
+            {
+                var child = wrapper.Children.First();
+                if (child.IsSelected)
+                {
+                    for (int i = 0; i < Math.Max(1, aggregateType.MinimumElementCount); i++)
+                    {
+                        var element = CreateSubmodelElement(child);
+                        if (element != null)
+                        {
+                            element.idShort += i;
+                            collection.Add(element);
+                        }
+                    }
+                }
+            }
+
+            return collection;
+        }
+
+        private AdminShellV20.SubmodelElementCollection CreateLevelCollection(Property property, LevelType levelType)
+        {
+            var data = property.GetIec61360Data();
+            var collection = Iec61360Utils.CreateCollection(_env, data);
+
+            foreach (var levelValue in levelType.Types)
+            {
+                var p = CreateLevelProperty(data, levelType, levelValue);
+                collection.Add(p);
+            }
+
+            return collection;
+        }
+
+        private AdminShellV20.Property CreateProperty(Property property)
+        {
+            return Iec61360Utils.CreateProperty(_env, property.GetIec61360Data(),
+                GetValueType(property.DataType));
+        }
+
+        private AdminShellV20.Property CreateLevelProperty(Iec61360Data data, LevelType levelType,
+            LevelType.Type levelValue)
+        {
+            // idShort for the level property: <Level><Property>, e. g. MinimumOperatingTemperature,
+            // MaximumOperatingTemperature
+            var idShort = levelValue.ToString() + data.IdShort;
+            return new AdminShellV20.Property()
+            {
+                idShort = idShort,
+                kind = AdminShellV20.ModelingKind.CreateAsInstance(),
+                valueType = GetValueType(levelType.Subtype),
+            };
+        }
+
+        private static string GetValueType(DataType type)
+        {
+            if (type is SimpleType simpleType)
+            {
+                return SimpleTypeToValueType(simpleType);
+            }
+            else if (type is EnumType enumType)
+            {
+                return EnumTypeToValueType(enumType);
+            }
+            else if (type is AggregateType || type is ClassInstanceType || type is ClassReferenceType
+                || type is LevelType)
+            {
+                // With these data types, we should never end up in this method as we should create a collection
+                // instead.
+            }
+            else if (type is UnknownType)
+            {
+                // UnknownType
+            }
+            else
+            {
+                // LargeObjectType, PlacementType
+            }
+            return String.Empty;
+        }
+
+        private static string SimpleTypeToValueType(SimpleType simpleType)
+        {
+            switch (simpleType.TypeValue)
+            {
+                case SimpleType.Type.Boolean:
+                    return "boolean";
+                case SimpleType.Type.Date:
+                    return "date";
+                case SimpleType.Type.DateTime:
+                    return "dateTime";
+                case SimpleType.Type.Int:
+                case SimpleType.Type.IntCurrency:
+                case SimpleType.Type.IntMeasure:
+                    return "int";
+                case SimpleType.Type.Real:
+                case SimpleType.Type.RealCurrency:
+                case SimpleType.Type.RealMeasure:
+                    return "double";
+                case SimpleType.Type.String:
+                    return "string";
+                case SimpleType.Type.Time:
+                    return "time";
+                case SimpleType.Type.Binary:
+                case SimpleType.Type.Html5:
+                case SimpleType.Type.Icid:
+                case SimpleType.Type.Irdi:
+                case SimpleType.Type.Iso29002Irdi:
+                case SimpleType.Type.NonTranslatableString:
+                case SimpleType.Type.Number:
+                case SimpleType.Type.RationalMeasure:
+                case SimpleType.Type.Rational:
+                case SimpleType.Type.TranslatableString:
+                case SimpleType.Type.Uri:
+                    return "string";
+            }
+            return String.Empty;
+        }
+
+        private static string EnumTypeToValueType(EnumType enumType)
+        {
+            switch (enumType.TypeValue)
+            {
+                case EnumType.Type.Boolean:
+                    return "boolean";
+                case EnumType.Type.Code:
+                case EnumType.Type.String:
+                    return "string";
+                case EnumType.Type.Int:
+                    return "int";
+                case EnumType.Type.Instance:
+                case EnumType.Type.Rational:
+                case EnumType.Type.Real:
+                case EnumType.Type.Reference:
+                    return "string";
+            }
+            return String.Empty;
+        }
+    }
+}

--- a/src/AasxDictionaryImport/Cdd/Model.cs
+++ b/src/AasxDictionaryImport/Cdd/Model.cs
@@ -1,0 +1,317 @@
+﻿/*
+ * Copyright (c) 2020 SICK AG <info@sick.de>
+ *
+ * This software is licensed under the Apache License 2.0 (Apache-2.0).
+ * The ExcelDataReder dependency is licensed under the MIT license
+ * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
+ */
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AdminShellNS;
+
+namespace AasxDictionaryImport.Cdd
+{
+    /// <summary>
+    /// A data provider for the IEC CDD Database.  The database stores classes and properties that can be mapped to AAS
+    /// submodels, collections and properties.  The data is typically stored as a set of XLS files.
+    /// </summary>
+    public class DataProvider : Model.DataProviderBase
+    {
+        /// <inheritdoc/>
+        public override string Name => "IEC CDD";
+
+        /// <inheritdoc/>
+        public override bool IsValidPath(string path) => Parser.IsValidDirectory(path);
+
+        /// <inheritdoc/>
+        protected override IEnumerable<string> GetDefaultPaths()
+        {
+            var searchDirectory = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "iec-cdd");
+            if (!System.IO.Directory.Exists(searchDirectory))
+                return new List<string>();
+            return System.IO.Directory.GetDirectories(searchDirectory);
+        }
+
+        /// <inheritdoc/>
+        protected override Model.IDataSource OpenPath(string path, Model.DataSourceType type)
+            => new DataSource(this, path, type);
+    }
+
+    /// <summary>
+    /// An IEC CDD data source.  The data is read from a directory that contains a set of XLS files exported from the
+    /// IEC CDD.  For more information on the format of these files, see the Parser class.
+    /// </summary>
+    public class DataSource : Model.FileSystemDataSource
+    {
+        private Context? _context;
+
+        /// <summary>
+        /// Creates a new IEC CDD DataSource object.
+        /// </summary>
+        /// <param name="dataProvider">The IEC CDD data provider</param>
+        /// <param name="directory">The directory to read the data from</param>
+        /// <param name="type">The type of the data source</param>
+        /// <exception cref="Model.ImportException">If the given directory does not exist</exception>
+        public DataSource(Model.IDataProvider dataProvider, string directory, Model.DataSourceType type)
+            : base(dataProvider, directory, type)
+        {
+            if (!System.IO.Directory.Exists(directory))
+                throw new Model.ImportException($"Directory '{directory}' does not exist");
+        }
+
+        /// <inheritdoc/>
+        public override Model.IDataContext Load()
+        {
+            _context ??= new Parser().Parse(this);
+            return _context;
+        }
+    }
+
+    /// <summary>
+    /// An IEC CDD data context.  This class stores a dictionary with all elements (using the code as the key), as well
+    /// as a list of all top-level classes.
+    /// </summary>
+    public class Context : Model.IDataContext
+    {
+        private readonly IDictionary<string, Element> _elements = new Dictionary<string, Element>();
+
+        /// <summary>
+        /// The data source this data has been read from.
+        /// </summary>
+        public DataSource DataSource { get; }
+
+        /// <summary>
+        /// The top-level classes in this data context.
+        /// </summary>
+        public IEnumerable<Class> Classes { get; }
+
+        /// <inheritdoc/>
+        public ICollection<Model.UnknownReference> UnknownReferences { get; } = new List<Model.UnknownReference>();
+
+        /// <summary>
+        /// Creates a new IEC CDD Context.
+        /// </summary>
+        /// <param name="dataSource">The data source for this context</param>
+        /// <param name="classes">The classes stored in the data source</param>
+        /// <param name="properties">The properties stored in the data source</param>
+        public Context(DataSource dataSource, List<Class> classes, List<Property> properties)
+        {
+            DataSource = dataSource;
+            Classes = classes;
+
+            AddElements(classes);
+            AddElements(properties);
+        }
+
+        /// <summary>
+        /// Returns the element with the given code or null if the element could not be found.
+        /// </summary>
+        /// <typeparam name="T">The type of the element to retrieve</typeparam>
+        /// <param name="key">The code of thje element to retrieve</param>
+        /// <returns>The requested element or null if the element could not be found</returns>
+        public T? GetElement<T>(string key) where T : Element
+        {
+            if (key.Length == 0)
+                return null;
+
+            if (!_elements.TryGetValue(key, out Element element))
+            {
+                UnknownReferences.Add(Model.UnknownReference.Create<T>(key));
+                return null;
+            }
+
+            return element as T;
+        }
+
+        private void AddElements<T>(IEnumerable<T> elements) where T : Element
+        {
+            foreach (var element in elements)
+            {
+                if (!_elements.ContainsKey(element.Code))
+                    _elements.Add(element.Code, element);
+            }
+        }
+
+        /// <inheritdoc/>
+        public ICollection<Model.IElement> LoadSubmodels()
+        {
+            return Classes.Select(cls => new ClassWrapper(this, cls)).ToList<Model.IElement>();
+        }
+    }
+
+    /// <summary>
+    /// An element in the IEC CDD data structure.  This is a high-level view of the actual IEC CDD elements stored in
+    /// the types defined in the Data.cs file.  The reason for this separation is that some properties may be reference
+    /// to classes or aggregate types.  This additional level of indirection should not be shown in the user interface.
+    /// The wrapper classes make it easier to handle these special cases.
+    /// </summary>
+    /// <typeparam name="T">The type of the wrapped element</typeparam>
+    public abstract class ElementWrapper<T> : Model.LazyElementBase where T : Element
+    {
+        /// <summary>
+        /// The current data context.
+        /// </summary>
+        public Context Context { get; }
+
+        /// <summary>
+        /// The wrapped element.
+        /// </summary>
+        public T Element { get; }
+
+        /// <inheritdoc/>
+        public override string Id => Element.Code;
+
+        /// <inheritdoc/>
+        public override string Name => Element.PreferredName.GetDefault();
+
+        /// <summary>
+        /// Creates a new ElementWrapper for an IEC CDD element.
+        /// </summary>
+        /// <param name="context">The current data context</param>
+        /// <param name="element">The wrapped IEC CDD element</param>
+        /// <param name="parent">The parent element, or null if this is a top-level element</param>
+        protected ElementWrapper(Context context, T element, Model.IElement? parent = null)
+            : base(context.DataSource, parent)
+        {
+            Context = context;
+            Element = element;
+        }
+
+        /// <inheritdoc/>
+        public override Dictionary<string, string> GetDetails()
+        {
+            return new Dictionary<string, string>
+            {
+                { "Code", Element.Code },
+                { "Version", Element.Version },
+                { "Revision", Element.Revision },
+                { "Preferred Name", Element.PreferredName.GetDefault() },
+                { "Definition", Element.Definition.GetDefault() }
+            };
+        }
+
+        /// <inheritdoc/>
+        public override Uri? GetDetailsUrl() => Element.GetDetailsUrl();
+
+        /// <inheritdoc/>
+        public override string ToString() => Id;
+
+        protected ICollection<Model.IElement> LoadChildren(Class cls)
+        {
+            return cls.GetAllProperties(Context).Get(Context)
+                .Select(p => new PropertyWrapper(Context, p, this))
+                .ToList<Model.IElement>();
+        }
+    }
+
+    /// <summary>
+    /// A wrapper for an IEC CDD class.  See the ElementWrapper type for more information.
+    /// </summary>
+    public class ClassWrapper : ElementWrapper<Class>
+    {
+        /// <summary>
+        /// Creates a new ClassWrapper for an IEC CDD class.
+        /// </summary>
+        /// <param name="context">The current data context</param>
+        /// <param name="cls">The wrapped IEC CDD class</param>
+        /// <param name="parent">The parent element, or null if this is a top-level element</param>
+        public ClassWrapper(Context context, Class cls, Model.IElement? parent = null)
+            : base(context, cls, parent)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool ImportSubmodelInto(AdminShellV20.AdministrationShellEnv env,
+           AdminShellV20.AdministrationShell adminShell)
+        {
+            return new Importer(env, Context).ImportSubmodel(this, adminShell);
+        }
+
+        /// <inheritdoc/>
+        public override Dictionary<string, string> GetDetails()
+        {
+            var dict = base.GetDetails();
+            dict.Add("Definition Source", Element.DefinitionSource);
+            dict.Add("Superclass", Element.Superclass.Code);
+            return dict;
+        }
+
+        protected override ICollection<Model.IElement> LoadChildren() => LoadChildren(Element);
+    }
+
+    /// <summary>
+    /// A wrapper for an IEC CDD property.  See the ElementWrapper type for more information.
+    /// </summary>
+    public class PropertyWrapper : ElementWrapper<Property>
+    {
+        private readonly Class? _referenceClass;
+
+        /// <inheritdoc/>
+        public override string Id
+        {
+            get
+            {
+                if (_referenceClass != null)
+                    return _referenceClass.Code;
+                return base.Id;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override string Name
+        {
+            get
+            {
+                if (_referenceClass != null)
+                    return _referenceClass.PreferredName.GetDefault();
+                return base.Name;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new PropertyWrapper for an IEC CDD property.
+        /// </summary>
+        /// <param name="context">The current data context</param>
+        /// <param name="property">The wrapped IEC CDD property</param>
+        /// <param name="parent">The parent element</param>
+        public PropertyWrapper(Context context, Property property, Model.IElement parent)
+            : base(context, property, parent)
+        {
+            Reference<Class>? reference = property.DataType.GetClassReference();
+            if (reference != null)
+                _referenceClass = reference.Get(context);
+        }
+
+        /// <inheritdoc/>
+        public override Dictionary<string, string> GetDetails()
+        {
+            var dict = base.GetDetails();
+            dict.Add("Definition Source", Element.DefinitionSource);
+            dict.Add("Short Name", Element.ShortName.GetDefault());
+            dict.Add("Symbol", Element.Symbol);
+            dict.Add("Primary Unit", Element.PrimaryUnit);
+            dict.Add("Unit Code", Element.UnitCode);
+            dict.Add("Data Type", Element.RawDataType);
+            dict.Add("Format", Element.Format);
+            return dict;
+        }
+
+        protected override ICollection<Model.IElement> LoadChildren()
+        {
+            if (_referenceClass != null)
+                return LoadChildren(_referenceClass);
+
+            var children = new List<Model.IElement>();
+            if (Element.DataType is AggregateType aggregateType)
+            {
+                var subProperty = Element.ReplaceDataType(aggregateType.Subtype);
+                children.Add(new PropertyWrapper(Context, subProperty, this));
+            }
+            return children;
+        }
+    }
+}

--- a/src/AasxDictionaryImport/Cdd/Parser.cs
+++ b/src/AasxDictionaryImport/Cdd/Parser.cs
@@ -1,0 +1,186 @@
+﻿/*
+ * Copyright (c) 2020 SICK AG <info@sick.de>
+ *
+ * This software is licensed under the Apache License 2.0 (Apache-2.0).
+ * The ExcelDataReder dependency is licensed under the MIT license
+ * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
+ */
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using AasxDictionaryImport.Model;
+using ExcelDataReader;
+
+namespace AasxDictionaryImport.Cdd
+{
+    /// <summary>
+    /// A parser for IEC CDD exports.  An IEC CDD export is a set of XLS files storing the attributes of the CDD
+    /// elements.  This parser reads the class and property tables, creates Class and Property elements (defined in
+    /// Data.cs) and provides them with a dictionary storing their attributes.
+    /// </summary>
+    internal class Parser
+    {
+        /// <summary>
+        /// Parses the IEC CDD export files and creates a new data context from the given data source.
+        /// </summary>
+        /// <param name="dataSource">The data source to read the export files from</param>
+        /// <returns>The data context read from the given data source</returns>
+        /// <exception cref="Model.ImportException">If an unexpected error occurs during the import</exception>
+        /// <exception cref="MissingExportFilesException">If the data source does not contain all required export
+        /// files</exception>
+        /// <exception cref="MultipleExportFilesException">If the data source contains more than one set of export
+        /// files</exception>
+        public Context Parse(DataSource dataSource)
+        {
+            try
+            {
+                var files = FindFiles(dataSource.Path);
+                return new Context(dataSource,
+                    ParseFile<Class>(files, "class"),
+                    ParseFile<Property>(files, "property"));
+            }
+            catch (System.IO.IOException e)
+            {
+                throw new Model.ImportException(
+                    $"Could not parse data in directory '{dataSource.Path}'", e);
+            }
+        }
+
+        /// <exception cref="MultipleExportFilesException"/>
+        private Dictionary<string, string> FindFiles(string directory)
+        {
+            var fileRegex = new Regex(@"\\export_(.*)_TSTM-.*\.xls$");
+            var dict = new Dictionary<string, string>();
+            var files = System.IO.Directory.GetFiles(directory, "export_*.xls");
+            foreach (var f in files)
+            {
+                var match = fileRegex.Match(f);
+                if (match.Success)
+                {
+                    var type = match.Groups[1].Value.ToLowerInvariant();
+                    if (dict.ContainsKey(type))
+                    {
+                        throw new MultipleExportFilesException(type);
+                    }
+                    dict.Add(match.Groups[1].Value.ToLowerInvariant(), f);
+                }
+            }
+            return dict;
+        }
+
+        /// <exception cref="MissingExportFilesException"/>
+        private List<T> ParseFile<T>(Dictionary<string, string> files, string name)
+            where T : Element
+        {
+            if (!files.ContainsKey(name))
+                throw new MissingExportFilesException(name);
+            return ParseFile<T>(files[name]);
+        }
+
+        private List<T> ParseFile<T>(string filename) where T : Element
+        {
+
+            using var stream = File.Open(filename, FileMode.Open, FileAccess.Read);
+            using var reader = ExcelReaderFactory.CreateReader(stream);
+
+            if (reader.FieldCount == 0)
+            {
+                // no columns
+                return new List<T>();
+            }
+
+            return ParseFile<T>(reader);
+        }
+
+        private List<T> ParseFile<T>(IExcelDataReader reader) where T : Element
+        {
+            var data = new List<T>();
+            var columns = new List<string>();
+
+            while (reader.Read())
+            {
+                // The row type is determined by the value of the first column:
+                //    #PROPERTY_ID --> header row
+                //    empty        --> data row
+                //    other        --> comment
+
+                var value = GetString(reader, 0);
+                if (value == "#PROPERTY_ID")
+                    columns = ParseHeaders(reader);
+                else if (value.Length == 0)
+                    data.Add(ParseElement<T>(reader, columns));
+            }
+
+            return data;
+        }
+
+        private List<string> ParseHeaders(IExcelDataReader reader)
+        {
+            var columns = new List<string>(reader.FieldCount - 1);
+            for (int i = 1; i < reader.FieldCount; i++)
+            {
+                var column = GetString(reader, i);
+                if (column == null)
+                    break;
+                columns.Add(column);
+            }
+            return columns;
+        }
+
+        private T ParseElement<T>(IExcelDataReader reader, List<string> columns) where T : Element
+        {
+            var elementDict = new Dictionary<string, string>();
+            for (int i = 0; i < columns.Count; i++)
+            {
+                elementDict.Add(columns[i], GetString(reader, i + 1) ?? String.Empty);
+            }
+            return (T)Activator.CreateInstance(typeof(T), elementDict);
+        }
+
+        private String GetString(IExcelDataReader reader, int index)
+        {
+            var value = reader.GetValue(index);
+            return (value == null) ? String.Empty : value.ToString();
+        }
+
+        /// <summary>
+        /// Checks whether the given directory contains a valid IEC CDD data set.
+        /// </summary>
+        /// <param name="directory">The path of the directory th check</param>
+        /// <returns>true if the directory contains a valid IEC CDD data set</returns>
+        public static bool IsValidDirectory(string directory)
+        {
+            if (!System.IO.Directory.Exists(directory))
+                return false;
+            try
+            {
+                var files = new Parser().FindFiles(directory);
+                return files.ContainsKey("class") && files.ContainsKey("property");
+            }
+            catch (ImportException)
+            {
+                return false;
+            }
+        }
+    }
+
+    public class MissingExportFilesException : Model.ImportException
+    {
+        public MissingExportFilesException(string fileType)
+            : base("Could not find the export file of type " + fileType)
+        {
+        }
+    }
+
+    public class MultipleExportFilesException : Model.ImportException
+    {
+        public MultipleExportFilesException(string fileType)
+            : base("Found more than one export file of type " + fileType)
+        {
+        }
+    }
+}

--- a/src/AasxDictionaryImport/ElementDetailsDialog.xaml
+++ b/src/AasxDictionaryImport/ElementDetailsDialog.xaml
@@ -1,0 +1,41 @@
+﻿<Window x:Class="AasxDictionaryImport.ElementDetailsDialog"
+             x:ClassModifier="internal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:AasxDictionaryImport"
+             mc:Ignorable="d"
+             MinWidth="300" MinHeight="200" SizeToContent="WidthAndHeight">
+    <DockPanel Margin="5" LastChildFill="False">
+        <Grid x:Name="Grid" DockPanel.Dock="Top" VerticalAlignment="Stretch">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="7*"/>
+            </Grid.ColumnDefinitions>
+
+            <Grid.Resources>
+                <Style x:Key="marginStyle" TargetType="{x:Type FrameworkElement}">
+                    <Setter Property="Margin" Value="5,1"/>
+                </Style>
+                <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource marginStyle}">
+                    <Setter Property="IsReadOnly" Value="True"/>
+                    <Setter Property="Width" Value="300"/>
+                    <Setter Property="VerticalAlignment" Value="Center"/>
+                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                </Style>
+                <Style TargetType="{x:Type Label}" BasedOn="{StaticResource marginStyle}"/>
+                <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource marginStyle}">
+                    <Setter Property="VerticalAlignment" Value="Center"/>
+                    <EventSetter Event="SelectionChanged" Handler="ComboBox_SelectionChanged"/>
+                </Style>
+            </Grid.Resources>
+        </Grid>
+
+        <WrapPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right">
+            <Button Content="View in Browser" HorizontalAlignment="Right" Padding="5,0" MinWidth="75" Margin="5" Click="ButtonViewInBrowser_Click"/>
+            <Button Content="OK" HorizontalAlignment="Right" MinWidth="75" IsDefault="True" Margin="5" Click="ButtonOk_Click"/>
+        </WrapPanel>
+    </DockPanel>
+</Window>

--- a/src/AasxDictionaryImport/ElementDetailsDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ElementDetailsDialog.xaml.cs
@@ -1,0 +1,134 @@
+﻿/*
+ * Copyright (c) 2020 SICK AG <info@sick.de>
+ *
+ * This software is licensed under the Apache License 2.0 (Apache-2.0).
+ * The ExcelDataReder dependency is licensed under the MIT license
+ * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
+ */
+
+#nullable enable
+
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace AasxDictionaryImport
+{
+    /// <summary>
+    /// Display detail information for an element in the import dialog.  This dialog supports simple string values
+    /// (AddString) as well as multi-language strings (AddMultiString).  But as the current data model only returns
+    /// simple string values (IElement.GetDetails), AddMultiString is currently unused.
+    /// </summary>
+    internal partial class ElementDetailsDialog : Window
+    {
+        public Model.IElement Element { get; }
+
+        public ElementDetailsDialog(Model.IElement element)
+        {
+            DataContext = this;
+            Element = element;
+
+            InitializeComponent();
+
+            var details = element.GetDetails();
+            foreach (var field in details.Keys)
+                AddString(field, details[field]);
+
+            Title = $"{Element} [{Element.DataSource}]";
+        }
+
+        private void AddString(string label, string value)
+        {
+            AddRow();
+            CreateLabel(label);
+            CreateTextBox(value);
+        }
+
+        private void AddMultiString(string label, MultiString value)
+        {
+            AddRow();
+            CreateLabel(label);
+            CreateMultiStringTextBox(value);
+        }
+
+        private void AddRow()
+        {
+            Grid.RowDefinitions.Add(new RowDefinition());
+        }
+
+        private void AddElement(FrameworkElement element, int column)
+        {
+            Grid.SetRow(element, Grid.RowDefinitions.Count - 1);
+            Grid.SetColumn(element, column);
+            Grid.Children.Add(element);
+        }
+
+        private void CreateLabel(string content)
+        {
+            var label = new Label { Content = content };
+            AddElement(label, 0);
+        }
+
+        private TextBox CreateTextBox(string text)
+        {
+            var textBox = new TextBox { Text = text };
+            AddElement(textBox, 2);
+            return textBox;
+        }
+
+        private void CreateLanguageComboBox(MultiString ms, TextBox textBox)
+        {
+            var comboBox = new ComboBox();
+            AddElement(comboBox, 1);
+
+            foreach (var lang in ms.Languages)
+                comboBox.Items.Add(lang);
+            comboBox.Tag = textBox;
+            textBox.Tag = ms;
+
+            if (comboBox.Items.Count > 0)
+                comboBox.SelectedItem = ms.DefaultLanguage;
+        }
+
+        private void CreateMultiStringTextBox(MultiString ms)
+        {
+            var textBox = CreateTextBox(ms.GetDefault());
+            CreateLanguageComboBox(ms, textBox);
+
+            var toolTip = new StringBuilder();
+            foreach (var lang in ms.AvailableLanguages)
+            {
+                if (toolTip.Length > 0)
+                    toolTip.AppendLine();
+                toolTip.Append($"[{lang}] {ms.Get(lang)}");
+            }
+            textBox.ToolTip = new ToolTip { Content = toolTip.ToString() };
+        }
+
+        private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (sender is ComboBox comboBox)
+            {
+                if (comboBox.Tag is TextBox textBox)
+                {
+                    if (textBox.Tag is MultiString ms)
+                    {
+                        textBox.Text = ms.Get(comboBox.SelectedItem.ToString());
+                    }
+                }
+            }
+        }
+
+        private void ButtonOk_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private void ButtonViewInBrowser_Click(object sender, RoutedEventArgs e)
+        {
+            var url = Element.GetDetailsUrl();
+            if (url != null)
+                System.Diagnostics.Process.Start(url.AbsoluteUri);
+        }
+    }
+}

--- a/src/AasxDictionaryImport/Iec61360Utils.cs
+++ b/src/AasxDictionaryImport/Iec61360Utils.cs
@@ -1,0 +1,408 @@
+﻿/*
+ * Copyright (c) 2020 SICK AG <info@sick.de>
+ *
+ * This software is licensed under the Apache License 2.0 (Apache-2.0).
+ * The ExcelDataReder dependency is licensed under the MIT license
+ * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
+ */
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AdminShellNS;
+
+namespace AasxDictionaryImport
+{
+    /// <summary>
+    /// Utility functions for the conversion of IEC 61360 data objects into AAS elements.
+    /// </summary>
+    public static class Iec61360Utils
+    {
+        /// <summary>
+        /// Generates an idShort from the given string.  This means that illegal characters are removed and the string
+        /// is converted to UpperCamelCase (using white space as word boundaries).
+        /// </summary>
+        /// <param name="s">The input string</param>
+        /// <returns>A valid idShort based on the given input string</returns>
+        public static string CreateIdShort(string s)
+        {
+            return new string(FixIdShort(s).ToArray());
+        }
+
+        /// <summary>
+        /// Creates a new submodel with the given IEC 61360 data within the given AAS environment and admin shell,
+        /// generating a new IRI based on the current settings and setting the kind to Instance.
+        /// </summary>
+        /// <param name="env">The AAS environment to add the submodel to</param>
+        /// <param name="adminShell">The admin shell to add the submodel to</param>
+        /// <param name="data">The IEC 61360 data to create the submodel from</param>
+        /// <returns>A new submodel with the given data</returns>
+        public static AdminShellV20.Submodel CreateSubmodel(
+            AdminShellV20.AdministrationShellEnv env,
+            AdminShellV20.AdministrationShell adminShell, Iec61360Data data)
+        {
+            var submodel = new AdminShellV20.Submodel()
+            {
+                identification = new AdminShellV20.Identification(
+                    AdminShellV20.Identification.IRI,
+                    AasxPackageExplorer.Options.Curr.GenerateIdAccordingTemplate(
+                        AasxPackageExplorer.Options.Curr.TemplateIdSubmodelInstance)),
+                idShort = data.IdShort,
+                kind = AdminShellV20.ModelingKind.CreateAsInstance(),
+            };
+
+            AddDescriptions(submodel, data);
+            AddDataSpecification(env, submodel, data);
+
+            adminShell.AddSubmodelRef(submodel.GetReference() as AdminShellV20.SubmodelRef);
+            env.Submodels.Add(submodel);
+
+            return submodel;
+        }
+
+        /// <summary>
+        /// Creates a new submodel element collection with the given IEC 61360 data, setting the kind to Instance.
+        /// </summary>
+        /// <param name="env">The AAS environment to add the collection to</param>
+        /// <param name="data">The IEC 61360 data to create the collection from</param>
+        /// <returns>A new submodel element collection with the given data</returns>
+        public static AdminShellV20.SubmodelElementCollection CreateCollection(
+            AdminShellV20.AdministrationShellEnv env, Iec61360Data data)
+        {
+            var collection = new AdminShellV20.SubmodelElementCollection()
+            {
+                idShort = data.IdShort,
+                kind = AdminShellV20.ModelingKind.CreateAsInstance(),
+            };
+            InitSubmodelElement(env, collection, data);
+            return collection;
+        }
+
+        /// <summary>
+        /// Creates a new property with the given IEC 61360 data and value type, setting the kind to Instance.
+        /// </summary>
+        /// <param name="env">The AAS environment to add the property to</param>
+        /// <param name="data">The IEC 61360 data to create the property from</param>
+        /// <param name="valueType">The value type of the property</param>
+        /// <returns>A new property with the given data</returns>
+        public static AdminShellV20.Property CreateProperty(
+            AdminShellV20.AdministrationShellEnv env, Iec61360Data data, string valueType)
+        {
+            var property = new AdminShellV20.Property()
+            {
+                idShort = data.IdShort,
+                kind = AdminShellV20.ModelingKind.CreateAsInstance(),
+                valueType = valueType,
+            };
+            InitSubmodelElement(env, property, data);
+            return property;
+        }
+
+        private static void InitSubmodelElement(AdminShellV20.AdministrationShellEnv env,
+            AdminShellV20.SubmodelElement submodelElement, Iec61360Data data)
+        {
+            AddDescriptions(submodelElement, data);
+            AddDataSpecification(env, submodelElement, data);
+        }
+
+        private static void AddDescriptions(AdminShellV20.Referable r, Iec61360Data data)
+        {
+            foreach (var lang in data.PreferredName.AvailableLanguages)
+                r.AddDescription(lang, data.PreferredName.Get(lang));
+        }
+
+        private static void AddDataSpecification(AdminShellV20.AdministrationShellEnv env,
+            AdminShellV20.Submodel submodel, Iec61360Data data)
+        {
+            var cd = CreateConceptDescription(env, data);
+            submodel.hasDataSpecification = new AdminShellV20.HasDataSpecification();
+            submodel.hasDataSpecification.reference.Add(cd.GetReference());
+            submodel.semanticId = new AdminShellV20.SemanticId(cd.GetReference());
+        }
+
+        private static void AddDataSpecification(AdminShellV20.AdministrationShellEnv env,
+            AdminShellV20.SubmodelElement submodelElement, Iec61360Data data)
+        {
+            var cd = CreateConceptDescription(env, data);
+            submodelElement.hasDataSpecification = new AdminShellV20.HasDataSpecification();
+            submodelElement.hasDataSpecification.reference.Add(cd.GetReference());
+            submodelElement.semanticId = new AdminShellV20.SemanticId(cd.GetReference());
+        }
+
+        private static AdminShellV20.ConceptDescription CreateConceptDescription(
+            AdminShellV20.AdministrationShellEnv env, Iec61360Data data)
+        {
+            var cd = AdminShellV20.ConceptDescription.CreateNew(AdminShellV20.Identification.IRDI, data.Irdi,
+                idShort: data.IdShort);
+            cd.embeddedDataSpecification = new AdminShellV20.EmbeddedDataSpecification()
+            {
+                dataSpecificationContent = new AdminShellV20.DataSpecificationContent()
+                {
+                    dataSpecificationIEC61360 = data.ToDataSpecification(),
+                },
+            };
+            cd.AddIsCaseOf(AdminShellV20.Reference.CreateIrdiReference(data.Irdi));
+            env.ConceptDescriptions.Add(cd);
+            return cd;
+        }
+
+        private static IEnumerable<char> FixIdShort(string s)
+        {
+            bool start = true;
+            bool newWord = true;
+
+            foreach (var c in s)
+            {
+                if (start)
+                    if (!Char.IsLetter(c))
+                        continue;
+
+                start = false;
+
+                if (Char.IsWhiteSpace(c))
+                {
+                    newWord = true;
+                }
+                else if (Char.IsLetter(c) || Char.IsDigit(c) || c == '_')
+                {
+                    yield return newWord ? Char.ToUpper(c) : c;
+                    newWord = false;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// String that is available in multiple languages.
+    /// </summary>
+    public sealed class MultiString
+    {
+        private const string DefaultLanguageCode = "en";
+        private readonly Dictionary<string, string> _data;
+
+        /// <summary>
+        /// All languages that are supported by the data model.
+        /// </summary>
+        public IEnumerable<string> Languages => _data.Keys;
+
+        /// <summary>
+        /// All languages that have a non-empty value for this attribute.
+        /// </summary>
+        public IEnumerable<string> AvailableLanguages
+            => Languages.Where(lang => _data[lang].Length > 0);
+
+        /// <summary>
+        /// All values for this attribute.
+        /// </summary>
+        public IEnumerable<string> Values => _data.Values;
+
+        /// <summary>
+        /// The default language for this attribute – English if available, otherwise the first available language.
+        /// </summary>
+        public string DefaultLanguage
+        {
+            get
+            {
+                if (AvailableLanguages.Contains(DefaultLanguageCode))
+                    return DefaultLanguageCode;
+                return AvailableLanguages.DefaultIfEmpty("").First();
+            }
+        }
+
+        /// <summary>
+        /// Creates a new MultiString object without any values.
+        /// </summary>
+        public MultiString() : this(new Dictionary<string, string>())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new MultiString object with the given values.
+        /// </summary>
+        /// <param name="data">The data to store in the MultiString object, as a mapping from languages to
+        /// values</param>
+        public MultiString(Dictionary<string, string> data)
+        {
+            _data = data;
+        }
+
+        /// <summary>
+        /// Adds the given value for the given language to this multi string.
+        /// </summary>
+        /// <param name="lang">The language code for the value</param>
+        /// <param name="value">The value to add to the multi string</param>
+        public void Add(string lang, string value)
+        {
+            if (!_data.ContainsKey(lang))
+                _data.Add(lang, value);
+        }
+
+        /// <summary>
+        /// Returns the value for the given language, or an empty string if no value is set.
+        /// </summary>
+        /// <param name="lang">The language to check</param>
+        /// <returns>The value for the given language, or an empty string</returns>
+        public string Get(string lang)
+        {
+            return _data.TryGetValue(lang, out string? value) ? value : string.Empty;
+        }
+
+        /// <summary>
+        /// Returns the value of this attribute in the default language – English if available, otherwise the first
+        /// available language.  If this multi string does not contain any values, this method returns an empty string.
+        /// </summary>
+        /// <returns>The value of this attribute in the default language</returns>
+        public string GetDefault()
+        {
+            return Get(DefaultLanguage);
+        }
+
+        /// <summary>
+        /// Converts this multi string to a LangStringSet used by the AdminShell data model.  Only the non-empty values
+        /// are added to the set.
+        /// </summary>
+        /// <returns>A LangStringSet with the values form this multi string</returns>
+        public AdminShellV20.LangStringSetIEC61360 ToLangStringSet()
+        {
+            var set = new AdminShellV20.LangStringSetIEC61360();
+            foreach (var lang in Languages)
+            {
+                var value = Get(lang);
+                if (value.Length > 0)
+                    set.langString.Add(new AdminShellV20.LangStr(lang, value));
+            }
+            return set;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return GetDefault();
+        }
+    }
+
+    /// <summary>
+    /// The data for an element according to the IEC 61360 standard.  This data can be used to generate AAS elements,
+    /// especially submodels, properties and collections.  The idShort for the generated AAS element is derived from
+    /// the short name or the preferred name.
+    /// <para>
+    /// It is not necessary to set all fields -- some are only applicable for some element types.  But every data
+    /// object must have a unique IRDI.
+    /// </para>
+    /// </summary>
+    public sealed class Iec61360Data
+    {
+        private string? _idShort = null;
+
+        /// <summary>
+        /// The IRDI of this element.
+        /// </summary>
+        public string Irdi { get; set; }
+
+        /// <summary>
+        /// The preferred name for this element in multiple languages.
+        /// </summary>
+        public MultiString PreferredName { get; set; } = new MultiString();
+
+        /// <summary>
+        /// The short name for this element in multiple languages.
+        /// </summary>
+        public MultiString ShortName { get; set; } = new MultiString();
+
+        /// <summary>
+        /// The definition for this element in multiple languages.
+        /// </summary>
+        public MultiString Definition { get; set; } = new MultiString();
+
+        /// <summary>
+        /// The definition source for this element.
+        /// </summary>
+        public string DefinitionSource { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The symbol for this element (properties only).
+        /// </summary>
+        public string Symbol { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The unit for this element (properties only).
+        /// </summary>
+        public string Unit { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The IRDI of the unit element for this element (properties only).
+        /// </summary>
+        public string UnitIrdi { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The data type for this element (properties only).
+        /// </summary>
+        public string DataType { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The data format for this element (properties only).
+        /// </summary>
+        public string DataFormat { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The AAS shortId for this element.  The short ID is generated from the preferred name.
+        /// </summary>
+        public string IdShort
+        {
+            get
+            {
+                _idShort ??= GenerateIdShort();
+                return _idShort;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new Iec61360Data object with the given IRDI.
+        /// </summary>
+        /// <param name="irdi">The IRDI for this object</param>
+        public Iec61360Data(string irdi)
+        {
+            Irdi = irdi;
+        }
+
+        /// <summary>
+        /// Converts this data to a DataSpecification object used by the AAS data model.  Empty fields are ignored.
+        /// </summary>
+        /// <returns>The AAS DataSpecification with the data stored in this element</returns>
+        public AdminShellV20.DataSpecificationIEC61360 ToDataSpecification()
+        {
+            var ds = new AdminShellV20.DataSpecificationIEC61360()
+            {
+                definition = Definition.ToLangStringSet(),
+                preferredName = PreferredName.ToLangStringSet(),
+                shortName = ShortName.ToLangStringSet(),
+            };
+
+            if (DefinitionSource.Length > 0)
+                ds.sourceOfDefinition = DefinitionSource;
+            if (Symbol.Length > 0)
+                ds.symbol = Symbol;
+            if (Unit.Length > 0)
+                ds.unit = Unit;
+            if (UnitIrdi.Length > 0)
+                ds.unitId = AdminShellV20.UnitId.CreateNew(
+                    AdminShellV20.Key.GlobalReference, false,
+                    AdminShellV20.Identification.IRDI, UnitIrdi);
+            if (DataType.Length > 0)
+                ds.dataType = DataType;
+            if (DataFormat.Length > 0)
+                ds.valueFormat = DataFormat;
+
+            return ds;
+        }
+
+        private string GenerateIdShort()
+        {
+            var shortName = ShortName.GetDefault();
+            var name = shortName.Length > 0 ? shortName : PreferredName.GetDefault();
+            return Iec61360Utils.CreateIdShort(name);
+        }
+    }
+}

--- a/src/AasxDictionaryImport/Import.cs
+++ b/src/AasxDictionaryImport/Import.cs
@@ -1,0 +1,109 @@
+﻿/*
+ * Copyright (c) 2020 SICK AG <info@sick.de>
+ *
+ * This software is licensed under the Apache License 2.0 (Apache-2.0).
+ * The ExcelDataReder dependency is licensed under the MIT license
+ * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
+ */
+
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Windows.Input;
+using AasxGlobalLogging;
+using AdminShellNS;
+
+namespace AasxDictionaryImport
+{
+    /// <summary>
+    /// A generic import dialog for submodels.  For the data model, see the Model namespace.  For implementations of
+    /// this data model, see the Cdd namespace.  For the actual dialog, see the ImportDialog.xaml file.
+    /// <para>
+    /// This project uses nullable types.  Methods may only throw exceptions if they are mentioned in the doc comment.
+    /// </para>
+    /// <para>
+    /// This project could be extended and improved by:
+    /// <list type="bullet">
+    /// <item>
+    /// <description>supporting multi-language strings in the user interface (see e. g.
+    /// ElementDetailsDialog)</description>
+    /// </item>
+    /// <item>
+    /// <description>supporting other data providers, especially eCl@ss</description>
+    /// </item>
+    /// <item>
+    /// <description>fetching data from the network (IEC CDD HTML web service, eCl@ss REST API)</description>
+    /// </item>
+    /// <item>
+    /// <description>supporting import of properties and concept descriptions</description>
+    /// </item>
+    /// <item>
+    /// <description>better resize handling in ElementDetailsDialog</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    // ReSharper disable once UnusedType.Global
+    internal class NamespaceDoc
+    {
+    }
+
+    /// <summary>
+    /// A generic import dialog for submodels.
+    /// </summary>
+    public static class Import
+    {
+        /// <summary>
+        /// Shows the import dialog and allows the user to select data from a data provider implementation that is
+        /// converted into an AAS submodel and imported into the given admin shell.  If <paramref name="adminShell"/> is
+        /// null, a new empty admin shell is created in the given environment.
+        /// </summary>
+        /// <param name="env">The AAS environment to import into</param>
+        /// <param name="adminShell">The admin shell to import into, or null if a new admin shell should be
+        /// created</param>
+        /// <returns>true if at least one submodel was imported</returns>
+        public static bool ImportSubmodel(AdminShellV20.AdministrationShellEnv env,
+            AdminShellV20.AdministrationShell? adminShell = null)
+        {
+            adminShell ??= CreateAdminShell(env);
+            var dialog = new ImportDialog();
+            if (dialog.ShowDialog() != true || dialog.Context == null)
+                return false;
+
+
+            int imported;
+            try
+            {
+                Mouse.OverrideCursor = Cursors.Wait;
+                imported = dialog.GetResult().Count(e => e.ImportSubmodelInto(env, adminShell));
+            }
+            finally
+            {
+                Mouse.OverrideCursor = null;
+            }
+
+            if (dialog.Context.UnknownReferences.Count > 0)
+            {
+                Log.Info($"Found {dialog.Context.UnknownReferences.Count} unknown references during import: " +
+                    string.Join(", ", dialog.Context.UnknownReferences));
+            }
+
+            return imported > 0;
+        }
+
+        private static AdminShellV20.AdministrationShell CreateAdminShell(AdminShellV20.AdministrationShellEnv env)
+        {
+            var adminShell = new AdminShellV20.AdministrationShell()
+            {
+                identification = new AdminShellV20.Identification(
+                        AdminShellV20.Identification.IRI,
+                        AasxPackageExplorer.Options.Curr.GenerateIdAccordingTemplate(
+                            AasxPackageExplorer.Options.Curr.TemplateIdAas)),
+            };
+            env.AdministrationShells.Add(adminShell);
+            return adminShell;
+        }
+
+    }
+}

--- a/src/AasxDictionaryImport/ImportDialog.xaml
+++ b/src/AasxDictionaryImport/ImportDialog.xaml
@@ -1,0 +1,79 @@
+﻿<Window x:Class="AasxDictionaryImport.ImportDialog"
+             x:ClassModifier="internal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:AasxDictionaryImport"
+             mc:Ignorable="d" 
+             Title="Dictionary Import" Width="1000" Height="500" MinWidth="550" MinHeight="200">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="5*"/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="5*"/>
+        </Grid.ColumnDefinitions>
+
+        <WrapPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Margin="0" HorizontalAlignment="Stretch">
+            <Label Content="Supported data providers:"/>
+            <Label x:Name="DataSourceLabel"/>
+        </WrapPanel>
+
+        <DockPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,10" HorizontalAlignment="Stretch">
+            <WrapPanel>
+                <Label Content="Source:" Margin="0,0,10,0" VerticalAlignment="Center"/>
+                <ComboBox x:Name="ComboBoxSource" Width="150" Margin="0,0,10,0" SelectionChanged="ComboBoxSource_SelectionChanged" VerticalAlignment="Center"/>
+                <Button Content="Open Directory" Padding="5,0" Click="ButtonOpenDirectory_Click" VerticalAlignment="Center" Margin="0,0,10,0"/>
+            </WrapPanel>
+            <WrapPanel HorizontalAlignment="Right">
+                <Label Content="Filter classes: " VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBox TextWrapping="NoWrap" Width="150" Text="{Binding Filter,UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center"/>
+            </WrapPanel>
+        </DockPanel>
+
+        <ListView x:Name="ClassViewControl" Grid.Row="2" Grid.Column="0" ItemsSource="{Binding TopLevelView}" SelectionChanged="ClassViewControl_SelectionChanged">
+            <ListView.ItemContainerStyle>
+                <Style TargetType="{x:Type ListViewItem}">
+                    <EventSetter Event="MouseDoubleClick" Handler="ViewItem_MouseDoubleClick"/>
+                </Style>
+            </ListView.ItemContainerStyle>
+            <ListView.View>
+                <GridView>
+                    <GridViewColumn Header="ID" DisplayMemberBinding="{Binding Id}"/>
+                    <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Name}"/>
+                </GridView>
+            </ListView.View>
+        </ListView>
+
+        <GridSplitter Grid.Row="2" Grid.Column="1" VerticalAlignment="Stretch" Width="5" ShowsPreview="True" ResizeBehavior="PreviousAndNext" />
+
+        <TreeView x:Name="ClassDetailsViewControl" Grid.Row="2" Grid.Column="2" ItemsSource="{Binding DetailsView}">
+            <TreeView.ItemContainerStyle>
+                <Style TargetType="{x:Type TreeViewItem}">
+                    <Setter Property="IsExpanded" Value="{Binding IsExpanded}"/>
+                    <EventSetter Event="MouseDoubleClick" Handler="ViewItem_MouseDoubleClick"/>
+                </Style>
+            </TreeView.ItemContainerStyle>
+            <TreeView.Resources>
+                <HierarchicalDataTemplate DataType="{x:Type local:ElementWrapper}" ItemsSource="{Binding Children}">
+                    <StackPanel Orientation="Horizontal">
+                        <CheckBox IsChecked="{Binding IsChecked}" Focusable="False" VerticalAlignment="Center" IsThreeState="True"/>
+                        <TextBlock Text="{Binding Name}" Margin="2,0"/>
+                    </StackPanel>
+                </HierarchicalDataTemplate>
+            </TreeView.Resources>
+        </TreeView>
+
+        <WrapPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,10,0,0" HorizontalAlignment="Right">
+            <Button Content="Cancel" Width="75" Margin="0,0,10,0" IsCancel="True"/>
+            <Button x:Name="ButtonImport" Content="Import" Width="75" IsDefault="True" IsEnabled="False" Click="ButtonImport_Click"/>
+        </WrapPanel>
+
+    </Grid>
+</Window>

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -1,0 +1,319 @@
+﻿/*
+ * Copyright (c) 2020 SICK AG <info@sick.de>
+ *
+ * This software is licensed under the Apache License 2.0 (Apache-2.0).
+ * The ExcelDataReder dependency is licensed under the MIT license
+ * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
+ */
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Input;
+using AasxGlobalLogging;
+
+namespace AasxDictionaryImport
+{
+    /// <summary>
+    /// The main import dialog.  The main elements of the dialog are a list view (the left half of the main panel) that
+    /// lists all available top-level elements and a tree view (the right half of the main panel) that displays the
+    /// structure of one or more top-level elements that have been selected in the list view.  Elements of the tree view
+    /// can be checked or unchecked to determine whether they should be imported.  The selection can be accessed using
+    /// the GetResult method.
+    /// <para>
+    /// The data source can be selected using a combo box.  If the user wants to use other data sources than those
+    /// shipped with the AASX Package Exlporer, they can select a custom directory.  This dialog could be extended by
+    /// adding another button that fetches a data source from the network.
+    /// </para>
+    /// </summary>
+    internal partial class ImportDialog : Window
+    {
+        public ISet<Model.IDataProvider> DataProviders = new HashSet<Model.IDataProvider> {
+            new Cdd.DataProvider(),
+        };
+        public Model.IDataContext? Context;
+        private readonly ObservableCollection<Model.IElement> _topLevelElements
+            = new ObservableCollection<Model.IElement>();
+        private readonly ObservableCollection<ElementWrapper> _detailsElements
+            = new ObservableCollection<ElementWrapper>();
+        private string _filter = string.Empty;
+
+        public ListCollectionView TopLevelView { get; }
+
+        public ListCollectionView DetailsView { get; }
+
+        public string Filter
+        {
+            get { return _filter; }
+            set
+            {
+                var lowerValue = value.ToLower();
+                if (_filter != lowerValue)
+                {
+                    _filter = lowerValue;
+                    ApplyFilter();
+                }
+            }
+        }
+
+        public ImportDialog()
+        {
+            DataContext = this;
+
+            TopLevelView = new ListCollectionView(_topLevelElements);
+            DetailsView = new ListCollectionView(_detailsElements);
+
+            InitializeComponent();
+
+            foreach (var provider in DataProviders)
+                foreach (var source in provider.FindDefaultDataSources())
+                    ComboBoxSource.Items.Add(source);
+
+            DataSourceLabel.Content = String.Join(", ", DataProviders.Select(p => p.Name));
+        }
+
+        public IEnumerable<Model.IElement> GetResult()
+        {
+            return _detailsElements.Select(e => e.Element);
+        }
+
+        private void UpdateImportButton()
+        {
+            ButtonImport.IsEnabled = _detailsElements.Any(w => w.IsChecked != false);
+        }
+
+        private string? GetImportDirectory()
+        {
+            using var dialog = new System.Windows.Forms.FolderBrowserDialog
+            {
+                Description = "Select the import directory."
+            };
+
+            return dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK
+                ? dialog.SelectedPath : null;
+        }
+
+        private void ApplyFilter()
+        {
+            if (string.IsNullOrEmpty(_filter))
+            {
+                TopLevelView.Filter = null;
+            }
+            else
+            {
+                var parts = _filter.Split(' ').Where(s => s.Length > 0);
+                TopLevelView.Filter = o =>
+                {
+                    if (!(o is Model.IElement element))
+                        return false;
+
+                    return element.Match(parts);
+                };
+            }
+        }
+
+        private void ButtonImport_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void ClassViewControl_SelectionChanged(object sender,
+            System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (Context == null)
+                return;
+
+            _detailsElements.Clear();
+
+            foreach (var item in ClassViewControl.SelectedItems)
+            {
+                if (item is Model.IElement element)
+                {
+                    var wrapper = new ElementWrapper(element);
+                    wrapper.PropertyChanged += ClassWrapper_PropertyChanged;
+                    _detailsElements.Add(wrapper);
+                }
+            }
+
+            UpdateImportButton();
+        }
+
+        private void ClassWrapper_PropertyChanged(object o, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "IsChecked")
+                UpdateImportButton();
+        }
+
+        private void ComboBoxSource_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            Title = "IEC CDD Import";
+            _topLevelElements.Clear();
+            _detailsElements.Clear();
+
+            if (ComboBoxSource.SelectedItem is Model.IDataSource source)
+            {
+                try
+                {
+                    try
+                    {
+                        Mouse.OverrideCursor = Cursors.Wait;
+                        Context = source.Load();
+                    }
+                    finally
+                    {
+                        Mouse.OverrideCursor = null;
+                    }
+
+                    foreach (var cls in Context.LoadSubmodels())
+                    {
+                        _topLevelElements.Add(cls);
+                    }
+                    Title = $"IEC CDD Import [{source}]";
+
+                    if (ClassViewControl.Items.Count > 0)
+                        ClassViewControl.SelectedItem = ClassViewControl.Items[0];
+                }
+                catch (Model.ImportException ex)
+                {
+                    Log.Error(ex, "Could not load the selected data source.");
+                    MessageBox.Show(
+                     "Could not load the selected data source.\n" +
+                     "Details: " + ex.Message,
+                     "Import Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+        }
+
+        private void ButtonOpenDirectory_Click(object sender, RoutedEventArgs e)
+        {
+            var path = GetImportDirectory();
+            if (path == null)
+                return;
+
+            var validProviders = DataProviders.Where(p => p.IsValidPath(path)).ToList();
+            if (validProviders.Count != 1)
+                return;
+
+            var source = validProviders.First().OpenPath(path);
+
+            foreach (var item in ComboBoxSource.Items)
+            {
+                if (source.Equals(item))
+                {
+                    ComboBoxSource.SelectedItem = item;
+                    return;
+                }
+            }
+
+            ComboBoxSource.Items.Add(source);
+            ComboBoxSource.SelectedItem = source;
+        }
+
+        private void ViewItem_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            Model.IElement? element = null;
+
+            if (sender is TreeViewItem treeViewItem && treeViewItem.IsSelected)
+                element = (treeViewItem.DataContext as ElementWrapper)?.Element;
+            else if (sender is ListViewItem listViewItem && listViewItem.IsSelected)
+                element = listViewItem.DataContext as Model.IElement;
+
+            if (element != null)
+            {
+                e.Handled = true;
+
+                var dialog = new ElementDetailsDialog(element);
+                dialog.Show();
+                dialog.Activate();
+            }
+        }
+    }
+
+    internal class ElementWrapper : INotifyPropertyChanged
+    {
+        private bool? _isChecked = true;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public Model.IElement Element { get; }
+
+        public ElementWrapper? Parent { get; }
+
+        public string Id => Element.Id;
+
+        public string Name => Element.Name;
+
+        public bool IsExpanded => Parent == null;
+
+        public bool? IsChecked
+        {
+            get { return _isChecked; }
+            set { SetIsChecked(value == true, true, true); }
+        }
+
+        public List<ElementWrapper> Children { get; }
+
+        public ElementWrapper(Model.IElement element, ElementWrapper? parent = null)
+        {
+            Parent = parent;
+            Element = element;
+            Children = element.Children.Select(e => new ElementWrapper(e, this)).ToList();
+
+            Element.IsSelected = _isChecked != false;
+        }
+
+        protected void PropagateIsChecked(bool up, bool down)
+        {
+            if (up)
+                Parent?.UpdateIsChecked();
+            if (down)
+            {
+                foreach (var child in Children)
+                    child.SetIsChecked(IsChecked, false, true);
+            }
+        }
+
+        public void UpdateIsChecked()
+        {
+            // tri-state checkbox:  true = checked, null = partial, false = unchecked
+            var any = false;
+            var all = true;
+            foreach (var child in Children)
+            {
+                if (child.IsChecked == true || child.IsChecked == null)
+                    any = true;
+                if (child.IsChecked != true)
+                    all = false;
+            }
+
+            bool? isChecked;
+            if (all)
+                isChecked = true;
+            else if (any)
+                isChecked = null;
+            else
+                isChecked = false;
+            SetIsChecked(isChecked, true, false);
+        }
+
+        public void SetIsChecked(bool? value, bool propagateUp, bool propagateDown)
+        {
+            if (_isChecked == value)
+                return;
+
+            _isChecked = value;
+            Element.IsSelected = value != false;
+            PropagateIsChecked(propagateUp, propagateDown);
+
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("IsChecked"));
+        }
+    }
+}

--- a/src/AasxDictionaryImport/LICENSE.txt
+++ b/src/AasxDictionaryImport/LICENSE.txt
@@ -1,0 +1,908 @@
+Copyright (c) 2018-2020 Festo AG & Co. KG
+<https://www.festo.com/net/de_de/Forms/web/contact_international>,
+author: Michael Hoffmeister
+
+Copyright (c) 2019-2020 PHOENIX CONTACT GmbH & Co. KG
+<opensource@phoenixcontact.com>,
+author: Andreas Orzelski
+
+Copyright (c) 2019-2020 Fraunhofer IOSB-INA Lemgo,
+    eine rechtlich nicht selbstaendige Einrichtung der Fraunhofer-Gesellschaft
+    zur Foerderung der angewandten Forschung e.V.
+
+Copyright (c) 2020 Schneider Electric Automation GmbH
+<marco.mendes@se.com>,
+author: Marco Mendes
+
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+Some licenses may only apply to their related plugins.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
+
+The browser functionality is licensed under the cefSharp license (see below).
+
+The Newtonsoft.JSON serialization is licensed under the MIT License
+(MIT, see below).
+
+The QR code generation is licensed under the MIT license (MIT, see below).
+
+The Zxing.Net Dot Matrix Code (DMC) generation is licensed under
+the Apache License 2.0 (Apache-2.0, see below).
+
+The Grapevine REST server framework is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The AutomationML.Engine is licensed under the MIT license (MIT, see below).
+
+The MQTT server and client is licensed under the MIT license (MIT, see below).
+
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
+
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
+
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
+
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to cefSharp
+========================
+
+(https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
+
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+With respect to Newtonsoft.Json
+===============================
+
+(https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md)
+
+The MIT License (MIT)
+
+Copyright (c) 2007 James Newton-King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to QRcoder
+=======================
+
+(https://github.com/codebude/QRCoder/blob/master/LICENSE.txt)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2018 Raffael Herrmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to ZXing.Net
+=========================
+With respect to Grapevine
+=========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to AutomationML.Engine
+===================================
+
+(https://raw.githubusercontent.com/AutomationML/AMLEngine2.1/master/license.txt)
+
+The MIT License (MIT)
+
+Copyright 2017 AutomationML e.V.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+With respect to MQTTnet
+=======================
+
+(https://github.com/chkr1011/MQTTnet/blob/master/LICENSE)
+
+MIT License
+
+MQTTnet Copyright (c) 2016-2019 Christian Kratky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
+
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
+
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
+
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
+
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
+
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
+
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
+
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
+
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
+
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
+
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxDictionaryImport/Model.cs
+++ b/src/AasxDictionaryImport/Model.cs
@@ -1,0 +1,552 @@
+﻿/*
+ * Copyright (c) 2020 SICK AG <info@sick.de>
+ *
+ * This software is licensed under the Apache License 2.0 (Apache-2.0).
+ * The ExcelDataReder dependency is licensed under the MIT license
+ * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
+ */
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using AdminShellNS;
+
+namespace AasxDictionaryImport.Model
+{
+    /// <summary>
+    /// The generic data model for structure imports.  The core of this data model is a tree of elements that could be
+    /// imported into the AAS environment (IElement).  The top-level nodes of this tree typically correspond to
+    /// submodels in the AAS.  These elements are stored in a data context (IDataContext) that can be retrieved using a
+    /// data source (IDataSource), for example a directory with export files.  A data provider (IDataProvider) can be
+    /// used to open data sources.  There should be one IDataProvider implementation per data repository (e. g. IEC CDD
+    /// or eCl@ss), but there could be multiple IDataSource implementations -- for example one for accessing paths on
+    /// the file system and one for retrieving data from the network.
+    /// </summary>
+    // ReSharper disable once UnusedType.Global
+    internal class NamespaceDoc
+    {
+    }
+
+    /// <summary>
+    /// Provides access to a data repository, for example IEC CDD or eCl@ss.  Implementations of this interface can be
+    /// used to access IDataSource instances that store the actual data structures.
+    /// </summary>
+    public interface IDataProvider
+    {
+        /// <summary>
+        /// The name of the data provider, suitable for the user interface.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Returns a list of all default data sources for this provider, i. e. all data sources that have been shipped
+        /// with the AASX Package Explorer or that are freely available on the internet.
+        /// </summary>
+        /// <returns>A list of all default data sources</returns>
+        IEnumerable<IDataSource> FindDefaultDataSources();
+
+        /// <summary>
+        /// Checks whether the given path contains valid data that can be read by this data provider.  This method
+        /// should never throw an exception.  If this method returns true, the data source at the given path can be
+        /// opened using the <see cref="OpenPath"/> method.
+        /// </summary>
+        /// <param name="path">The path of the data to check</param>
+        /// <returns>true if the path is a valid data source for this provider</returns>
+        bool IsValidPath(string path);
+
+        /// <summary>
+        /// Creates a new data source that reads the data stored at the given path.  If <see cref="IsValidPath"/>
+        /// returns true for this path, this method will always succeed.  Otherwise it will throw an exception.
+        /// </summary>
+        /// <param name="path">The path of the data set to open</param>
+        /// <returns>A data source that reads from the given path</returns>
+        /// <exception cref="ImportException">If the path could not be accessed or does not contain valid data for this
+        /// data provider</exception>
+        IDataSource OpenPath(string path);
+    }
+
+    /// <summary>
+    /// Provides access to a data set extracted from a data provider.
+    /// </summary>
+    public interface IDataSource : IEquatable<IDataSource>
+    {
+        /// <summary>
+        /// The data provider for this data set.
+        /// </summary>
+        IDataProvider DataProvider { get; }
+
+        /// <summary>
+        /// The name of this data source.  For a file, this should be the file name.  For a directory, this should be
+        /// the name of the top-level directory.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// The type of this data source.
+        /// </summary>
+        DataSourceType Type { get; }
+
+        /// <summary>
+        /// Loads and returns the data stored in this data sources.  This method should cache the loaded data.
+        /// </summary>
+        /// <returns>The data stored in this data source</returns>
+        /// <exception cref="ImportException">If the data source could not be accessed or does not contain valid
+        /// data</exception>
+        IDataContext Load();
+    }
+
+    /// <summary>
+    /// The type of a data source.
+    /// </summary>
+    public enum DataSourceType
+    {
+        /// <summary>
+        /// A source in the default search path, i. e. that has been shipped with the AASX Package Explorer.
+        /// </summary>
+        Default,
+        /// <summary>
+        /// A custom data source, usually provided and selected by the user.
+        /// </summary>
+        Custom,
+        /// <summary>
+        /// An export that has been performed directly by the AASX Package Explorer using the network.
+        /// </summary>
+        Online,
+    }
+
+    /// <summary>
+    /// A collection of elements stored in a data set as a tree.  The LoadSubmodels method can be used to retrieve those
+    /// elements that correspond to AAS submodels, the first level of the tree.  If the data source contains undefined
+    /// references, they will be ignored and recorded in the UnknownReferences collection.
+    /// </summary>
+    public interface IDataContext
+    {
+        /// <summary>
+        /// A collection of unknown references.  If an element in this data set references another element that is not
+        /// part of the data set, the reference is ignored and recorded in this collection.
+        /// </summary>
+        ICollection<Model.UnknownReference> UnknownReferences { get; }
+
+        /// <summary>
+        /// Loads and returns those elements that correspond to an AAS submodel, for example IEC CDD top-level classes.
+        /// </summary>
+        /// <returns>A collection of elements corresponding to AAS submodels</returns>
+        ICollection<IElement> LoadSubmodels();
+    }
+
+    /// <summary>
+    /// An element of a data set, identified by a unique ID.  The format of the ID depends on the data source.  To
+    /// examine the next level of the tree, use the Children property.  Implementations of this interface are free to
+    /// use lazy loading for the children, but should cache the results.
+    /// <para>
+    /// Elements can be converted into AAS submodels using the ImportSubmodelInto method.  Implementations should
+    /// respect the value of the IsSelected property, both for this element and for all children.
+    /// </para>
+    /// </summary>
+    public interface IElement
+    {
+        /// <summary>
+        /// The data source for this element.
+        /// </summary>
+        IDataSource DataSource { get; }
+
+        /// <summary>
+        /// The ID of this element.  This should be a unique ID.  The format of the ID depends on the data source.
+        /// Typically, an IRDI is used.
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// The name of this element, usually in English.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// The parent of this element or null if the element is a root element of the element tree.
+        /// </summary>
+        IElement? Parent { get; }
+
+        /// <summary>
+        /// The list of children of this element.  Implementations may use lazy loading for this list but should cache
+        /// the result.
+        /// </summary>
+        ICollection<IElement> Children { get; }
+
+        /// <summary>
+        /// Stores whether the user selected this element for the import.  If this is false, this element should be
+        /// ignored during the import.
+        /// </summary>
+        bool IsSelected { get; set; }
+
+        /// <summary>
+        /// Checks whether all parts of the given query match this element.  Implementations should at least check the
+        /// name and the ID and may also check other attributes.
+        /// </summary>
+        /// <param name="queryParts">A list of query strings</param>
+        /// <returns>true if all query strings match this element</returns>
+        bool Match(IEnumerable<string> queryParts);
+
+        /// <summary>
+        /// Converts this element into an AAS submodel and adds it to the given admin shell.  If this element cannot be
+        /// converted into a submodel, this method returns false.
+        /// <para>
+        /// Implementations of this method should check the IsSelected attribute both for this element and for all
+        /// children.  Only those elements with IsSelected equals true should be imported into the admin shell.
+        /// </para>
+        /// </summary>
+        /// <param name="env">The admin shell environment for the import</param>
+        /// <param name="adminShell">The admin shell to add the submodel to</param>
+        /// <returns>true if the import was successful, or false if the import failed or if this element cannot be
+        /// converted to an AAS submodel</returns>
+        bool ImportSubmodelInto(AdminShellV20.AdministrationShellEnv env,
+            AdminShellV20.AdministrationShell adminShell);
+
+        /// <summary>
+        /// Returns all detail information for this element, suitable for the user interface.  The keys of the returned
+        /// dictionary are the name of the attribute, the values are the attribute values.  This dictionary should also
+        /// include the ID and the name, typically as the first elements.
+        /// </summary>
+        /// <returns>The detail information for this element</returns>
+        Dictionary<string, string> GetDetails();
+
+        /// <summary>
+        /// Returns a URL that points to a web page with more information for this element (if available).
+        /// </summary>
+        /// <returns>A URL with more information for this element or null</returns>
+        Uri? GetDetailsUrl();
+    }
+
+    /// <summary>
+    /// A reference to an element that could not be resolved within a data set.
+    /// </summary>
+    public class UnknownReference : IEquatable<UnknownReference>
+    {
+        /// <summary>
+        /// The ID of the referenced element.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// The expected type of the referenced element, typically a class name.
+        /// </summary>
+        public string Type { get; }
+
+        /// <summary>
+        /// Creates a new UnknownReference object.
+        /// </summary>
+        /// <param name="id">The ID of the reference element</param>
+        /// <param name="type">The expected type of the referenced element</param>
+        public UnknownReference(string id, string type)
+        {
+            Id = id;
+            Type = type;
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(UnknownReference? reference)
+        {
+            return reference != null &&
+                Id.Equals(reference.Id) &&
+                Type.Equals(reference.Type);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object o)
+        {
+            return Equals(o as UnknownReference);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 23 + Id.GetHashCode();
+                hash = hash * 23 + Type.GetHashCode();
+                return hash;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"{Type}<{Id}>";
+        }
+
+        /// <summary>
+        /// Creates a new UnknownReference object.
+        /// </summary>
+        /// <typeparam name="T">The expected type of the referenced element</typeparam>
+        /// <param name="id">The ID of the referenced element</param>
+        /// <returns>A new UnknownReference object with the given data</returns>
+        public static UnknownReference Create<T>(string id)
+        {
+            return new UnknownReference(id, typeof(T).Name);
+        }
+    }
+
+    /// <summary>
+    /// Default implementation of the IDataProvider interface.
+    /// </summary>
+    public abstract class DataProviderBase : IDataProvider
+    {
+        /// <inheritdoc/>
+        public abstract string Name { get; }
+
+        /// <inheritdoc/>
+        public virtual IEnumerable<IDataSource> FindDefaultDataSources()
+        {
+            return GetDefaultPaths()
+                .Where(IsValidPath)
+                .Select(p => OpenPath(p, Model.DataSourceType.Default))
+                .ToList();
+        }
+
+        /// <inheritdoc/>
+        public override string ToString() => Name;
+
+        /// <inheritdoc/>
+        public abstract bool IsValidPath(string path);
+
+        /// <inheritdoc/>
+        public virtual IDataSource OpenPath(string path)
+            => OpenPath(path, DataSourceType.Custom);
+
+        /// <summary>
+        /// Returns all paths that could contain a default data source.
+        /// </summary>
+        /// <returns>A list of all possible default data sources</returns>
+        protected abstract IEnumerable<string> GetDefaultPaths();
+
+        /// <summary>
+        /// Creates a new data source that reads the data stored at the given path and sets the data source type to the
+        /// given value.  If IsValidPath returns true for this path, this method will always succeed.  Otherwise it will
+        /// throw an exception.
+        /// </summary>
+        /// <param name="path">The path of the data set to open</param>
+        /// <param name="type">The type of the data source to open</param>
+        /// <returns>A data source that reads from the given path</returns>
+        /// <exception cref="ImportException">If the path could not be accessed or does not contain valid data for this
+        /// data provider</exception>
+        protected abstract IDataSource OpenPath(string path, DataSourceType type);
+    }
+
+    /// <summary>
+    /// Default implementation of the IElement interface.
+    /// </summary>
+    public abstract class ElementBase : IElement
+    {
+        /// <inheritdoc/>
+        public virtual IDataSource DataSource { get; }
+
+        /// <inheritdoc/>
+        public abstract string Id { get; }
+
+        /// <inheritdoc/>
+        public abstract string Name { get; }
+
+        /// <inheritdoc/>
+        public virtual IElement? Parent { get; }
+
+        /// <inheritdoc/>
+        public abstract ICollection<IElement> Children { get; }
+
+        /// <inheritdoc/>
+        public virtual bool IsSelected { get; set; }
+
+        protected ElementBase(IDataSource dataSource, IElement? parent = null)
+        {
+            DataSource = dataSource;
+            Parent = parent;
+        }
+
+        /// <inheritdoc/>
+        public abstract Dictionary<string, string> GetDetails();
+
+        /// <inheritdoc/>
+        public virtual Uri? GetDetailsUrl() => null;
+
+        /// <inheritdoc/>
+        public virtual bool ImportSubmodelInto(AdminShellV20.AdministrationShellEnv env,
+            AdminShellV20.AdministrationShell adminShell) => false;
+
+        /// <inheritdoc/>
+        public virtual bool Match(IEnumerable<string> queryParts)
+        {
+            return queryParts.All(Match);
+        }
+
+        /// <summary>
+        /// Check whether the given string matches this element.  Implementations should at least check the ID and the
+        /// name and may also check other attributes.
+        /// </summary>
+        /// <param name="query">The string to match this element against</param>
+        /// <returns>true if this element matches the given string, otherwise false</returns>
+        protected virtual bool Match(string query)
+        {
+            return new[] { Id, Name }.Any(s => s.IndexOf(query, StringComparison.InvariantCultureIgnoreCase) >= 0);
+        }
+    }
+
+    /// <summary>
+    /// Default implementation of the IElement interface that implements lazy loading for the element's children.
+    /// </summary>
+    public abstract class LazyElementBase : ElementBase
+    {
+        private ICollection<IElement>? _children;
+
+        /// <inheritdoc/>
+        public override ICollection<IElement> Children
+        {
+            get
+            {
+                _children ??= LoadChildren();
+                return _children;
+            }
+        }
+
+        protected LazyElementBase(IDataSource dataSource, IElement? parent = null)
+            : base(dataSource, parent)
+        {
+        }
+
+        protected virtual ICollection<IElement> LoadChildren() => new List<IElement>();
+    }
+
+    /// <summary>
+    /// A data source that reads its data from a path on the file system.  If no name is specified, the file name
+    /// component of the path is used.
+    /// </summary>
+    public abstract class FileSystemDataSource : IDataSource
+    {
+        /// <inheritdoc/>
+        public IDataProvider DataProvider { get; }
+
+        /// <inheritdoc/>
+        public string Name { get; }
+
+        /// <inheritdoc/>
+        public DataSourceType Type { get; }
+
+        /// <summary>
+        /// The path used by this data source.
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// Creates a new FileSystemDataSource object and uses the file name component of the path as its name.
+        /// </summary>
+        /// <param name="dataProvider">The data provider</param>
+        /// <param name="path">The path of the directory</param>
+        /// <param name="type">The type of this data source</param>
+        /// <exception cref="ImportException">If the path cannot be accessed</exception>
+        protected FileSystemDataSource(IDataProvider dataProvider, string path,
+            DataSourceType type)
+            : this(dataProvider, GetName(path), path, type)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new FileSystemDataSource object.
+        /// </summary>
+        /// <param name="dataProvider">The data provider</param>
+        /// <param name="name">The name of this data source</param>
+        /// <param name="path">The path of this data source</param>
+        /// <param name="type">The type of this data source</param>
+        protected FileSystemDataSource(IDataProvider dataProvider, string name,
+            string path, DataSourceType type)
+        {
+            DataProvider = dataProvider;
+            Name = name;
+            Type = type;
+            Path = path;
+        }
+
+        /// <inheritdoc/>
+        public abstract IDataContext Load();
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            var stringBuilder = new StringBuilder();
+            stringBuilder.Append(DataProvider);
+            stringBuilder.Append(": ");
+            stringBuilder.Append(Name);
+            switch (Type)
+            {
+                case DataSourceType.Custom:
+                    stringBuilder.Append(" [");
+                    stringBuilder.Append(System.IO.Path.GetDirectoryName(Path));
+                    stringBuilder.Append("]");
+                    break;
+                case DataSourceType.Online:
+                    stringBuilder.Append(" [online]");
+                    break;
+                case DataSourceType.Default:
+                    break;
+            }
+            return stringBuilder.ToString();
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(IDataSource? source)
+        {
+            if (!(source is FileSystemDataSource ds))
+                return false;
+            return DataProvider.Equals(ds.DataProvider) && Path.Equals(ds.Path);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object o)
+        {
+            return Equals(o as IDataSource);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 23 + DataProvider.GetHashCode();
+                hash = hash * 23 + Path.GetHashCode();
+                return hash;
+            }
+        }
+
+        private static string GetName(string path)
+        {
+            try
+            {
+                return System.IO.Path.GetFileName(path);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new ImportException($"Could not get file name for path '{path}'", ex);
+            }
+        }
+    }
+
+    /// <summary>
+    /// An exception that occured during the import.  IDataProvider implementors should create subclasses for all types
+    /// of exceptions that could occur during the import.
+    /// </summary>
+    public class ImportException : Exception
+    {
+        public ImportException() : base()
+        {
+        }
+
+        public ImportException(string message) : base(message)
+        {
+        }
+
+        public ImportException(string message, Exception exception) : base(message, exception)
+        {
+        }
+    }
+}

--- a/src/AasxDictionaryImport/Properties/AssemblyInfo.cs
+++ b/src/AasxDictionaryImport/Properties/AssemblyInfo.cs
@@ -1,0 +1,34 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// Allgemeine Informationen über eine Assembly werden über die folgenden
+// Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
+// die einer Assembly zugeordnet sind.
+[assembly: AssemblyTitle("AasxDictionaryImport")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("SICK")]
+[assembly: AssemblyProduct("AasxDictionaryImport")]
+[assembly: AssemblyCopyright("Copyright © SICK 2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Durch Festlegen von ComVisible auf FALSE werden die Typen in dieser Assembly
+// für COM-Komponenten unsichtbar.  Wenn Sie auf einen Typ in dieser Assembly von
+// COM aus zugreifen müssen, sollten Sie das ComVisible-Attribut für diesen Typ auf "True" festlegen.
+[assembly: ComVisible(false)]
+
+// Die folgende GUID bestimmt die ID der Typbibliothek, wenn dieses Projekt für COM verfügbar gemacht wird
+[assembly: Guid("dec389bc-59bc-48e5-b163-6e44ce782c4a")]
+
+// Versionsinformationen für eine Assembly bestehen aus den folgenden vier Werten:
+//
+//      Hauptversion
+//      Nebenversion
+//      Buildnummer
+//      Revision
+//
+// Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
+// indem Sie "*" wie unten gezeigt eingeben:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/AasxDictionaryImport/packages.config
+++ b/src/AasxDictionaryImport/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ExcelDataReader" version="3.6.0" targetFramework="net472" />
+</packages>

--- a/src/AasxPackageExplorer.sln
+++ b/src/AasxPackageExplorer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.1000
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30128.74
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AasxPackageExplorer", "AasxPackageExplorer\AasxPackageExplorer.csproj", "{569B369E-9393-4F57-994E-6B84398FD7CC}"
 EndProject
@@ -49,6 +49,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AasxUANodesetImExport", "AasxUANodesetImExport\AasxUANodesetImExport.csproj", "{65783100-86DA-4CF6-8066-1292B902B216}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AasxDictionaryImport", "AasxDictionaryImport\AasxDictionaryImport.csproj", "{DEC389BC-59BC-48E5-B163-6E44CE782C4A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AasxSignature", "AasxSignature\AasxSignature.csproj", "{69824EF3-30F8-4C8A-874E-9B1F5873D25E}"
 EndProject
@@ -604,6 +606,17 @@ Global
 		{65783100-86DA-4CF6-8066-1292B902B216}.ReleaseWithoutCEF|x64.Build.0 = Release|Any CPU
 		{65783100-86DA-4CF6-8066-1292B902B216}.ReleaseWithoutCEF|x86.ActiveCfg = Release|Any CPU
 		{65783100-86DA-4CF6-8066-1292B902B216}.ReleaseWithoutCEF|x86.Build.0 = Release|Any CPU
+		{DEC389BC-59BC-48E5-B163-6E44CE782C4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DEC389BC-59BC-48E5-B163-6E44CE782C4A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DEC389BC-59BC-48E5-B163-6E44CE782C4A}.Debug|x64.Build.0 = Debug|Any CPU
+		{DEC389BC-59BC-48E5-B163-6E44CE782C4A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DEC389BC-59BC-48E5-B163-6E44CE782C4A}.Debug|x86.Build.0 = Debug|Any CPU
+		{DEC389BC-59BC-48E5-B163-6E44CE782C4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DEC389BC-59BC-48E5-B163-6E44CE782C4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEC389BC-59BC-48E5-B163-6E44CE782C4A}.Release|x64.ActiveCfg = Release|Any CPU
+		{DEC389BC-59BC-48E5-B163-6E44CE782C4A}.Release|x64.Build.0 = Release|Any CPU
+		{DEC389BC-59BC-48E5-B163-6E44CE782C4A}.Release|x86.ActiveCfg = Release|Any CPU
+		{DEC389BC-59BC-48E5-B163-6E44CE782C4A}.Release|x86.Build.0 = Release|Any CPU
 		{69824EF3-30F8-4C8A-874E-9B1F5873D25E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{69824EF3-30F8-4C8A-874E-9B1F5873D25E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69824EF3-30F8-4C8A-874E-9B1F5873D25E}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/src/AasxPackageExplorer/AasxPackageExplorer.csproj
+++ b/src/AasxPackageExplorer/AasxPackageExplorer.csproj
@@ -273,6 +273,10 @@
       <Project>{294fc59a-5645-412f-8216-702fb66528c1}</Project>
       <Name>AasxGenerate</Name>
     </ProjectReference>
+    <ProjectReference Include="..\AasxDictionaryImport\AasxDictionaryImport.csproj">
+      <Project>{dec389bc-59bc-48e5-b163-6e44ce782c4a}</Project>
+      <Name>AasxDictionaryImport</Name>
+    </ProjectReference>
     <ProjectReference Include="..\AasxIntegrationBaseWpf\AasxIntegrationBaseWpf.csproj">
       <Project>{e3ab36ea-e98a-4cc2-bc18-1d0e40eeae1a}</Project>
       <Name>AasxIntegrationBaseWpf</Name>

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -431,6 +431,9 @@ namespace AasxPackageExplorer
             if (cmd == "opcuaimportnodeset")
                 CommandBinding_OpcUaImportNodeSet();
 
+            if (cmd == "importsubmodel")
+                CommandBinding_ImportSubmodel();
+
             if (cmd == "importaml")
                 CommandBinding_ImportAML();
 
@@ -1452,6 +1455,44 @@ namespace AasxPackageExplorer
                 }
             }
 
+        }
+
+        public void CommandBinding_ImportSubmodel()
+        {
+            VisualElementAdminShell ve = null;
+            if (DisplayElements.SelectedItem != null)
+            {
+                if (DisplayElements.SelectedItem is VisualElementAdminShell)
+                {
+                    ve = DisplayElements.SelectedItem as VisualElementAdminShell;
+                }
+                else
+                {
+                    MessageBoxFlyoutShow("Please select the administration shell for the submodel import.",
+                        "Submodel Import", MessageBoxButton.OK, MessageBoxImage.Error);
+                    return;
+                }
+            }
+
+            var dataChanged = false;
+            try
+            {
+                if (ve != null && ve.theEnv != null && ve.theAas != null)
+                    dataChanged = AasxDictionaryImport.Import.ImportSubmodel(ve.theEnv, ve.theAas);
+                else
+                    dataChanged = AasxDictionaryImport.Import.ImportSubmodel(thePackageEnv.AasEnv);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "An error occurred during the submodel import.");
+            }
+
+            if (dataChanged)
+            {
+                Mouse.OverrideCursor = System.Windows.Input.Cursors.Wait;
+                RestartUIafterNewPackage();
+                Mouse.OverrideCursor = null;
+            }
         }
 
         public void CommandBinding_ImportAML()

--- a/src/AasxPackageExplorer/MainWindow.xaml
+++ b/src/AasxPackageExplorer/MainWindow.xaml
@@ -40,6 +40,7 @@ The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www
         <RoutedUICommand x:Key="PrintRepo" Text="PrintRepo" />
         <RoutedUICommand x:Key="PrintAsset" Text="PrintAsset" />
         <RoutedUICommand x:Key="ImportAML" Text="ImportAML" />
+        <RoutedUICommand x:Key="ImportSubmodel" Text="ImportSubmodel" />
         <RoutedUICommand x:Key="OPCRead" Text="OPCRead" />
         <RoutedUICommand x:Key="SubmodelWrite" Text="SubmodelWrite" />
         <RoutedUICommand x:Key="SubmodelRead" Text="SubmodelRead" />
@@ -176,6 +177,7 @@ The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www
         <CommandBinding Command="{StaticResource PrintRepo}" Executed="CommandBinding_Executed"/>
         <CommandBinding Command="{StaticResource PrintAsset}" Executed="CommandBinding_Executed"/>
         <CommandBinding Command="{StaticResource ImportAML}" Executed="CommandBinding_Executed"/>
+        <CommandBinding Command="{StaticResource ImportSubmodel}" Executed="CommandBinding_Executed"/>
         <CommandBinding Command="{StaticResource OPCRead}" Executed="CommandBinding_Executed"/>
         <CommandBinding Command="{StaticResource SubmodelWrite}" Executed="CommandBinding_Executed"/>
         <CommandBinding Command="{StaticResource SubmodelRead}" Executed="CommandBinding_Executed"/>
@@ -276,6 +278,7 @@ The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www
                             <MenuItem Header="Import AutomationML into AASX .." Command="{StaticResource ImportAML}"/>
                             <MenuItem Header="Import Submodel from JSON .." Command="{StaticResource SubmodelRead}"/>
                             <MenuItem Header="GET Submodel from URL .." Command="{StaticResource SubmodelGet}"/>
+                            <MenuItem Header="Import Submodel from Dictionary .." Command="{StaticResource ImportSubmodel}"/>
                             <MenuItem Header="Import BMEcat-file into SubModel .." Command="{StaticResource BMEcatImport}"/>
                             <MenuItem Header="Import CSV-file into SubModel .." Command="{StaticResource CSVImport}"/>
                             <MenuItem Header="Import AAS from i4aas-nodeset .." Command="{StaticResource OPCUAi4aasImport}"/>


### PR DESCRIPTION
This patch adds a new project, AasxDictionaryImport, that provides a new
import dialog that can be used to import submodels into an
administration shell.  It provides a generic interface that can be
implemented for different data providers as the IEC CDD or eCl@ss, see
Model.cs.

This patch also includes a first implementation of an import data
provider for the IEC CDD in the Cdd directory.  The IEC CDD data files
should be placed in subfolders of the iec-cdd folder in the working
directory.  Alternatively, the user can chose an import folder at
runtime.

(This commit was originally written by krahlro-sick. It was impossible
to rebase the original commit since the LICENSE.txt's changed too much
in the meanwhile. mristin only re-comitted the changes and fixed the
conflicts.)