### PR TITLE
Add SubmodelElement import interface

### DIFF
--- a/src/AasxDictionaryImport/Cdd/Importer.cs
+++ b/src/AasxDictionaryImport/Cdd/Importer.cs
@@ -60,6 +60,28 @@ namespace AasxDictionaryImport.Cdd
             return true;
         }
 
+        /// <summary>
+        /// Import the given IEC CDD element as a submodel element into the given parent
+        /// element.
+        /// </summary>
+        /// <param name="element">The IEC CDD element to import</param>
+        /// <param name="parent">The parent element to import the submodel into</param>
+        /// <returns>true if the class was imported successfully</returns>
+        public bool ImportSubmodelElements(Model.IElement element, AdminShell.IManageSubmodelElements parent)
+        {
+            if (!element.IsSelected)
+                return false;
+
+            var submodelElement = CreateSubmodelElement(element);
+            if (submodelElement != null)
+            {
+                parent.Add(submodelElement);
+                return true;
+            }
+
+            return false;
+        }
+
         private void AddProperties<T>(T elements, IEnumerable<Model.IElement> properties)
             where T : AdminShellV20.IManageSubmodelElements
         {

--- a/src/AasxDictionaryImport/Cdd/Model.cs
+++ b/src/AasxDictionaryImport/Cdd/Model.cs
@@ -141,6 +141,29 @@ namespace AasxDictionaryImport.Cdd
         {
             return Classes.Select(cls => new ClassWrapper(this, cls)).ToList<Model.IElement>();
         }
+
+        /// <inheritdoc/>
+        public ICollection<Model.IElement> LoadSubmodelElements()
+        {
+            var elements = new List<Model.IElement>();
+            foreach (var element in _elements.Values)
+            {
+                var w = CreateElementWrapper(this, element);
+                if (w != null)
+                    elements.Add(w);
+            }
+            return elements;
+        }
+
+        private static Model.IElement? CreateElementWrapper(Context context, Element element)
+        {
+            if (element is Class cls)
+                return new ClassWrapper(context, cls, null);
+            else if (element is Property property)
+                return new PropertyWrapper(context, property, null);
+            else
+                return null;
+        }
     }
 
     /// <summary>
@@ -232,6 +255,17 @@ namespace AasxDictionaryImport.Cdd
         }
 
         /// <inheritdoc/>
+        public override bool ImportSubmodelElementsInto(AdminShell.AdministrationShellEnv env,
+           AdminShell.IManageSubmodelElements parent)
+        {
+            // If we wanted to import the class, we would typically use the submodel import
+            // instead.  Therefore we import the children instead.
+            var importer = new Importer(env, Context);
+            // We use Count() > 0 instead of Any() to make sure that every element is imported
+            return Children.Count(c => importer.ImportSubmodelElements(c, parent)) > 0;
+        }
+
+        /// <inheritdoc/>
         public override Dictionary<string, string> GetDetails()
         {
             var dict = base.GetDetails();
@@ -278,7 +312,7 @@ namespace AasxDictionaryImport.Cdd
         /// <param name="context">The current data context</param>
         /// <param name="property">The wrapped IEC CDD property</param>
         /// <param name="parent">The parent element</param>
-        public PropertyWrapper(Context context, Property property, Model.IElement parent)
+        public PropertyWrapper(Context context, Property property, Model.IElement? parent)
             : base(context, property, parent)
         {
             Reference<Class>? reference = property.DataType.GetClassReference();
@@ -298,6 +332,13 @@ namespace AasxDictionaryImport.Cdd
             dict.Add("Data Type", Element.RawDataType);
             dict.Add("Format", Element.Format);
             return dict;
+        }
+
+        /// <inheritdoc/>
+        public override bool ImportSubmodelElementsInto(AdminShell.AdministrationShellEnv env,
+           AdminShell.IManageSubmodelElements parent)
+        {
+            return new Importer(env, Context).ImportSubmodelElements(this, parent);
         }
 
         protected override ICollection<Model.IElement> LoadChildren()

--- a/src/AasxDictionaryImport/Import.cs
+++ b/src/AasxDictionaryImport/Import.cs
@@ -17,8 +17,9 @@ using AdminShellNS;
 namespace AasxDictionaryImport
 {
     /// <summary>
-    /// A generic import dialog for submodels.  For the data model, see the Model namespace.  For implementations of
-    /// this data model, see the Cdd namespace.  For the actual dialog, see the ImportDialog.xaml file.
+    /// A generic import dialog for submodels and submodel elements.  For the data model, see the Model namespace.  For
+    /// implementations of this data model, see the Cdd namespace.  For the actual dialog, see the ImportDialog.xaml
+    /// file.
     /// <para>
     /// This project uses nullable types.  Methods may only throw exceptions if they are mentioned in the doc comment.
     /// </para>
@@ -36,7 +37,7 @@ namespace AasxDictionaryImport
     /// <description>fetching data from the network (IEC CDD HTML web service, eCl@ss REST API)</description>
     /// </item>
     /// <item>
-    /// <description>supporting import of properties and concept descriptions</description>
+    /// <description>supporting import of concept descriptions for existing elements</description>
     /// </item>
     /// <item>
     /// <description>better resize handling in ElementDetailsDialog</description>
@@ -50,7 +51,7 @@ namespace AasxDictionaryImport
     }
 
     /// <summary>
-    /// A generic import dialog for submodels.
+    /// A generic import dialog for submodels and submodel elements.
     /// </summary>
     public static class Import
     {
@@ -67,27 +68,41 @@ namespace AasxDictionaryImport
             AdminShellV20.AdministrationShell? adminShell = null)
         {
             adminShell ??= CreateAdminShell(env);
-            var dialog = new ImportDialog();
+            return PerformImport(ImportMode.Submodels, e => e.ImportSubmodelInto(env, adminShell));
+        }
+
+        /// <summary>
+        /// Shows the import dialog and allows the user to select data from a data provider implementation that is
+        /// converted into AAS submodel elements (usually properties and collections) and imported into the given parent
+        /// element (usually a submodel).
+        /// </summary>
+        /// <param name="env">The AAS environment to import into</param>
+        /// <param name="parent">The parent element to import into</param>
+        /// <returns>true if at least one submodel element was imported</returns>
+        public static bool ImportSubmodelElements(AdminShell.AdministrationShellEnv env,
+            AdminShell.IManageSubmodelElements parent)
+        {
+            return PerformImport(ImportMode.SubmodelElements, e => e.ImportSubmodelElementsInto(env, parent));
+        }
+
+        private static bool PerformImport(ImportMode importMode, Func<Model.IElement, bool> f)
+        {
+            var dialog = new ImportDialog(importMode);
             if (dialog.ShowDialog() != true || dialog.Context == null)
                 return false;
-
 
             int imported;
             try
             {
                 Mouse.OverrideCursor = Cursors.Wait;
-                imported = dialog.GetResult().Count(e => e.ImportSubmodelInto(env, adminShell));
+                imported = dialog.GetResult().Count(f);
             }
             finally
             {
                 Mouse.OverrideCursor = null;
             }
 
-            if (dialog.Context.UnknownReferences.Count > 0)
-            {
-                Log.Info($"Found {dialog.Context.UnknownReferences.Count} unknown references during import: " +
-                    string.Join(", ", dialog.Context.UnknownReferences));
-            }
+            CheckUnresolvedReferences(dialog.Context);
 
             return imported > 0;
         }
@@ -105,5 +120,13 @@ namespace AasxDictionaryImport
             return adminShell;
         }
 
+        private static void CheckUnresolvedReferences(Model.IDataContext context)
+        {
+            if (context.UnknownReferences.Count > 0)
+            {
+                Log.Info($"Found {context.UnknownReferences.Count} unknown references during import: " +
+                    string.Join(", ", context.UnknownReferences));
+            }
+        }
     }
 }

--- a/src/AasxDictionaryImport/ImportDialog.xaml
+++ b/src/AasxDictionaryImport/ImportDialog.xaml
@@ -28,11 +28,11 @@
         <DockPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,10" HorizontalAlignment="Stretch">
             <WrapPanel>
                 <Label Content="Source:" Margin="0,0,10,0" VerticalAlignment="Center"/>
-                <ComboBox x:Name="ComboBoxSource" Width="150" Margin="0,0,10,0" SelectionChanged="ComboBoxSource_SelectionChanged" VerticalAlignment="Center"/>
+                <ComboBox x:Name="ComboBoxSource" Width="250" Margin="0,0,10,0" SelectionChanged="ComboBoxSource_SelectionChanged" VerticalAlignment="Center"/>
                 <Button Content="Open Directory" Padding="5,0" Click="ButtonOpenDirectory_Click" VerticalAlignment="Center" Margin="0,0,10,0"/>
             </WrapPanel>
             <WrapPanel HorizontalAlignment="Right">
-                <Label Content="Filter classes: " VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <Label Content="Filter elements: " VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <TextBox TextWrapping="NoWrap" Width="150" Text="{Binding Filter,UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center"/>
             </WrapPanel>
         </DockPanel>

--- a/src/AasxDictionaryImport/Model.cs
+++ b/src/AasxDictionaryImport/Model.cs
@@ -118,9 +118,9 @@ namespace AasxDictionaryImport.Model
     }
 
     /// <summary>
-    /// A collection of elements stored in a data set as a tree.  The LoadSubmodels method can be used to retrieve those
-    /// elements that correspond to AAS submodels, the first level of the tree.  If the data source contains undefined
-    /// references, they will be ignored and recorded in the UnknownReferences collection.
+    /// A collection of elements stored in a data set as a tree.  The LoadSubmodels and LoadSubmodelElements methods can
+    /// be used to retrieve the elements stored in this data set.  If the data source contains undefined references,
+    /// they will be ignored and recorded in the UnknownReferences collection.
     /// </summary>
     public interface IDataContext
     {
@@ -135,6 +135,13 @@ namespace AasxDictionaryImport.Model
         /// </summary>
         /// <returns>A collection of elements corresponding to AAS submodels</returns>
         ICollection<IElement> LoadSubmodels();
+
+        /// <summary>
+        /// Loads and returns those elements that correspond to AAS submodel elements, for example IEC CDD classes and
+        /// properties.
+        /// </summary>
+        /// <returns>A collection of elements corresponding to AAS submodel elements</returns>
+        ICollection<IElement> LoadSubmodelElements();
     }
 
     /// <summary>
@@ -203,6 +210,22 @@ namespace AasxDictionaryImport.Model
         /// converted to an AAS submodel</returns>
         bool ImportSubmodelInto(AdminShellV20.AdministrationShellEnv env,
             AdminShellV20.AdministrationShell adminShell);
+
+        /// <summary>
+        /// Converts this element into a AAS submodel element (i. e. a property or a collection) and adds it to the
+        /// given parent element (typically a submodel).  If this element cannot be converted into a submodel element,
+        /// this method returns false.
+        /// <para>
+        /// Implementations of this method should check the IsSelected attribute both for this element and for all
+        /// children.  Only those elements with IsSelected equals true should be imported.
+        /// </para>
+        /// </summary>
+        /// <param name="env">The admin shell environment for the import</param>
+        /// <param name="parent">The parent element to add the submodel elements to</param>
+        /// <returns>true if the import was successful, or false if the import failed or
+        /// if this element cannot be converted to an AAS submodel element</returns>
+        bool ImportSubmodelElementsInto(AdminShell.AdministrationShellEnv env,
+            AdminShell.IManageSubmodelElements parent);
 
         /// <summary>
         /// Returns all detail information for this element, suitable for the user interface.  The keys of the returned
@@ -373,6 +396,10 @@ namespace AasxDictionaryImport.Model
         /// <inheritdoc/>
         public virtual bool ImportSubmodelInto(AdminShellV20.AdministrationShellEnv env,
             AdminShellV20.AdministrationShell adminShell) => false;
+
+        /// <inheritdoc/>
+        public virtual bool ImportSubmodelElementsInto(AdminShell.AdministrationShellEnv env,
+            AdminShell.IManageSubmodelElements parent) => false;
 
         /// <inheritdoc/>
         public virtual bool Match(IEnumerable<string> queryParts)

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -434,6 +434,9 @@ namespace AasxPackageExplorer
             if (cmd == "importsubmodel")
                 CommandBinding_ImportSubmodel();
 
+            if (cmd == "importsubmodelelements")
+                CommandBinding_ImportSubmodelElements();
+
             if (cmd == "importaml")
                 CommandBinding_ImportAML();
 
@@ -1485,6 +1488,45 @@ namespace AasxPackageExplorer
             catch (Exception e)
             {
                 Log.Error(e, "An error occurred during the submodel import.");
+            }
+
+            if (dataChanged)
+            {
+                Mouse.OverrideCursor = System.Windows.Input.Cursors.Wait;
+                RestartUIafterNewPackage();
+                Mouse.OverrideCursor = null;
+            }
+        }
+
+        public void CommandBinding_ImportSubmodelElements()
+        {
+            AdminShell.AdministrationShellEnv env = null;
+            AdminShell.Submodel submodel = null;
+            if (DisplayElements.SelectedItem is VisualElementSubmodel ves)
+            {
+                env = ves.theEnv;
+                submodel = ves.theSubmodel;
+            }
+            else if (DisplayElements.SelectedItem is VisualElementSubmodelRef vesr)
+            {
+                env = vesr.theEnv;
+                submodel = vesr.theSubmodel;
+            }
+            else
+            {
+                MessageBoxFlyoutShow("Please select the submodel for the submodel element import.",
+                    "Submodel Element Import", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            var dataChanged = false;
+            try
+            {
+                dataChanged = AasxDictionaryImport.Import.ImportSubmodelElements(env, submodel);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "An error occurred during the submodel element import.");
             }
 
             if (dataChanged)

--- a/src/AasxPackageExplorer/MainWindow.xaml
+++ b/src/AasxPackageExplorer/MainWindow.xaml
@@ -41,6 +41,7 @@ The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www
         <RoutedUICommand x:Key="PrintAsset" Text="PrintAsset" />
         <RoutedUICommand x:Key="ImportAML" Text="ImportAML" />
         <RoutedUICommand x:Key="ImportSubmodel" Text="ImportSubmodel" />
+        <RoutedUICommand x:Key="ImportSubmodelElements" Text="ImportSubmodelElements" />
         <RoutedUICommand x:Key="OPCRead" Text="OPCRead" />
         <RoutedUICommand x:Key="SubmodelWrite" Text="SubmodelWrite" />
         <RoutedUICommand x:Key="SubmodelRead" Text="SubmodelRead" />
@@ -178,6 +179,7 @@ The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www
         <CommandBinding Command="{StaticResource PrintAsset}" Executed="CommandBinding_Executed"/>
         <CommandBinding Command="{StaticResource ImportAML}" Executed="CommandBinding_Executed"/>
         <CommandBinding Command="{StaticResource ImportSubmodel}" Executed="CommandBinding_Executed"/>
+        <CommandBinding Command="{StaticResource ImportSubmodelElements}" Executed="CommandBinding_Executed"/>
         <CommandBinding Command="{StaticResource OPCRead}" Executed="CommandBinding_Executed"/>
         <CommandBinding Command="{StaticResource SubmodelWrite}" Executed="CommandBinding_Executed"/>
         <CommandBinding Command="{StaticResource SubmodelRead}" Executed="CommandBinding_Executed"/>
@@ -279,6 +281,7 @@ The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www
                             <MenuItem Header="Import Submodel from JSON .." Command="{StaticResource SubmodelRead}"/>
                             <MenuItem Header="GET Submodel from URL .." Command="{StaticResource SubmodelGet}"/>
                             <MenuItem Header="Import Submodel from Dictionary .." Command="{StaticResource ImportSubmodel}"/>
+                            <MenuItem Header="Import Submodel Elements from Dictionary .." Command="{StaticResource ImportSubmodelElements}"/>
                             <MenuItem Header="Import BMEcat-file into SubModel .." Command="{StaticResource BMEcatImport}"/>
                             <MenuItem Header="Import CSV-file into SubModel .." Command="{StaticResource CSVImport}"/>
                             <MenuItem Header="Import AAS from i4aas-nodeset .." Command="{StaticResource OPCUAi4aasImport}"/>


### PR DESCRIPTION
Previously, we introduced the AasxDictionaryImport project that provides
a generic import dialog for submodels.  This patch introduces a new
import mode that can be used to import submodel elements in to the AAS
environment.

The main differences are:
- IEC CDD classes are converted to AAS collections.
- IEC CDD properties are converted to AAS properties or collections.
- The import dialog will not only list the top-level elements
  (corresponding to submodels), but also all other elements available
  in the data set.

The import can be triggered from the File -> Import menu.

(This commit was originally written by krahlro-sick. It was impossible
to rebase the original commit since the LICENSE.txt's changed too much
in the meanwhile. mristin only re-comitted the changes and fixed the
conflicts.)