### PR TITLE
Fix quotes issues when checking local commits

### DIFF
--- a/src/CheckPushCommitMessages.ps1
+++ b/src/CheckPushCommitMessages.ps1
@@ -40,8 +40,7 @@ function Main
         Write-Host "--- Verifying the message: ---"
         Write-Host $message
         Write-Host "---"
-        powershell `
-            -File OpinionatedCommitMessage.ps1 `
+        & ./OpinionatedCommitMessage.ps1 `
             -message $message `
             -pathToAdditionalVerbs AdditionalVerbsInImperativeMood.txt
     }


### PR DESCRIPTION
The quotes were not correctly interpreted in
`CheckPushCommitMessages.ps1`: they were not properly escaped by
powershell so the commit checker received only a part of the message.

This patch fixes the issue by properly invoking the checker script from
within `CheckPushCommitMessages.ps1`.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.