### PR TITLE
Add "integrate" to additional commit verbs

### DIFF
--- a/src/AdditionalVerbsInImperativeMood.txt
+++ b/src/AdditionalVerbsInImperativeMood.txt
@@ -11,3 +11,4 @@ assign
 standardize
 verbosify
 log
+integrate


### PR DESCRIPTION
The current version (2.1.2) of the commit message checker lacked
"integrate" in its whitelist of verbs in imperative mood. This patch
adds the verb to the additional whitelist specific to this project.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.