### PR TITLE
Include all plug-ins in the release

### DIFF
--- a/src/BuildForRelease.ps1
+++ b/src/BuildForRelease.ps1
@@ -44,7 +44,10 @@ function Main
         "AasxPluginDocumentShelf",
         "AasxPluginExportTable",
         "AasxPluginGenericForms",
+        "AasxPluginMtpViewer",
         "AasxPluginTechnicalData",
+        "AasxPluginUaNetClient",
+        "AasxPluginUaNetServer",
         "AasxPluginWebBrowser"
         )
 

--- a/src/PackageRelease.ps1
+++ b/src/PackageRelease.ps1
@@ -29,13 +29,16 @@ function PackageRelease($outputDir)
     ##
     # Define plugins
     ##
-
+    
     $portableSmallPlugins = $(
     "AasxPluginBomStructure",
     "AasxPluginDocumentShelf",
     "AasxPluginExportTable",
     "AasxPluginGenericForms",
-    "AasxPluginTechnicalData"
+    "AasxPluginMtpViewer",
+    "AasxPluginTechnicalData",
+    "AasxPluginUaNetClient",
+    "AasxPluginUaNetServer"
     )
 
     $portablePlugins = $portableSmallPlugins.Clone()


### PR DESCRIPTION
This change includes all the existing plug-ins in the release.
Previously, only a subset was included since the move from GitLab.