### PR TITLE
Handle free and non-free IEC CDD attributes

### DIFF
--- a/src/AasxDictionaryImport/Cdd/Data.cs
+++ b/src/AasxDictionaryImport/Cdd/Data.cs
@@ -76,14 +76,17 @@ namespace AasxDictionaryImport.Cdd
         /// <summary>
         /// Returns the IEC 61360 attributes for this element.
         /// </summary>
+        /// <param name="all">Whether all attributes or only the free attributes should be used</param>
         /// <returns>The IEC 61360 data for this element</returns>
-        public virtual Iec61360Data GetIec61360Data()
+        public virtual Iec61360Data GetIec61360Data(bool all)
         {
-            return new Iec61360Data(FormatIrdi(Code, Version))
+            var data = new Iec61360Data(FormatIrdi(Code, Version))
             {
                 PreferredName = PreferredName,
-                Definition = Definition
             };
+            if (all)
+                data.Definition = Definition;
+            return data;
         }
 
         /// <summary>
@@ -266,10 +269,11 @@ namespace AasxDictionaryImport.Cdd
             return properties;
         }
 
-        public override Iec61360Data GetIec61360Data()
+        public override Iec61360Data GetIec61360Data(bool all)
         {
-            var data = base.GetIec61360Data();
-            data.DefinitionSource = DefinitionSource;
+            var data = base.GetIec61360Data(all);
+            if (all)
+                data.DefinitionSource = DefinitionSource;
             return data;
         }
 
@@ -328,16 +332,19 @@ namespace AasxDictionaryImport.Cdd
             return new Property(this, dataType);
         }
 
-        public override Iec61360Data GetIec61360Data()
+        public override Iec61360Data GetIec61360Data(bool all)
         {
-            var data = base.GetIec61360Data();
-            data.ShortName = ShortName;
-            data.DefinitionSource = DefinitionSource;
-            data.Symbol = Symbol;
+            var data = base.GetIec61360Data(all);
             data.Unit = PrimaryUnit;
             data.UnitIrdi = UnitCode;
-            data.DataType = RawDataType;
             data.DataFormat = Format;
+            data.Symbol = Symbol;
+            if (all)
+            {
+                data.ShortName = ShortName;
+                data.DefinitionSource = DefinitionSource;
+                data.DataType = RawDataType;
+            }
             return data;
         }
 

--- a/src/AasxDictionaryImport/Cdd/Importer.cs
+++ b/src/AasxDictionaryImport/Cdd/Importer.cs
@@ -32,6 +32,7 @@ namespace AasxDictionaryImport.Cdd
     {
         private readonly AdminShellV20.AdministrationShellEnv _env;
         private readonly Context _context;
+        private readonly bool _all;
 
         /// <summary>
         /// Creates a new IEC CDD Importer.
@@ -42,6 +43,7 @@ namespace AasxDictionaryImport.Cdd
         {
             _env = env;
             _context = context;
+            _all = context.DataSource.ImportAllAttributes;
         }
 
         /// <summary>
@@ -55,7 +57,7 @@ namespace AasxDictionaryImport.Cdd
             if (!cls.IsSelected)
                 return false;
 
-            var submodel = Iec61360Utils.CreateSubmodel(_env, adminShell, cls.Element.GetIec61360Data());
+            var submodel = Iec61360Utils.CreateSubmodel(_env, adminShell, cls.Element.GetIec61360Data(_all));
             AddProperties(submodel, cls.Children);
             return true;
         }
@@ -108,7 +110,7 @@ namespace AasxDictionaryImport.Cdd
         private AdminShellV20.SubmodelElementCollection CreatePropertyCollection(Class cls,
             IEnumerable<Model.IElement> properties)
         {
-            var collection = Iec61360Utils.CreateCollection(_env, cls.GetIec61360Data());
+            var collection = Iec61360Utils.CreateCollection(_env, cls.GetIec61360Data(_all));
             AddProperties(collection, properties);
             return collection;
         }
@@ -132,7 +134,7 @@ namespace AasxDictionaryImport.Cdd
         private AdminShellV20.SubmodelElementCollection CreateAggregateCollection(
             PropertyWrapper wrapper, AggregateType aggregateType)
         {
-            var collection = Iec61360Utils.CreateCollection(_env, wrapper.Element.GetIec61360Data());
+            var collection = Iec61360Utils.CreateCollection(_env, wrapper.Element.GetIec61360Data(_all));
 
             if (wrapper.Children.Count == 1)
             {
@@ -156,7 +158,7 @@ namespace AasxDictionaryImport.Cdd
 
         private AdminShellV20.SubmodelElementCollection CreateLevelCollection(Property property, LevelType levelType)
         {
-            var data = property.GetIec61360Data();
+            var data = property.GetIec61360Data(_all);
             var collection = Iec61360Utils.CreateCollection(_env, data);
 
             foreach (var levelValue in levelType.Types)
@@ -170,7 +172,7 @@ namespace AasxDictionaryImport.Cdd
 
         private AdminShellV20.Property CreateProperty(Property property)
         {
-            return Iec61360Utils.CreateProperty(_env, property.GetIec61360Data(),
+            return Iec61360Utils.CreateProperty(_env, property.GetIec61360Data(_all),
                 GetValueType(property.DataType));
         }
 

--- a/src/AasxDictionaryImport/Cdd/Model.cs
+++ b/src/AasxDictionaryImport/Cdd/Model.cs
@@ -50,6 +50,12 @@ namespace AasxDictionaryImport.Cdd
         private Context? _context;
 
         /// <summary>
+        /// Determines whether all available IEC CDD attributes should be imported into the AAS environment, or whether
+        /// the import should be restricted to the free attributes (default).
+        /// </summary>
+        public bool ImportAllAttributes { get; set; } = false;
+
+        /// <summary>
         /// Creates a new IEC CDD DataSource object.
         /// </summary>
         /// <param name="dataProvider">The IEC CDD data provider</param>

--- a/src/AasxDictionaryImport/ImportDialog.xaml
+++ b/src/AasxDictionaryImport/ImportDialog.xaml
@@ -13,6 +13,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="5*"/>
@@ -70,7 +71,11 @@
             </TreeView.Resources>
         </TreeView>
 
-        <WrapPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,10,0,0" HorizontalAlignment="Right">
+        <CheckBox x:Name="CheckBoxAllIecCddAttributes" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,10,0,10" HorizontalAlignment="Left"
+                  Visibility="Hidden" Content="Import all attributes from the IEC CDD"
+                  Click="CheckBoxAllIecCddAttributes_Click"/>
+
+        <WrapPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,10,0,0" HorizontalAlignment="Right">
             <Button Content="Cancel" Width="75" Margin="0,0,10,0" IsCancel="True"/>
             <Button x:Name="ButtonImport" Content="Import" Width="75" IsDefault="True" IsEnabled="False" Click="ButtonImport_Click"/>
         </WrapPanel>

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -196,6 +196,8 @@ namespace AasxDictionaryImport
 
                     if (ClassViewControl.Items.Count > 0)
                         ClassViewControl.SelectedItem = ClassViewControl.Items[0];
+                    CheckBoxAllIecCddAttributes.Visibility = (source.DataProvider is Cdd.DataProvider) ?
+                        Visibility.Visible : Visibility.Hidden;
                 }
                 catch (Model.ImportException ex)
                 {
@@ -249,6 +251,24 @@ namespace AasxDictionaryImport
                 var dialog = new ElementDetailsDialog(element);
                 dialog.Show();
                 dialog.Activate();
+            }
+        }
+
+        private void CheckBoxAllIecCddAttributes_Click(object sender, RoutedEventArgs e)
+        {
+            if (ComboBoxSource.SelectedItem is Cdd.DataSource source)
+                source.ImportAllAttributes = CheckBoxAllIecCddAttributes.IsChecked == true;
+
+            if (CheckBoxAllIecCddAttributes.IsChecked == true)
+            {
+                if (MessageBox.Show(
+                    "Only the free IEC CDD attributes may be used without restrictions. Please read the End User " +
+                    "License Agreement for IEC Common Data Dictionary (CDD) for more information. Do you want to " +
+                    "open the EULA now?",
+                    "IEC CDD Import", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
+                {
+                    System.Diagnostics.Process.Start("https://cdd.iec.ch/CDD/iec61360/iec61360.nsf/License?openPage");
+                }
             }
         }
     }


### PR DESCRIPTION
Only some IEC CDD attributes are free and can be used without
restrictions.  Previously, we did not distinguish free and non-free
attributes.  With this patch, we only import the free attributes per
default.  If the user wants to import all attributes, they have to
activate a check box in the import dialog.  If they activate this check
box, a warning dialog mentioning the IEC CDD EULA is shown.