### PR TITLE
Explain how to fix missing samples in Test.ps1

### DIFF
--- a/src/Test.ps1
+++ b/src/Test.ps1
@@ -30,13 +30,14 @@ function Main
     $samplesDir = GetSamplesDir
     if(!(Test-Path $samplesDir))
     {
-        throw ("The directory containing samples could not be found: " +
-                "$samplesDir; these samples are necessary to " +
-                "perform the integration tests.")
+        throw (
+            "The directory containing samples could not be found: " +
+            "$samplesDir; these samples are necessary to " +
+            "perform the integration tests. " +
+            "Did you maybe forget to download them with DownloadSamples.ps1?"
+        )
     }
-
-
-
+    
     # Glob test DLLs relative to $targetDir
     $testDlls = Get-ChildItem `
         -Path (Join-Path $targetDir "*.Tests.dll") `


### PR DESCRIPTION
The current error message in Test.ps1 merely reported that the samples
are missing, but the user was left at loss how to obtain them. This
patch points the user to use the download script.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.