### PR TITLE
Add XML failure cases invalid by the schema

### DIFF
--- a/src/AasxCsharpLibrary.Tests/AasxCsharpLibrary.Tests.csproj
+++ b/src/AasxCsharpLibrary.Tests/AasxCsharpLibrary.Tests.csproj
@@ -74,6 +74,9 @@
     <None Include="TestResources\XmlValidation\expectedOk\**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestResources\XmlValidation\expectedInvalidAccordingToSchema\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noId.err
+++ b/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noId.err
@@ -1,0 +1,1 @@
+﻿[Serialization] in : XML: 6, 8: Das Element 'assetAdministrationShell' in Namespace 'http://www.admin-shell.io/aas/2/0' hat ein ungültiges untergeordnetes Element 'assetRef' in Namespace 'http://www.admin-shell.io/aas/2/0'. Erwartet wurde die Liste der möglichen Elemente: 'category, description, parent, identification' in Namespace 'http://www.admin-shell.io/aas/2/0'.

--- a/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noId.xml
+++ b/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noId.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<aas:aasenv xmlns:IEC="http://www.admin-shell.io/IEC61360/2/0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:abac="http://www.admin-shell.io/aas/abac/2/0" xsi:schemaLocation="http://www.admin-shell.io/aas/2/0 AAS.xsd http://www.admin-shell.io/IEC61360/2/0 IEC61360.xsd" xmlns:aas="http://www.admin-shell.io/aas/2/0">
+  <aas:assetAdministrationShells>
+    <aas:assetAdministrationShell>
+      <aas:idShort>myAAS</aas:idShort>
+      <aas:assetRef>
+        <aas:keys>
+          <aas:key type="Asset" local="true" idType="">http://example.com/KLIYLHKLYUI</aas:key>
+        </aas:keys>
+      </aas:assetRef>
+      <aas:submodelRefs />
+      <aas:conceptDictionaries />
+    </aas:assetAdministrationShell>
+  </aas:assetAdministrationShells>
+  <aas:assets>
+    <aas:asset>
+      <aas:idShort>myAsset</aas:idShort>
+      <aas:identification idType="IRI">http://example.com/KLIYLHKLYUI</aas:identification>
+      <aas:kind>Instance</aas:kind>
+    </aas:asset>
+  </aas:assets>
+  <aas:submodels />
+  <aas:conceptDescriptions />
+</aas:aasenv>

--- a/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noIdShort.xml
+++ b/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noIdShort.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<aas:aasenv xmlns:IEC="http://www.admin-shell.io/IEC61360/2/0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:abac="http://www.admin-shell.io/aas/abac/2/0" xsi:schemaLocation="http://www.admin-shell.io/aas/2/0 AAS.xsd http://www.admin-shell.io/IEC61360/2/0 IEC61360.xsd" xmlns:aas="http://www.admin-shell.io/aas/2/0">
+  <aas:assetAdministrationShells>
+    <aas:assetAdministrationShell>
+      <aas:idShort/>
+      <aas:identification idType="IRI">http://example.com/demo/aas/1/1/NNNNNNNN</aas:identification>
+      <aas:assetRef>
+        <aas:keys>
+          <aas:key type="Asset" local="true" idType="IRI">http://example.com/KLIYLHKLYUI</aas:key>
+        </aas:keys>
+      </aas:assetRef>
+      <aas:submodelRefs />
+      <aas:conceptDictionaries />
+    </aas:assetAdministrationShell>
+  </aas:assetAdministrationShells>
+  <aas:assets>
+    <aas:asset>
+      <aas:idShort>myAsset</aas:idShort>
+      <aas:identification idType="IRI">http://example.com/KLIYLHKLYUI</aas:identification>
+      <aas:kind>Instance</aas:kind>
+    </aas:asset>
+  </aas:assets>
+  <aas:submodels />
+  <aas:conceptDescriptions />
+</aas:aasenv>

--- a/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noIdTypeInIdentifier.xml
+++ b/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noIdTypeInIdentifier.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<aas:aasenv xmlns:IEC="http://www.admin-shell.io/IEC61360/2/0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:abac="http://www.admin-shell.io/aas/abac/2/0" xsi:schemaLocation="http://www.admin-shell.io/aas/2/0 AAS.xsd http://www.admin-shell.io/IEC61360/2/0 IEC61360.xsd" xmlns:aas="http://www.admin-shell.io/aas/2/0">
+  <aas:assetAdministrationShells>
+    <aas:assetAdministrationShell>
+      <aas:idShort>myAAS</aas:idShort>
+      <aas:identification>http://example.com/demo/aas/1/1/NNNNNNNN</aas:identification>
+      <aas:assetRef>
+        <aas:keys>
+          <aas:key type="Asset" local="true" idType="IRI">http://example.com/KLIYLHKLYUI</aas:key>
+        </aas:keys>
+      </aas:assetRef>
+      <aas:submodelRefs />
+      <aas:conceptDictionaries />
+    </aas:assetAdministrationShell>
+  </aas:assetAdministrationShells>
+  <aas:assets>
+    <aas:asset>
+      <aas:idShort>myAsset</aas:idShort>
+      <aas:identification idType="IRI">http://example.com/KLIYLHKLYUI</aas:identification>
+      <aas:kind>Instance</aas:kind>
+    </aas:asset>
+  </aas:assets>
+  <aas:submodels />
+  <aas:conceptDescriptions />
+</aas:aasenv>

--- a/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noIdTypeInKey.err
+++ b/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noIdTypeInKey.err
@@ -1,0 +1,1 @@
+﻿[Serialization] in : XML: 9, 46: Das 'idType'-Attribut ist ungültig - Der Wert '' ist gemäß seinem Datentyp 'String' ungültig - Enumeration-Einschränkung ist fehlgeschlagen..

--- a/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noIdTypeInKey.xml
+++ b/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noIdTypeInKey.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<aas:aasenv xmlns:IEC="http://www.admin-shell.io/IEC61360/2/0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:abac="http://www.admin-shell.io/aas/abac/2/0" xsi:schemaLocation="http://www.admin-shell.io/aas/2/0 AAS.xsd http://www.admin-shell.io/IEC61360/2/0 IEC61360.xsd" xmlns:aas="http://www.admin-shell.io/aas/2/0">
+  <aas:assetAdministrationShells>
+    <aas:assetAdministrationShell>
+      <aas:idShort>myAAS</aas:idShort>
+      <aas:identification idType="IRI">http://example.com/demo/aas/1/1/NNNNNNNN</aas:identification>
+      <aas:assetRef>
+        <aas:keys>
+          <aas:key type="Asset" local="true" idType="">http://example.com/KLIYLHKLYUI</aas:key>
+        </aas:keys>
+      </aas:assetRef>
+      <aas:submodelRefs />
+      <aas:conceptDictionaries />
+    </aas:assetAdministrationShell>
+  </aas:assetAdministrationShells>
+  <aas:assets>
+    <aas:asset>
+      <aas:idShort>myAsset</aas:idShort>
+      <aas:identification idType="IRI">http://example.com/KLIYLHKLYUI</aas:identification>
+      <aas:kind>Instance</aas:kind>
+    </aas:asset>
+  </aas:assets>
+  <aas:submodels />
+  <aas:conceptDescriptions />
+</aas:aasenv>

--- a/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noTypeInKey.xml
+++ b/src/AasxCsharpLibrary.Tests/TestResources/XmlValidation/expectedInvalidAccordingToSchema/ValidAASMinimum_noTypeInKey.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<aas:aasenv xmlns:IEC="http://www.admin-shell.io/IEC61360/2/0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:abac="http://www.admin-shell.io/aas/abac/2/0" xsi:schemaLocation="http://www.admin-shell.io/aas/2/0 AAS.xsd http://www.admin-shell.io/IEC61360/2/0 IEC61360.xsd" xmlns:aas="http://www.admin-shell.io/aas/2/0">
+  <aas:assetAdministrationShells>
+    <aas:assetAdministrationShell>
+      <aas:idShort>myAAS</aas:idShort>
+      <aas:identification idType="IRI">http://example.com/demo/aas/1/1/NNNNNNNN</aas:identification>
+      <aas:assetRef>
+        <aas:keys>
+          <aas:key local="true" idType="IRI">http://example.com/KLIYLHKLYUI</aas:key>
+        </aas:keys>
+      </aas:assetRef>
+      <aas:submodelRefs />
+      <aas:conceptDictionaries />
+    </aas:assetAdministrationShell>
+  </aas:assetAdministrationShells>
+  <aas:assets>
+    <aas:asset>
+      <aas:idShort>myAsset</aas:idShort>
+      <aas:identification idType="IRI">http://example.com/KLIYLHKLYUI</aas:identification>
+      <aas:kind>Instance</aas:kind>
+    </aas:asset>
+  </aas:assets>
+  <aas:submodels />
+  <aas:conceptDescriptions />
+</aas:aasenv>

--- a/src/AasxCsharpLibrary.Tests/TestValidateXml.cs
+++ b/src/AasxCsharpLibrary.Tests/TestValidateXml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using Environment = System.Environment;
@@ -9,39 +10,45 @@ namespace AdminShellNS.Tests
 {
     public class TestOnFiles
     {
-        [Test]
-        public void TestSuccess()
+        private List<string> mustListXmlFiles(string xmlDir)
         {
-            string successDir = Path.Combine(
-                TestContext.CurrentContext.TestDirectory,
-                "TestResources\\XmlValidation\\expectedOk");
-
-            if (!System.IO.Directory.Exists(successDir))
+            if (!System.IO.Directory.Exists(xmlDir))
             {
                 throw new InvalidOperationException(
-                    $"The directory containing the valid AAS XML files does not exist or is not a directory: " +
-                    successDir);
+                    $"The directory containing the test XML files does not exist or is not a directory: " +
+                    xmlDir);
             }
 
-            var paths = System.IO.Directory.GetFiles(successDir)
+            var paths = System.IO.Directory.GetFiles(xmlDir)
                 .Where(p => System.IO.Path.GetExtension(p) == ".xml")
                 .ToList();
 
             if (paths.Count == 0)
             {
                 throw new InvalidOperationException(
-                    $"No *.xml files were found in the directory expected to contain the valid XML files: " +
-                    successDir);
+                    $"No *.xml files were found in the directory expected to contain the test XML files: " +
+                    xmlDir);
             }
 
-            var validator = AasSchemaValidation.NewXmlValidator();
+            return paths;
+        }
+
+        [Test]
+        public void TestSuccess()
+        {
+            var paths = mustListXmlFiles(
+                Path.Combine(
+                    TestContext.CurrentContext.TestDirectory,
+                    "TestResources\\XmlValidation\\expectedOk"));
+
+            var xmlValidator = AasSchemaValidation.NewXmlValidator();
 
             foreach (string path in paths)
             {
                 using (var fileStream = System.IO.File.OpenRead(path))
                 {
                     var records = new AasValidationRecordList();
-                    validator.Validate(records, fileStream);
+                    xmlValidator.Validate(records, fileStream);
                     if (records.Count != 0)
                     {
                         var parts = new List<string>
@@ -50,6 +57,92 @@ namespace AdminShellNS.Tests
                         };
                         parts.AddRange(records.Select((r) => r.Message));
                         throw new AssertionException(string.Join(Environment.NewLine, parts));
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void TestInvalidAccordingToSchema()
+        {
+            var paths = mustListXmlFiles(
+                Path.Combine(
+                    TestContext.CurrentContext.TestDirectory,
+                    "TestResources\\XmlValidation\\expectedInvalidAccordingToSchema"));
+
+            var xmlValidator = AasSchemaValidation.NewXmlValidator();
+
+            foreach (string path in paths)
+            {
+                using (var fileStream = System.IO.File.OpenRead(path))
+                {
+                    var records = new AasValidationRecordList();
+                    xmlValidator.Validate(records, fileStream);
+
+                    string errPath = Path.Combine(
+                        Path.GetDirectoryName(path),
+                        $"{Path.GetFileNameWithoutExtension(path)}.err");
+
+                    string expectedErr = null;
+                    if (File.Exists(errPath))
+                    {
+                        expectedErr = string.Join(Environment.NewLine, File.ReadAllLines(errPath));
+                    }
+
+                    if (records.Count == 0)
+                    {
+                        if (expectedErr == null)
+                        {
+                            throw new AssertionException(
+                                "Expected the test XML file to be invalid, " +
+                                $"but there were no validation records: {path}");
+                        }
+                        else
+                        {
+                            throw new AssertionException(
+                                "Expected the test XML file to be invalid, " +
+                                $"but there were no validation records: {path}; the expected errors were:" +
+                                $"{Environment.NewLine}{expectedErr}");
+                        }
+                    }
+
+                    var gotErr =
+                        string.Join(Environment.NewLine,
+                            records
+                                .Select((r) =>
+                                {
+                                    string message = r.ToString();
+                                    if (message.Contains("\n") || message.Contains("\r"))
+                                    {
+                                        throw new InvalidOperationException(
+                                            "Unexpected newline character in the validation record " +
+                                            $"caused by the invalid test XML file {path}: {message}");
+                                    }
+
+                                    return r.ToString();
+                                })
+                        );
+
+                    if (expectedErr == null)
+                    {
+                        var nl = Environment.NewLine;
+                        throw new AssertionException(
+                            $"The expected error for the test XML file {path} does not exist: {errPath}.{nl}" +
+                            "Did you create it in the test resources? " +
+                            $"The XML validation gave us the following error message:{nl}{gotErr}{nl}{nl}" +
+                            "Please verify the obtained error message and consider creating the corresponding " +
+                            "test resource.");
+                    }
+                    else if (gotErr != expectedErr)
+                    {
+                        var nl = Environment.NewLine;
+                        throw new AssertionException(
+                            $"The validation records caused by the test XML file {path} " +
+                            $"do not match the expected ones. Got:{nl}{gotErr}{nl}{nl}Expected:{nl}{expectedErr}");
+                    }
+                    else
+                    {
+                        // The errors match; everything is OK.
                     }
                 }
             }


### PR DESCRIPTION
We checked so far only that the valid XML files are correctly accepted
by the XML validator. This patch introduces a suite of XML files which
are invalid according to the schema.

The error messages are stored as-are in the test resources so that we
can verify not only the acceptance/rejection logic, but the content of
the validation records as well.