### PR TITLE
Instruct developer to look closer on failed checks

### DIFF
--- a/src/CheckBiteSized.ps1
+++ b/src/CheckBiteSized.ps1
@@ -35,7 +35,10 @@ function Main {
 
     if($LASTEXITCODE -ne 0)
     {
-        throw "The bite-sized check failed."
+        throw (
+            "The bite-sized check failed. " +
+            "Please have a close look at the output above."
+        )
     }
 }
 

--- a/src/CheckDeadCode.ps1
+++ b/src/CheckDeadCode.ps1
@@ -19,7 +19,10 @@ function Main
     dotnet dead-csharp --inputs "**/*.cs" --excludes "**/obj/**" "packages/**" "**/Properties/**"
     if($LASTEXITCODE -ne 0)
     {
-        throw "The dead-csharp check failed."
+        throw (
+            "The dead-csharp check failed. " +
+            "Please have a close look at the output above."
+        )
     }
 }
 

--- a/src/CheckFormat.ps1
+++ b/src/CheckFormat.ps1
@@ -24,8 +24,11 @@ function Main
     $formatReport = Get-Content $reportPath |ConvertFrom-Json
     if ($formatReport.Count -ge 1)
     {
-        throw "There are $( $formatReport.Count ) dotnet-format issue(s). " +  `
-             "The report is stored in: $reportPath"
+        throw (
+            "There are $( $formatReport.Count ) dotnet-format issue(s). " +
+            "The report is stored in: $reportPath. " +
+            "Please reformat the code with FormatCode.ps1."
+        )
     }
 }
 

--- a/src/CheckTodos.ps1
+++ b/src/CheckTodos.ps1
@@ -20,7 +20,10 @@ function Main
         --excludes 'packages/**' '**/obj/**' 'MsaglWpfControl/**'
     if($LASTEXITCODE -ne 0)
     {
-        throw "Failed to validate the TODOs in the code."
+        throw (
+            "The opinionated-csharp-todos check failed. " +
+            "Please have a close look at the output above."
+        )
     }
 }
 

--- a/src/InspectCode.ps1
+++ b/src/InspectCode.ps1
@@ -80,8 +80,15 @@ function Main
             Write-Host "... and some more issues ($( $issues.Count ) in total)."
         }
 
-        throw "There are $( $issues.Count ) InspectCode issue(s). " +      `
-                 "The issues are stored in: $codeInspectionPath"
+        throw (
+            "There are $( $issues.Count ) InspectCode issue(s). " +
+            "The issues are stored in: $codeInspectionPath. " +
+            "Please fix the issues either manually or semi-automatically " +
+            "using an IDE such as Rider (https://www.jetbrains.com/rider/ and " +
+            "https://www.jetbrains.com/help/resharper/Code_Analysis__Quick-Fixes.html). " +
+            "For the information about individual issues, have a look at: " +
+            "https://www.jetbrains.com/help/resharper/Reference__Code_Inspections_CSHARP.html#BestPractice"
+        )
     }
 }
 


### PR DESCRIPTION
This patch points the developer to have a closer look at the output of
the previous check. This is important since many users simply focus on
the error message ("something failed") and do not intuitively look up at
the previous output.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.