### PR TITLE
Instruct how to fix issues with commit checks

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -11,6 +11,17 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v2.1.2
+        uses: mristin/opinionated-commit-message@v2.2.0
         with:
           path-to-additional-verbs: src/AdditionalVerbsInImperativeMood.txt
+
+      - name: READ HERE ON FAILURE FOR MORE INSTRUCTIONS
+        if: ${{ failure() }}
+        run: |
+          Write-Host (
+            "The title and the description of your pull request do not fit our style guide. " +
+            "Please inspect carefully the error messages above and edit the pull request. " +
+            "Since we are always squashing before merge, you can leave the commit messages as-are.`n`n" +
+            "See the following page for more information about the style guide: " +
+            "https://admin-shell-io.github.io/aasx-package-explorer/devdoc/getting-started/development-workflow.html#pull-requests"
+          )

--- a/src/CheckPushCommitMessages.ps1
+++ b/src/CheckPushCommitMessages.ps1
@@ -40,9 +40,25 @@ function Main
         Write-Host "--- Verifying the message: ---"
         Write-Host $message
         Write-Host "---"
-        & ./OpinionatedCommitMessage.ps1 `
-            -message $message `
-            -pathToAdditionalVerbs AdditionalVerbsInImperativeMood.txt
+        try
+        {
+            & ./OpinionatedCommitMessage.ps1 `
+                -message $message `
+                -pathToAdditionalVerbs AdditionalVerbsInImperativeMood.txt
+        }
+        catch
+        {
+            Write-Host
+            Write-Host (
+                "`u{1F4A5} `u{26A1} ATTENTION! `u{26A1} `u{1F4A5}`n`n" +
+                "The commit message failed the check. Since we are squashing before the commit, " +
+                "make sure that the title and description of your pull request (and *not* the commits) " +
+                "are valid.`n`n" +
+                "This check is intended to save you time if you have a single commit which " +
+                "will be used by GitHub to automatically generate the title and the description " +
+                "of the pull request."
+            )
+        }
     }
 }
 


### PR DESCRIPTION
So far, the commit message checker reported the issues but the
contributors were left in the dark how to actually fix the issues.

This patch upgrades the checker to 2.2.0 (for more verbose messages)
and hints to the contributor that the pull request (and *not* the
commit message) needs to be changed.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.