### PR TITLE
Make outputs of Check.ps1 visually distinguishable

### DIFF
--- a/src/Check.ps1
+++ b/src/Check.ps1
@@ -5,27 +5,189 @@ This script runs all the pre-merge checks locally.
 
 $ErrorActionPreference = "Stop"
 
-function LogAndExecute($Expression)
+Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
+    CreateAndGetArtefactsDir
+
+function IsISE {
+    try {
+        return $null -ne $psISE;
+    }
+    catch {
+        return $false;
+    }
+}
+
+function LogAndExecute($Expression, $Timestamp, $ForegroundColor, $Emoji)
 {
     Write-Host "---"
     Write-Host "Running: $Expression"
     Write-Host "---"
 
-    Invoke-Expression $Expression
+    if (IsISE)
+    {
+        $symbol = $Emoji
+    }
+    else
+    {
+        $symbol = ""
+    }
+
+    if ($Expression.StartsWith("./Check"))
+    {
+        $title = $Expression -replace '^./Check([a-zA-Z_0-9-]+)\.ps1.*$', '$1'
+    }
+    elseif ($Expression.StartsWith("./Doctest"))
+    {
+        $title = "Doctest"
+    }
+    elseif ($Expression.StartsWith("./Build"))
+    {
+        $title = "Build"
+    }
+    elseif ($Expression.StartsWith("./Test"))
+    {
+        $title = "Test"
+    }
+    elseif ($Expression.StartsWith("./InspectCode"))
+    {
+        $title = "Inspect"
+    }
+    else
+    {
+        throw "Unhandled title for the expression: $($Expression|ConvertTo-Json)"
+    }
+
+    & powershell $Expression|ForEach-Object {
+        Write-Host -ForegroundColor $ForegroundColor -BackgroundColor White `
+            -NoNewline "$symbol${title}:${Timestamp}:"
+        Write-Host " $_"
+    }
+}
+
+function PickColor($ArtefactsDir) {
+    $colorPath = Join-Path $ArtefactsDir "CheckLastColor.txt"
+    if (Test-Path $colorPath)
+    {
+        $lastColor = Get-Content $colorPath
+    }
+    else
+    {
+        $lastColor = ""
+    }
+    
+    $colors = @(
+    "Black",
+    "DarkBlue",
+    "DarkGreen",
+    "DarkCyan",
+    "DarkMagenta",
+    "DarkGray",
+    "Blue",
+    "Magenta"
+    )
+
+    $lastColorIndex = [array]::indexof($colors, $lastColor)
+    if ($lastColorIndex -eq -1)
+    {
+        $lastColorIndex = 0
+    }
+    $colorIndex = ($lastColorIndex + 1) % $colors.Length
+    $color = $colors[$colorIndex]
+
+    Set-Content -Path $colorPath -Value $color
+    
+    return $color
+}
+
+function PickEmoji($ArtefactsDir)
+{
+    $emojiPath = Join-Path $ArtefactsDir "CheckLastEmoji.txt"
+    if (Test-Path $emojiPath)
+    {
+        $lastEmoji = (Get-Content $emojiPath) -as [int]
+    }
+    else
+    {
+        $lastEmoji = 0
+    }
+    
+    $emojis = @(
+    0x1F916,
+    0x1F600,
+    0x1F921,
+    0x1F63A,
+    0x1F44A,
+    0x1F47E,
+    0x1F91E,
+    0x1f64f,
+    0x1f4aa,
+    0x1f440
+    )
+
+    $lastEmojiIndex = [array]::indexof($emojis, $lastEmoji)
+    if ($lastEmojiIndex -eq -1)
+    {
+        $lastEmojiIndex = 0
+    }
+    $emojiIndex = ($lastEmojiIndex + 1) % $emojis.Length
+    $emoji = $emojis[$emojiIndex]
+
+    Set-Content -Path $emojiPath -Value $emoji.ToString()
+
+    return [char]::ConvertFromUtf32($emoji)
 }
 
 function Main
 {
-    LogAndExecute "$(Join-Path $PSScriptRoot "CheckPushCommitMessages.ps1")"
-    LogAndExecute "$(Join-Path $PSScriptRoot "CheckLicenses.ps1")"
-    LogAndExecute "$(Join-Path $PSScriptRoot "CheckFormat.ps1")"
-    LogAndExecute "$(Join-Path $PSScriptRoot "CheckBiteSized.ps1")"
-    LogAndExecute "$(Join-Path $PSScriptRoot "CheckDeadCode.ps1")"
-    LogAndExecute "$(Join-Path $PSScriptRoot "CheckTodos.ps1")"
-    LogAndExecute "$(Join-Path $PSScriptRoot "Doctest.ps1") -check"
-    LogAndExecute "$(Join-Path $PSScriptRoot "BuildForDebug.ps1")"
-    LogAndExecute "$(Join-Path $PSScriptRoot "Test.ps1")"
-    LogAndExecute "$(Join-Path $PSScriptRoot "InspectCode.ps1")"
+    Set-Location $PSScriptRoot
+
+    $artefactsDir = CreateAndGetArtefactsDir
+    $foregroundColor = PickColor -ArtefactsDir $artefactsDir
+    $emoji = PickEmoji -ArtefactsDir $artefactsDir
+    $timestamp = [DateTime]::Now.ToString('HH:mm:ss')
+
+    LogAndExecute `
+        -Expression "./CheckLicenses.ps1" `
+        -Timestamp $timestamp -ForegroundColor $foregroundColor -Emoji $emoji
+
+    LogAndExecute `
+        -Expression "./CheckFormat.ps1" `
+        -Timestamp $timestamp -ForegroundColor $foregroundColor -Emoji $emoji
+
+    LogAndExecute `
+        -Expression "./CheckBiteSized.ps1" `
+        -Timestamp $timestamp -ForegroundColor $foregroundColor -Emoji $emoji
+
+    LogAndExecute  `
+        -Expression "./CheckDeadCode.ps1" `
+        -Timestamp $timestamp -ForegroundColor $foregroundColor -Emoji $emoji
+
+    LogAndExecute  `
+        -Expression "./CheckTodos.ps1" `
+        -Timestamp $timestamp -ForegroundColor $foregroundColor -Emoji $emoji
+
+    LogAndExecute  `
+        -Expression "./Doctest.ps1 -check" `
+        -Timestamp $timestamp -ForegroundColor $foregroundColor -Emoji $emoji
+
+    LogAndExecute  `
+        -Expression "./BuildForDebug.ps1" `
+        -Timestamp $timestamp -ForegroundColor $foregroundColor -Emoji $emoji
+
+    LogAndExecute  `
+        -Expression "./Test.ps1" `
+        -Timestamp $timestamp -ForegroundColor $foregroundColor -Emoji $emoji
+
+    LogAndExecute  `
+        -Expression "./InspectCode.ps1" `
+        -Timestamp $timestamp -ForegroundColor $foregroundColor -Emoji $emoji
+
+    LogAndExecute `
+        -Expression "./CheckPushCommitMessages.ps1" `
+        -Timestamp $timestamp -ForegroundColor $foregroundColor -Emoji $emoji
+
+    Write-Host
+    Write-Host "All checks passed successfully. You can now push the commits."
 }
 
 $previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }

--- a/src/CheckPushCommitMessages.ps1
+++ b/src/CheckPushCommitMessages.ps1
@@ -12,6 +12,10 @@ We use `git` CLI to obtain the commit messages contained in the next (potential)
 The local `HEAD` is compared against the `origin/master`.
 #>
 
+Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
+    CreateAndGetArtefactsDir
+
+
 function Main
 {
     if ($null -eq (Get-Command "git" -ErrorAction SilentlyContinue))
@@ -20,6 +24,13 @@ function Main
     }
 
     Set-Location $PSScriptRoot
+
+    $artefactsDir = CreateAndGetArtefactsDir
+    $reportPath = Join-Path $artefactsDir "CheckPushCommitMessages.txt"
+    if (Test-Path $reportPath)
+    {
+        Remove-Item -Path $reportPath -Force
+    }
 
     # Get commit hashes not available in the master
     $hashesText = git log 'origin/master..HEAD' '--format=format:%H'|Out-String
@@ -48,15 +59,12 @@ function Main
         }
         catch
         {
+            Write-Host "---"
+            Write-Host "One or more commit messages failed the check, but you can ignore them."
             Write-Host
             Write-Host (
-                "`u{1F4A5} `u{26A1} ATTENTION! `u{26A1} `u{1F4A5}`n`n" +
-                "The commit message failed the check. Since we are squashing before the commit, " +
-                "make sure that the title and description of your pull request (and *not* the commits) " +
-                "are valid.`n`n" +
-                "This check is intended to save you time if you have a single commit which " +
-                "will be used by GitHub to automatically generate the title and the description " +
-                "of the pull request."
+                "Mind that we only check the title and the description " +
+                "of the pull request in our CI."
             )
         }
     }

--- a/src/InspectCode.ps1
+++ b/src/InspectCode.ps1
@@ -90,6 +90,10 @@ function Main
             "https://www.jetbrains.com/help/resharper/Reference__Code_Inspections_CSHARP.html#BestPractice"
         )
     }
+    else
+    {
+        Write-Host "There were no issues detected."
+    }
 }
 
 $previousLocation = Get-Location; try { Main } finally { Set-Location $previousLocation }


### PR DESCRIPTION
Reading the output of Check.ps1 was tedious. The individual blocks were
hardly distinguishable and it was a pain to scroll between multiple runs
in the console.

This change introduces emojis, colors and timestamps so that individual
runs can be identified more easily. Moreover, it adds a prefix for each
check so that scrolling between the checks is easier.

The commit checker is put at the end of the checks since it is now
optional (we only care about the title and the description of the pull
request).

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.