### PR TITLE
Rename `portable` to `aasx-package-explorer` in CI

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -48,14 +48,14 @@ jobs:
         working-directory: src
         run: powershell .\PackageRelease.ps1 -version LATEST.alpha
 
-      - name: Upload latest-portable
+      - name: Upload latest
         uses: actions/upload-artifact@v2
         with:
-          name: portable.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/portable.zip
+          name: aasx-package-explorer.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/aasx-package-explorer.zip
 
-      - name: Upload latest-portable-small
+      - name: Upload latest small
         uses: actions/upload-artifact@v2
         with:
-          name: portable-small.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/portable-small.zip
+          name: aasx-package-explorer-small.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/aasx-package-explorer-small.zip

--- a/src/PackageRelease.ps1
+++ b/src/PackageRelease.ps1
@@ -30,7 +30,7 @@ function PackageRelease($outputDir)
     # Define plugins
     ##
     
-    $portableSmallPlugins = $(
+    $smallPlugins = $(
     "AasxPluginBomStructure",
     "AasxPluginDocumentShelf",
     "AasxPluginExportTable",
@@ -41,8 +41,8 @@ function PackageRelease($outputDir)
     "AasxPluginUaNetServer"
     )
 
-    $portablePlugins = $portableSmallPlugins.Clone()
-    $portablePlugins += "AasxPluginWebBrowser"
+    $allPlugins = $smallPlugins.Clone()
+    $allPlugins += "AasxPluginWebBrowser"
 
     function MakePackage($identifier, $plugins)
     {
@@ -102,9 +102,9 @@ function PackageRelease($outputDir)
     # Make packages
     ##
 
-    MakePackage -identifier "portable" -plugins $portablePlugins
+    MakePackage -identifier "aasx-package-explorer" -plugins $allPlugins
 
-    MakePackage -identifier "portable-small" -plugins $portableSmallPlugins
+    MakePackage -identifier "aasx-package-explorer-small" -plugins $smallPlugins
 
     # Do not copy the source code in the releases.
     # The source code will be distributed automatically through Github releases.


### PR DESCRIPTION
The name `portable` is not really informative. In particular, a user
browsing his/her `Downloads` directory might be confused. Hence we
rename the artefacts to `aasx-package-explorer` and
`aasx-package-explorer-small` for easier identification.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.