### PR TITLE
Add timestamp to latest build artefacts in CI

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Set timestamp
+        id: setTimestamp
+        run: |
+          $timestamp = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH-mm-ssZ")
+          Write-Output "::set-output name=timestamp::$timestamp"
+
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.0
         with:
@@ -40,16 +46,30 @@ jobs:
 
       - name: Package
         working-directory: src
-        run: powershell .\PackageRelease.ps1 -version LATEST.alpha
+        run: |
+          powershell .\PackageRelease.ps1 -version LATEST.alpha
+          $timestamp = '${{ steps.setTimestamp.outputs.timestamp }}'
+
+          # Add a timestamp to make it easier for users to identify different
+          # versions
+
+          $latestDir = "..\artefacts\release\LATEST.alpha"
+          Move-Item `
+                -Path (Join-Path $latestDir "portable.zip") `
+                -Destination (Join-Path $latestDir "portable.$timestamp.zip")
+
+          Move-Item `
+                -Path (Join-Path $latestDir "portable-small.zip") `
+                -Destination (Join-Path $latestDir "portable-small.$timestamp.zip")
 
       - name: Upload latest-portable
         uses: actions/upload-artifact@v2
         with:
           name: portable.LATEST.alpha
-          path: artefacts/release/LATEST.alpha/portable.zip
+          path: artefacts/release/LATEST.alpha/portable.${{ steps.setTimestamp.outputs.timestamp }}.zip
 
       - name: Upload latest-portable-small
         uses: actions/upload-artifact@v2
         with:
           name: portable-small.LATEST.alpha
-          path: artefacts/release/LATEST.alpha/portable-small.zip
+          path: artefacts/release/LATEST.alpha/portable-small.${{ steps.setTimestamp.outputs.timestamp }}.zip


### PR DESCRIPTION
Through this change, the file names of the build artefacts in
check-release workflow are appended a timestamp so that the users can
distinguish different versions.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.