### PR TITLE
Refine failure messages in Check*.ps1

### DIFF
--- a/src/AdditionalVerbsInImperativeMood.txt
+++ b/src/AdditionalVerbsInImperativeMood.txt
@@ -14,3 +14,4 @@ log
 integrate
 enhance
 untrack
+refine

--- a/src/CheckBiteSized.ps1
+++ b/src/CheckBiteSized.ps1
@@ -37,7 +37,8 @@ function Main {
     {
         throw (
             "The bite-sized check failed. " +
-            "Please have a close look at the output above."
+            "Please have a close look at the output above, " +
+            "in particular the lines prefixed with `"FAIL`"."
         )
     }
 }

--- a/src/CheckDeadCode.ps1
+++ b/src/CheckDeadCode.ps1
@@ -21,7 +21,8 @@ function Main
     {
         throw (
             "The dead-csharp check failed. " +
-            "Please have a close look at the output above."
+            "Please have a close look at the output above, " +
+            "in particular the lines prefixed with `"FAIL`"."
         )
     }
 }

--- a/src/CheckTodos.ps1
+++ b/src/CheckTodos.ps1
@@ -22,7 +22,8 @@ function Main
     {
         throw (
             "The opinionated-csharp-todos check failed. " +
-            "Please have a close look at the output above."
+            "Please have a close look at the output above, " +
+            "in particular the lines prefixed with `"FAILED`"."
         )
     }
 }


### PR DESCRIPTION
The current message did not point the reader to lines beginning with
`FAIL`, so that the focus was lost on a large number of `OK` lines.
This patch tells the reader to explicitly look for `FAIL` lines.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.