### PR TITLE
Give an example commit in docdev

### DIFF
--- a/docdev/docfx_project/getting-started/development-workflow.md
+++ b/docdev/docfx_project/getting-started/development-workflow.md
@@ -28,21 +28,22 @@ https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/cr
 actions. The CI includes building the solution, running the test, inspecting
 the code *etc.* (see below the section "Pre-merge Checks").
 
-Please note that running the Github actions consumes limited resources (we have only 2,000 minutes
-per month available for CI on our current Github plan). You can manually disable workflows
-by appending the following lines to the body of the pull request:
+Please note that running the Github actions consumes computational resources
+which is often unnecessary if you are certain that some checks are not needed.
+For example, there is no need to build the whole solution if you only make a
+minor change in a powershell Script unrelated to building. 
+You can manually disable workflows by appending the following lines 
+to the body of the pull request (corresponding to which checks you want to
+disable):
+
 * `The workflow build-test-inspect was intentionally skipped.`
 * `The workflow check-style was intentionally skipped.`
 * `The workflow check-release was intentionally skipped.`
 
-For an example, see [this pull request](
-https://github.com/admin-shell-io/aasx-package-explorer/pull/94
-).
-
 ## Commit Messages
 
 The commit messages follow the guidelines from 
-from https://chris.beams.io/posts/git-commit:
+https://chris.beams.io/posts/git-commit:
 
 * Separate subject from body with a blank line
 * Limit the subject line to 50 characters
@@ -55,6 +56,22 @@ from https://chris.beams.io/posts/git-commit:
 We automatically check the commit messages using [opinionated-commit-message](
 https://github.com/mristin/opinionated-commit-message
 ).
+
+Here is an example commit message (from [this pull request](
+https://github.com/admin-shell-io/aasx-package-explorer/pull/208
+)):
+
+```
+Make DownloadSamples.ps1 use default proxy
+
+Using the default proxy is necessary so that DownloadSamples.ps1 can
+operate on enterprise networks which restrict the network traffic
+through the proxy.
+
+The workflow build-test-inspect was intentionally skipped.
+The workflow check-style was intentionally skipped.
+The workflow check-release was intentionally skipped.
+```
 
 ## Large Binary Files
 


### PR DESCRIPTION
There was an example missing in the docdev how to write a commit
message, so the readers were presented only the rules. This patch
copy/pastes the message of an existing correct pull request.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.