### PR TITLE
Update predefined concepts and Submodels

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -49,12 +49,14 @@ jobs:
         run: powershell .\PackageRelease.ps1 -version LATEST.alpha
 
       - name: Upload latest
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: aasx-package-explorer.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
           path: artefacts/release/LATEST.alpha/aasx-package-explorer.zip
 
       - name: Upload latest small
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: aasx-package-explorer-small.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}

--- a/src/AasxCsharpLibrary/AdminShell.cs
+++ b/src/AasxCsharpLibrary/AdminShell.cs
@@ -5498,7 +5498,7 @@ namespace AdminShellNS
 
             // for conversion
 
-            public T CopyOneSMEbyCopy<T>(Key destSemanticId, 
+            public T CopyOneSMEbyCopy<T>(Key destSemanticId,
                 SubmodelElementWrapperCollection sourceSmc, Key sourceSemanticId,
                 ConceptDescription createDefault = null, Action<T> setDefault = null,
                 Key.MatchMode matchMode = Key.MatchMode.Relaxed, bool addSme = false) where T : SubmodelElement, new()
@@ -5540,12 +5540,12 @@ namespace AdminShellNS
                 return dst;
             }
 
-            public T CopyOneSMEbyCopy<T>(ConceptDescription destCD, 
+            public T CopyOneSMEbyCopy<T>(ConceptDescription destCD,
                 SubmodelElementWrapperCollection sourceSmc, ConceptDescription sourceCD,
                 bool createDefault = false, Action<T> setDefault = null,
                 Key.MatchMode matchMode = Key.MatchMode.Relaxed, bool addSme = false) where T : SubmodelElement, new()
             {
-                return this.CopyOneSMEbyCopy<T>(destCD?.GetSingleKey(), sourceSmc, sourceCD?.GetSingleKey(), 
+                return this.CopyOneSMEbyCopy<T>(destCD?.GetSingleKey(), sourceSmc, sourceCD?.GetSingleKey(),
                     createDefault ? destCD : null, setDefault, matchMode, addSme);
             }
 
@@ -5556,7 +5556,9 @@ namespace AdminShellNS
             {
                 // bool find possible sources
                 bool foundSrc = false;
-                foreach (var src in sourceSmc?.FindAllSemanticIdAs<T>(sourceSemanticId, matchMode))
+                if (sourceSmc == null)
+                    return;
+                foreach (var src in sourceSmc.FindAllSemanticIdAs<T>(sourceSemanticId, matchMode))
                 {
                     // type of found src?
                     var aeSrc = SubmodelElementWrapper.GetAdequateEnum(src?.GetElementName());
@@ -5579,7 +5581,7 @@ namespace AdminShellNS
                         this.Add(dst);
                     }
                 }
-                
+
                 // default?
                 if (createDefault != null && !foundSrc)
                 {
@@ -5596,7 +5598,7 @@ namespace AdminShellNS
                 bool createDefault = false, Action<T> setDefault = null,
                 Key.MatchMode matchMode = Key.MatchMode.Relaxed) where T : SubmodelElement, new()
             {
-                CopyManySMEbyCopy(destCD.GetSingleKey(), sourceSmc, sourceCD.GetSingleKey(), 
+                CopyManySMEbyCopy(destCD.GetSingleKey(), sourceSmc, sourceCD.GetSingleKey(),
                     createDefault ? destCD : null, setDefault, matchMode);
             }
         }

--- a/src/AasxCsharpLibrary/AdminShell.cs
+++ b/src/AasxCsharpLibrary/AdminShell.cs
@@ -4994,31 +4994,31 @@ namespace AdminShellNS
             public static SubmodelElement CreateAdequateType(AdequateElementEnum ae, SubmodelElement src = null)
             {
                 if (ae == AdequateElementEnum.Property)
-                    return new Property(src);
+                    return new Property(src as Property);
                 if (ae == AdequateElementEnum.MultiLanguageProperty)
-                    return new MultiLanguageProperty(src);
+                    return new MultiLanguageProperty(src as MultiLanguageProperty);
                 if (ae == AdequateElementEnum.Range)
-                    return new Range(src);
+                    return new Range(src as Range);
                 if (ae == AdequateElementEnum.File)
-                    return new File(src);
+                    return new File(src as File);
                 if (ae == AdequateElementEnum.Blob)
-                    return new Blob(src);
+                    return new Blob(src as Blob);
                 if (ae == AdequateElementEnum.ReferenceElement)
-                    return new ReferenceElement(src);
+                    return new ReferenceElement(src as ReferenceElement);
                 if (ae == AdequateElementEnum.RelationshipElement)
-                    return new RelationshipElement(src);
+                    return new RelationshipElement(src as RelationshipElement);
                 if (ae == AdequateElementEnum.AnnotatedRelationshipElement)
-                    return new AnnotatedRelationshipElement(src);
+                    return new AnnotatedRelationshipElement(src as AnnotatedRelationshipElement);
                 if (ae == AdequateElementEnum.Capability)
-                    return new Capability(src);
+                    return new Capability(src as Capability);
                 if (ae == AdequateElementEnum.SubmodelElementCollection)
-                    return new SubmodelElementCollection(src);
+                    return new SubmodelElementCollection(src as SubmodelElementCollection);
                 if (ae == AdequateElementEnum.Operation)
-                    return new Operation(src);
+                    return new Operation(src as Operation);
                 if (ae == AdequateElementEnum.BasicEvent)
-                    return new BasicEvent(src);
+                    return new BasicEvent(src as BasicEvent);
                 if (ae == AdequateElementEnum.Entity)
-                    return new Entity(src);
+                    return new Entity(src as Entity);
                 return null;
             }
 
@@ -5457,6 +5457,10 @@ namespace AdminShellNS
                 if (category != null)
                     sme.category = category;
 
+                // if its a SMC, make sure its accessible
+                if (sme is SubmodelElementCollection smc)
+                    smc.value = new SubmodelElementWrapperCollection();
+
                 // instantanously add it?
                 if (addSme)
                     this.Add(sme);
@@ -5490,6 +5494,110 @@ namespace AdminShellNS
 
                 // give back
                 return sme;
+            }
+
+            // for conversion
+
+            public T CopyOneSMEbyCopy<T>(Key destSemanticId, 
+                SubmodelElementWrapperCollection sourceSmc, Key sourceSemanticId,
+                ConceptDescription createDefault = null, Action<T> setDefault = null,
+                Key.MatchMode matchMode = Key.MatchMode.Relaxed, bool addSme = false) where T : SubmodelElement, new()
+            {
+                // get source
+                var src = sourceSmc?.FindFirstSemanticIdAs<T>(sourceSemanticId, matchMode);
+                var aeSrc = SubmodelElementWrapper.GetAdequateEnum(src?.GetElementName());
+                if (src == null || aeSrc == SubmodelElementWrapper.AdequateElementEnum.Unknown)
+                {
+                    // create a default?
+                    if (createDefault == null)
+                        return null;
+
+                    // ok, default
+                    var dflt = this.CreateSMEForCD<T>(createDefault, addSme: addSme);
+
+                    // set default?
+                    setDefault?.Invoke(dflt);
+
+                    // return 
+                    return dflt;
+                }
+
+                // ok, create new one
+                var dst = SubmodelElementWrapper.CreateAdequateType(aeSrc, src) as T;
+                if (dst == null)
+                    return null;
+
+                // make same things sure
+                dst.idShort = src.idShort;
+                dst.category = src.category;
+                dst.semanticId = new SemanticId(destSemanticId);
+
+                // instantanously add it?
+                if (addSme)
+                    this.Add(dst);
+
+                // give back
+                return dst;
+            }
+
+            public T CopyOneSMEbyCopy<T>(ConceptDescription destCD, 
+                SubmodelElementWrapperCollection sourceSmc, ConceptDescription sourceCD,
+                bool createDefault = false, Action<T> setDefault = null,
+                Key.MatchMode matchMode = Key.MatchMode.Relaxed, bool addSme = false) where T : SubmodelElement, new()
+            {
+                return this.CopyOneSMEbyCopy<T>(destCD?.GetSingleKey(), sourceSmc, sourceCD?.GetSingleKey(), 
+                    createDefault ? destCD : null, setDefault, matchMode, addSme);
+            }
+
+            public void CopyManySMEbyCopy<T>(Key destSemanticId,
+                SubmodelElementWrapperCollection sourceSmc, Key sourceSemanticId,
+                ConceptDescription createDefault = null, Action<T> setDefault = null,
+                Key.MatchMode matchMode = Key.MatchMode.Relaxed) where T : SubmodelElement, new()
+            {
+                // bool find possible sources
+                bool foundSrc = false;
+                foreach (var src in sourceSmc?.FindAllSemanticIdAs<T>(sourceSemanticId, matchMode))
+                {
+                    // type of found src?
+                    var aeSrc = SubmodelElementWrapper.GetAdequateEnum(src?.GetElementName());
+
+                    // ok?
+                    if (src == null || aeSrc == SubmodelElementWrapper.AdequateElementEnum.Unknown)
+                        continue;
+                    foundSrc = true;
+
+                    // ok, create new one
+                    var dst = SubmodelElementWrapper.CreateAdequateType(aeSrc, src) as T;
+                    if (dst != null)
+                    {
+                        // make same things sure
+                        dst.idShort = src.idShort;
+                        dst.category = src.category;
+                        dst.semanticId = new SemanticId(destSemanticId);
+
+                        // instantanously add it?
+                        this.Add(dst);
+                    }
+                }
+                
+                // default?
+                if (createDefault != null && !foundSrc)
+                {
+                    // ok, default
+                    var dflt = this.CreateSMEForCD<T>(createDefault, addSme: true);
+
+                    // set default?
+                    setDefault?.Invoke(dflt);
+                }
+            }
+
+            public void CopyManySMEbyCopy<T>(ConceptDescription destCD,
+                SubmodelElementWrapperCollection sourceSmc, ConceptDescription sourceCD,
+                bool createDefault = false, Action<T> setDefault = null,
+                Key.MatchMode matchMode = Key.MatchMode.Relaxed) where T : SubmodelElement, new()
+            {
+                CopyManySMEbyCopy(destCD.GetSingleKey(), sourceSmc, sourceCD.GetSingleKey(), 
+                    createDefault ? destCD : null, setDefault, matchMode);
             }
         }
 
@@ -6049,6 +6157,12 @@ namespace AdminShellNS
             public override AasElementSelfDescription GetSelfDescription()
             {
                 return new AasElementSelfDescription("MultiLanguageProperty", "MLP");
+            }
+
+            public MultiLanguageProperty Set(LangStringSet ls)
+            {
+                this.value = ls;
+                return this;
             }
 
             public MultiLanguageProperty Set(ListOfLangStr ls)

--- a/src/AasxIntegrationBase/AasxPluginOptionsBase.cs
+++ b/src/AasxIntegrationBase/AasxPluginOptionsBase.cs
@@ -68,7 +68,8 @@ namespace AasxIntegrationBase
                     var opts = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(optText, settings);
                     this.Merge(opts);
                 }
-                catch (Exception ex) {
+                catch (Exception ex)
+                {
                     log?.Error(ex, $"loading additional options (${fn})");
                 }
             // ReSharper enable EmptyGeneralCatchClause

--- a/src/AasxIntegrationBase/AasxPluginOptionsBase.cs
+++ b/src/AasxIntegrationBase/AasxPluginOptionsBase.cs
@@ -45,7 +45,8 @@ namespace AasxIntegrationBase
 
         public void TryLoadAdditionalOptionsFromAssemblyDir<T>(
             string pluginName, Assembly assy = null,
-            JsonSerializerSettings settings = null) where T : AasxPluginOptionsBase
+            JsonSerializerSettings settings = null,
+            LogInstance log = null) where T : AasxPluginOptionsBase
         {
             // expand assy?
             if (assy == null)
@@ -67,7 +68,9 @@ namespace AasxIntegrationBase
                     var opts = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(optText, settings);
                     this.Merge(opts);
                 }
-                catch { }
+                catch (Exception ex) {
+                    log?.Error(ex, $"loading additional options (${fn})");
+                }
             // ReSharper enable EmptyGeneralCatchClause
         }
     }

--- a/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
@@ -70,7 +70,7 @@ namespace AasxIntegrationBase.AasForms
 
                         q = qs?.FindType("EditIdShort");
                         if (q != null)
-                            tsme.FormEditIdShort = q.value.Trim().ToLower() == "true" ;
+                            tsme.FormEditIdShort = q.value.Trim().ToLower() == "true";
 
                         q = qs?.FindType("EditDescription");
                         if (q != null)

--- a/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
@@ -68,6 +68,14 @@ namespace AasxIntegrationBase.AasForms
                         if (q != null)
                             tsme.FormInfo = "" + q.value;
 
+                        q = qs?.FindType("EditIdShort");
+                        if (q != null)
+                            tsme.FormEditIdShort = q.value.Trim().ToLower() == "true" ;
+
+                        q = qs?.FindType("EditDescription");
+                        if (q != null)
+                            tsme.FormEditDescription = q.value.Trim().ToLower() == "true";
+
                         q = qs?.FindType("Multiplicity");
                         if (q != null)
                         {

--- a/src/AasxPackageExplorer/AasxPackageExplorer.csproj
+++ b/src/AasxPackageExplorer/AasxPackageExplorer.csproj
@@ -361,9 +361,5 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
-  <ProjectExtensions>
-    <VisualStudio>
-      <UserProperties options-debug_1json__JSONSchema="http://json.schemastore.org/2.0.0-csd.2.beta.2018-10-10.json" />
-    </VisualStudio>
-  </ProjectExtensions>
+  <ProjectExtensions />
 </Project>

--- a/src/AasxPackageExplorer/MainWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MainWindow.xaml.cs
@@ -266,7 +266,7 @@ namespace AasxPackageExplorer
             {
                 // check for ReferenceElement
                 var navTo = sm?.submodelElements?.FindFirstSemanticIdAs<AdminShell.ReferenceElement>(
-                    AasxPredefinedConcepts.DefinitionsPackageExplorer.Static.CD_AasxLoadedNavigateTo.GetReference(),
+                    AasxPredefinedConcepts.PackageExplorer.Static.CD_AasxLoadedNavigateTo.GetReference(),
                     AdminShell.Key.MatchMode.Relaxed);
                 if (navTo?.value == null)
                     continue;

--- a/src/AasxPackageExplorer/options-debug.json
+++ b/src/AasxPackageExplorer/options-debug.json
@@ -39,7 +39,6 @@
     "This JSON file might contain special settings for debugging purposes of Michael Hoffmeisters setup."
   ],
   "PluginDll": [
-    /*
     {
       "Path": "..\\..\\..\\..\\AasxIntegrationEmptySample\\bin\\Debug\\AasxIntegrationEmptySample.dll",
       "Args": [],
@@ -62,7 +61,6 @@
       "Args": [],
       "Options": null
     },
-    */
     {
       "Path": "..\\..\\..\\..\\AasxPluginBomStructure\\bin\\Debug\\AasxPluginBomStructure.dll",
       "Args": []

--- a/src/AasxPackageExplorer/qualifier-presets.json
+++ b/src/AasxPackageExplorer/qualifier-presets.json
@@ -484,5 +484,23 @@
       "value": "True",
       "valueId": null
     }
+  },
+  {
+    "name": "GenericForms plugin | EditIdShort = True",
+    "qualifier": {
+      "semanticId": null,
+      "type": "EditIdShort",
+      "value": "True",
+      "valueId": null
+    }
+  },
+  {
+    "name": "GenericForms plugin | EditDescription = True",
+    "qualifier": {
+      "semanticId": null,
+      "type": "EditDescription",
+      "value": "True",
+      "valueId": null
+    }
   }
 ]

--- a/src/AasxPluginGenericForms/AasxPluginGenericForms.csproj
+++ b/src/AasxPluginGenericForms/AasxPluginGenericForms.csproj
@@ -93,6 +93,9 @@
     <None Include="AasxPluginGenericForms.options.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="AasxPluginGenericForms_SG2_TechnicalData_v11.add-options.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">

--- a/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData.add-options.json
+++ b/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData.add-options.json
@@ -3,12 +3,14 @@
   "Records": [
     {
       "$type": "Record",
-      "FormTag": "FRM",
-      "FormTitle": "Form: Technical data",
+      "FormTag": "TEC",
+      "FormTitle": "Technical data (sheet) model",
       "FormSubmodel": {
         "$type": "FormSubmodel",
         "FormTitle": "Submodel",
         "FormInfo": "",
+        "FormEditIdShort": false,
+        "FormEditDescription": false,
         "PresetIdShort": "TechnicalData",
         "PresetCategory": "CONSTANT",
         "KeySemanticId": {
@@ -23,6 +25,8 @@
           {
             "$type": "FormSubmodelElementCollection",
             "FormTitle": "GeneralInformation",
+            "FormEditIdShort": false,
+            "FormEditDescription": false,
             "PresetIdShort": "GeneralInformation",
             "KeySemanticId": {
               "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -38,6 +42,8 @@
               {
                 "$type": "FormProperty",
                 "FormTitle": "ManufacturerName",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
                 "PresetIdShort": "ManufacturerName",
                 "KeySemanticId": {
                   "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -57,6 +63,8 @@
               {
                 "$type": "FormFile",
                 "FormTitle": "ManufacturerLogo",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
                 "PresetIdShort": "ManufacturerLogo",
                 "KeySemanticId": {
                   "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -73,6 +81,8 @@
               {
                 "$type": "FormProperty",
                 "FormTitle": "ManufacturerProductDesignation",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
                 "PresetIdShort": "ManufacturerProductDesignation",
                 "KeySemanticId": {
                   "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -92,6 +102,8 @@
               {
                 "$type": "FormProperty",
                 "FormTitle": "ManufacturerPartNumber",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
                 "PresetIdShort": "ManufacturerPartNumber",
                 "KeySemanticId": {
                   "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -111,6 +123,8 @@
               {
                 "$type": "FormProperty",
                 "FormTitle": "ManufacturerOrderCode",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
                 "PresetIdShort": "ManufacturerOrderCode",
                 "KeySemanticId": {
                   "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -130,6 +144,8 @@
               {
                 "$type": "FormFile",
                 "FormTitle": "ProductImage",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
                 "PresetIdShort": "ProductImage{0:00}",
                 "KeySemanticId": {
                   "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -148,6 +164,8 @@
           {
             "$type": "FormSubmodelElementCollection",
             "FormTitle": "ProductClassifications",
+            "FormEditIdShort": false,
+            "FormEditDescription": false,
             "PresetIdShort": "ProductClassifications",
             "KeySemanticId": {
               "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -162,8 +180,10 @@
             "value": [
               {
                 "$type": "FormSubmodelElementCollection",
-                "FormTitle": "ProductClassificationItem",
-                "PresetIdShort": "ProductClassificationItem{0:00}",
+                "FormTitle": "ProductClassificationItem{00}",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
+                "PresetIdShort": "ProductClassificationItem{00}{0:00}",
                 "KeySemanticId": {
                   "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
                   "type": "ConceptDescription",
@@ -178,6 +198,8 @@
                   {
                     "$type": "FormProperty",
                     "FormTitle": "ClassificationSystem",
+                    "FormEditIdShort": false,
+                    "FormEditDescription": false,
                     "PresetIdShort": "ClassificationSystem",
                     "KeySemanticId": {
                       "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -197,6 +219,8 @@
                   {
                     "$type": "FormProperty",
                     "FormTitle": "SystemVersion",
+                    "FormEditIdShort": false,
+                    "FormEditDescription": false,
                     "PresetIdShort": "SystemVersion",
                     "KeySemanticId": {
                       "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -216,6 +240,8 @@
                   {
                     "$type": "FormProperty",
                     "FormTitle": "ProductClass",
+                    "FormEditIdShort": false,
+                    "FormEditDescription": false,
                     "PresetIdShort": "ProductClass",
                     "KeySemanticId": {
                       "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -239,6 +265,8 @@
           {
             "$type": "FormSubmodelElementCollection",
             "FormTitle": "TechnicalProperties",
+            "FormEditIdShort": false,
+            "FormEditDescription": false,
             "PresetIdShort": "TechnicalProperties",
             "KeySemanticId": {
               "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -254,9 +282,9 @@
               {
                 "$type": "FormProperty",
                 "FormTitle": "NonstandardizedProperty",
-                "PresetIdShort": "NonstandardizedProperty{0:00}",
                 "FormEditIdShort": true,
                 "FormEditDescription": true,
+                "PresetIdShort": "NonstandardizedProperty{0:00}",
                 "KeySemanticId": {
                   "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
                   "type": "ConceptDescription",
@@ -275,6 +303,8 @@
               {
                 "$type": "FormSubmodelElementCollection",
                 "FormTitle": "MainSection",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
                 "PresetIdShort": "MainSection{0:00}",
                 "KeySemanticId": {
                   "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -290,6 +320,8 @@
                   {
                     "$type": "FormProperty",
                     "FormTitle": "NonstandardizedProperty",
+                    "FormEditIdShort": true,
+                    "FormEditDescription": true,
                     "PresetIdShort": "NonstandardizedProperty{0:00}",
                     "KeySemanticId": {
                       "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -309,6 +341,8 @@
                   {
                     "$type": "FormSubmodelElementCollection",
                     "FormTitle": "SubSection",
+                    "FormEditIdShort": false,
+                    "FormEditDescription": false,
                     "PresetIdShort": "SubSection{0:00}",
                     "KeySemanticId": {
                       "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -324,6 +358,8 @@
                       {
                         "$type": "FormProperty",
                         "FormTitle": "NonstandardizedProperty",
+                        "FormEditIdShort": true,
+                        "FormEditDescription": true,
                         "PresetIdShort": "NonstandardizedProperty{0:00}",
                         "KeySemanticId": {
                           "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -349,6 +385,8 @@
           {
             "$type": "FormSubmodelElementCollection",
             "FormTitle": "FurtherInformation",
+            "FormEditIdShort": false,
+            "FormEditDescription": false,
             "PresetIdShort": "FurtherInformation",
             "KeySemanticId": {
               "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -364,6 +402,8 @@
               {
                 "$type": "FormProperty",
                 "FormTitle": "TextStatement",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
                 "PresetIdShort": "TextStatement{0:00}",
                 "KeySemanticId": {
                   "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -383,6 +423,8 @@
               {
                 "$type": "FormProperty",
                 "FormTitle": "ValidDate",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
                 "PresetIdShort": "ValidDate",
                 "KeySemanticId": {
                   "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
@@ -424,62 +466,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Generelle Informationen"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "General information"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "General information"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Generelle Informationen"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Generelle Informationen, zum Beispiel Bestell- und Herstellerinformationen"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "General information, for example ordering and manufacturer information"
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Generelle Informationen"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "General information"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "General information"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Generelle Informationen"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Generelle Informationen, zum Beispiel Bestell- und Herstellerinformationen"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "General information, for example ordering and manufacturer information"
+                  }
+                ]
               }
             }
           ]
@@ -504,63 +559,76 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Herstellername"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Manufacturer name"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Herstellername"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Manufacturer name"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "symbol": "string",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "legally valid designation of the natural or judicial person which is directly responsible for the design, production, packaging and labeling of a product in respect to its being brought into circulation"
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Herstellername"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Manufacturer name"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Herstellername"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Manufacturer name"
+                  }
+                ],
+                "unit": "",
+                "symbol": "string",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "legally valid designation of the natural or judicial person which is directly responsible for the design, production, packaging and labeling of a product in respect to its being brought into circulation"
+                  }
+                ]
               }
             }
           ],
@@ -576,7 +644,23 @@
                   "index": 0,
                   "idType": "IRDI"
                 }
-              ]
+              ],
+              "First": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO677#002",
+                "index": 0,
+                "idType": "IRDI"
+              },
+              "Last": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO677#002",
+                "index": 0,
+                "idType": "IRDI"
+              }
             }
           ]
         },
@@ -600,62 +684,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Herstellerlogo-Datei"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "File with manufactuer logo"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Herstellerlogo"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Manufactuer logo"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Bilddatei für Logo des Herstellers im gebräuchlichem Format (.png, .jpg). "
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Imagefile for logo of manufacturer provided in common format (.png, .jpg). "
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Herstellerlogo-Datei"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "File with manufactuer logo"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Herstellerlogo"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Manufactuer logo"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Bilddatei für Logo des Herstellers im gebräuchlichem Format (.png, .jpg). "
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Imagefile for logo of manufacturer provided in common format (.png, .jpg). "
+                  }
+                ]
               }
             }
           ]
@@ -680,62 +777,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Herstellerproduktbezeichnung"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Manufacturer product designation"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Product designation"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Produktbezeichnung"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Kurze Beschreibung des Produktes (Kurztext)"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Short description of the product (short text)"
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Herstellerproduktbezeichnung"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Manufacturer product designation"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Product designation"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktbezeichnung"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Kurze Beschreibung des Produktes (Kurztext)"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Short description of the product (short text)"
+                  }
+                ]
               }
             }
           ],
@@ -751,7 +861,23 @@
                   "index": 0,
                   "idType": "IRDI"
                 }
-              ]
+              ],
+              "First": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAW338#001",
+                "index": 0,
+                "idType": "IRDI"
+              },
+              "Last": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAW338#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
             }
           ]
         },
@@ -775,62 +901,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Herstellerartikelnummer"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "product article number of manufacturer"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Manufacturer order code"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Herstellerbestellcode"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "eindeutiger Bestellschlüssel des Herstellers"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "unique product identifier of the manufacturer"
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Herstellerartikelnummer"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "product article number of manufacturer"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Manufacturer order code"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Herstellerbestellcode"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "eindeutiger Bestellschlüssel des Herstellers"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "unique product identifier of the manufacturer"
+                  }
+                ]
               }
             }
           ],
@@ -846,7 +985,23 @@
                   "index": 0,
                   "idType": "IRDI"
                 }
-              ]
+              ],
+              "First": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO676#003",
+                "index": 0,
+                "idType": "IRDI"
+              },
+              "Last": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO676#003",
+                "index": 0,
+                "idType": "IRDI"
+              }
             }
           ]
         },
@@ -870,62 +1025,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Eindeutiger Herstellerbestellcode"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Unique manufacturer order code"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Manufacturer order code"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Herstellerbestellcode"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "eindeutiger Bestellschlüssel des Herstellers um exakt gleiches Produkt zu bestellen"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "unique product identifier of the manufacturer to order exact same produkt"
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Eindeutiger Herstellerbestellcode"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Unique manufacturer order code"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Manufacturer order code"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Herstellerbestellcode"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "eindeutiger Bestellschlüssel des Herstellers um exakt gleiches Produkt zu bestellen"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "unique product identifier of the manufacturer sufficient to order exact same produkt"
+                  }
+                ]
               }
             }
           ],
@@ -941,7 +1109,23 @@
                   "index": 0,
                   "idType": "IRDI"
                 }
-              ]
+              ],
+              "First": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO676#003",
+                "index": 0,
+                "idType": "IRDI"
+              },
+              "Last": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO676#003",
+                "index": 0,
+                "idType": "IRDI"
+              }
             }
           ]
         },
@@ -965,62 +1149,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Bilddatei für Produkt"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Imagefile for product"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Product image"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Produktbild"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Bilddatei für das assozierte Produkt im gebräuchlichem Format (.png, .jpg). "
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Imagefile for associated product provided in common format (.png, .jpg). "
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Bilddatei für Produkt"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Imagefile for product"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Product image"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktbild"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Bilddatei für das assozierte Produkt im gebräuchlichem Format (.png, .jpg). "
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Imagefile for associated product provided in common format (.png, .jpg). "
+                  }
+                ]
               }
             }
           ]
@@ -1045,62 +1242,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Produktklassifizierungen"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "ProductClassifications"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "ProductClassification"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Produktklassifizierung"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Produktklassifizierungen durch Assoziation mit Produktklassen in gebräuchlichen Klassifizierungssystemen."
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Product classifications by association with product classes in common classification systems."
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Produktklassifizierungen"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "ProductClassifications"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "ProductClassification"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktklassifizierung"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Produktklassifizierungen durch Assoziation mit Produktklassen in gebräuchlichen Klassifizierungssystemen."
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Product classifications by association with product classes in common classification systems."
+                  }
+                ]
               }
             }
           ]
@@ -1125,62 +1335,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Einzelne Produktklassifizierung"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Single ProductClassification"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "ProductClassification"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Produktklassifizierung"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Einzelne Produktklassifizierung durch Assoziation mit einer Produktklasse"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Single product classification by association with product class"
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Einzelne Produktklassifizierung"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Single ProductClassification"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "ProductClassification"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktklassifizierung"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Einzelne Produktklassifizierung durch Assoziation mit einer Produktklasse"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Single product classification by association with product class"
+                  }
+                ]
               }
             }
           ]
@@ -1200,62 +1423,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Klassifikationssystem"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Classification system"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Classification system"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Klassifikationssystem"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Common name of the classification system"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Gebräuchlicher Name für das Klassifikationssystem"
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Klassifikationssystem"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Classification system"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Classification system"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Klassifikationssystem"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Common name of the classification system"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Gebräuchlicher Name für das Klassifikationssystem"
+                  }
+                ]
               }
             }
           ]
@@ -1275,62 +1511,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Versionskennung des Klassifikationssystems"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Verison id  of the classification system"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Version class. system"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Version Klass.-System"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Common version identifier of the used classification system"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Gebräuchliche Versionskennung des genutzen Klassifikationssystems"
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Versionskennung des Klassifikationssystems"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Verison id  of the classification system"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Version class. system"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Version Klass.-System"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Common version identifier of the used classification system"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Gebräuchliche Versionskennung des genutzen Klassifikationssystems"
+                  }
+                ]
               }
             }
           ]
@@ -1350,62 +1599,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Produktklasse im System"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Product class in system"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Product class"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Produktklasse "
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Class of the associated product in the classification system; according to the notation of the system"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Klasse des assoziierten Produktes im Klassifikationssystem; entsprechend der Notationsweise des Systems."
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktklasse im System"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Product class in system"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Product class"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktklasse "
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Class of the associated product in the classification system; according to the notation of the system"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Klasse des assoziierten Produktes im Klassifikationssystem; entsprechend der Notationsweise des Systems."
+                  }
+                ]
               }
             }
           ]
@@ -1430,62 +1692,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Technische und Produktmerkmale"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Technical and product properties"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Properties"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Merkmale"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Einzelne Merkmale die das Produkt und die technischen Eigenschaften beschreiben"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Individual characteristics that describe the product and its technical properties"
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Technische und Produktmerkmale"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Technical and product properties"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Properties"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Merkmale"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Einzelne Merkmale die das Produkt und die technischen Eigenschaften beschreiben"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Individual characteristics that describe the product and its technical properties"
+                  }
+                ]
               }
             }
           ]
@@ -1510,62 +1785,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Nichtstandardisiertes Merkmal"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Nonstandardized property"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Nonstandardized property"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Nichtstandardisiertes Merkmal"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Merkmal, welches nicht über ein gebräuchliches Klassifikationssystem beschrieben ist"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Property that is not described using a common classification system"
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Nichtstandardisiertes Merkmal"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Nonstandardized property"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Nonstandardized property"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Nichtstandardisiertes Merkmal"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Merkmal, welches nicht über ein gebräuchliches Klassifikationssystem beschrieben ist"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Property that is not described using a common classification system"
+                  }
+                ]
               }
             }
           ]
@@ -1590,62 +1878,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Hauptsektion für Merkmale"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Main section for properties"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Main section"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Hauptsektion"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Haupt-Unterteilungsmöglichkeit für Merkmale. Kann über idShort benannt werden."
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Main subdivision possibility for properties. Can be named via idShort."
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Hauptsektion für Merkmale"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Main section for properties"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Main section"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Hauptsektion"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Haupt-Unterteilungsmöglichkeit für Merkmale. Kann über idShort benannt werden."
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Main subdivision possibility for properties. Can be named via idShort."
+                  }
+                ]
               }
             }
           ]
@@ -1670,62 +1971,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Untersektion für Merkmale"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Subsection for properties"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Subsection "
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Untersektion "
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Untergeordnete Unterteilungsmöglichkeit für Merkmale. Kann über idShort benannt werden."
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Subordinate subdivision possibility for properties. Can be named via idShort."
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Untersektion für Merkmale"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Subsection for properties"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Subsection "
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Untersektion "
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Untergeordnete Unterteilungsmöglichkeit für Merkmale. Kann über idShort benannt werden."
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Subordinate subdivision possibility for properties. Can be named via idShort."
+                  }
+                ]
               }
             }
           ]
@@ -1750,62 +2064,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Weitere Informationen"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Further information"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Further information"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Weitere Informationen"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "de",
-                        "text": "Weiterführende Informationen zum Produkt, der Gültigkeit der gemachten Angaben und zu diesem Datensatz"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "en",
-                        "text": "Further information on the product, the validity of the information provided and this data record"
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Weitere Informationen"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Further information"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Further information"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Weitere Informationen"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Weiterführende Informationen zum Produkt, der Gültigkeit der gemachten Angaben und zu diesem Datensatz"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Further information on the product, the validity of the information provided and this data record"
+                  }
+                ]
               }
             }
           ]
@@ -1825,62 +2152,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Aussage des Herstellers als Text"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Statement by the manufacturer as text"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Valid on date"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Gültig am"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "STRING",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Statement in text form, e.g. scope of validity of the statements."
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Aussage in Textform, etwa Gültigkeitsbereich der Aussagen."
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Aussage des Herstellers als Text"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Statement by the manufacturer as text"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Valid on date"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Gültig am"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Statement in text form, e.g. scope of validity of the statements."
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Aussage in Textform, etwa Gültigkeitsbereich der Aussagen."
+                  }
+                ]
               }
             }
           ]
@@ -1900,62 +2240,75 @@
           "embeddedDataSpecifications": [
             {
               "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
-              "dataSpecificationContent": {
-                "$type": "AdminShellNS.AdminShellV20+DataSpecificationContent, AasxCsharpLibrary",
-                "dataSpecificationIEC61360": {
-                  "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
-                  "preferredName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Informationen gültig am"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Information valid on date"
-                      }
-                    ]
-                  },
-                  "shortName": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Valid on date"
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Gültig am"
-                      }
-                    ]
-                  },
-                  "unit": "",
-                  "dataType": "DATE",
-                  "definition": {
-                    "$type": "AdminShellNS.AdminShellV20+LangStringSetIEC61360, AasxCsharpLibrary",
-                    "langString": [
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "EN",
-                        "text": "Denotes a date on which the data specified in the submodel was valid for the associated product. Approximately: Date of the last update of the data."
-                      },
-                      {
-                        "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
-                        "language": "DE",
-                        "text": "Bezeichnet ein Datum, an welchem die im Submodel genannten Daten für das assoziierte Produkt gültig waren. Etwa: Tag der letzten Aktualisierung der Daten."
-                      }
-                    ]
-                  }
-                }
-              },
               "dataSpecification": {
                 "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
-                "keys": []
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Informationen gültig am"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Information valid on date"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Valid on date"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Gültig am"
+                  }
+                ],
+                "unit": "",
+                "dataType": "DATE",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Denotes a date on which the data specified in the submodel was valid for the associated product. Approximately: Date of the last update of the data."
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Bezeichnet ein Datum, an welchem die im Submodel genannten Daten für das assoziierte Produkt gültig waren. Etwa: Tag der letzten Aktualisierung der Daten."
+                  }
+                ]
               }
             }
           ]

--- a/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData_v11.add-options.json
+++ b/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData_v11.add-options.json
@@ -1,0 +1,2319 @@
+{
+  "$type": "Options",
+  "Records": [
+    {
+      "$type": "Record",
+      "FormTag": "TEC",
+      "FormTitle": "Technical data (sheet) model",
+      "FormSubmodel": {
+        "$type": "FormSubmodel",
+        "FormTitle": "Submodel",
+        "FormInfo": "",
+        "FormEditIdShort": false,
+        "FormEditDescription": false,
+        "PresetIdShort": "TechnicalData",
+        "PresetCategory": "CONSTANT",
+        "KeySemanticId": {
+          "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+          "type": "Submodel",
+          "local": false,
+          "value": "http://admin-shell.io/sandbox/SG2/TechnicalData/Submodel/1/1",
+          "index": 0,
+          "idType": "IRI"
+        },
+        "SubmodelElements": [
+          {
+            "$type": "FormSubmodelElementCollection",
+            "FormTitle": "GeneralInformation",
+            "FormEditIdShort": false,
+            "FormEditDescription": false,
+            "PresetIdShort": "GeneralInformation",
+            "KeySemanticId": {
+              "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/GeneralInformation/1/1",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Multiplicity": "One",
+            "IsReadOnly": false,
+            "value": [
+              {
+                "$type": "FormProperty",
+                "FormTitle": "ManufacturerName",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
+                "PresetIdShort": "ManufacturerName",
+                "KeySemanticId": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerName/1/1",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Multiplicity": "One",
+                "IsReadOnly": false,
+                "allowedValueTypes": [
+                  ""
+                ],
+                "presetValue": ""
+              },
+              {
+                "$type": "FormFile",
+                "FormTitle": "ManufacturerLogo",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
+                "PresetIdShort": "ManufacturerLogo",
+                "KeySemanticId": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerLogo/1/1",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Multiplicity": "ZeroToOne",
+                "IsReadOnly": false,
+                "presetMimeType": ""
+              },
+              {
+                "$type": "FormProperty",
+                "FormTitle": "ManufacturerProductDesignation",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
+                "PresetIdShort": "ManufacturerProductDesignation",
+                "KeySemanticId": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerProductDesignation/1/1",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Multiplicity": "One",
+                "IsReadOnly": false,
+                "allowedValueTypes": [
+                  "string"
+                ],
+                "presetValue": ""
+              },
+              {
+                "$type": "FormProperty",
+                "FormTitle": "ManufacturerPartNumber",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
+                "PresetIdShort": "ManufacturerPartNumber",
+                "KeySemanticId": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerPartNumber/1/1",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Multiplicity": "ZeroToOne",
+                "IsReadOnly": false,
+                "allowedValueTypes": [
+                  "string"
+                ],
+                "presetValue": ""
+              },
+              {
+                "$type": "FormProperty",
+                "FormTitle": "ManufacturerOrderCode",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
+                "PresetIdShort": "ManufacturerOrderCode",
+                "KeySemanticId": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerOrderCode/1/1",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Multiplicity": "ZeroToOne",
+                "IsReadOnly": false,
+                "allowedValueTypes": [
+                  "string"
+                ],
+                "presetValue": ""
+              },
+              {
+                "$type": "FormFile",
+                "FormTitle": "ProductImage",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
+                "PresetIdShort": "ProductImage{0:00}",
+                "KeySemanticId": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductImage/1/1",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Multiplicity": "ZeroToMany",
+                "IsReadOnly": false,
+                "presetMimeType": ""
+              }
+            ]
+          },
+          {
+            "$type": "FormSubmodelElementCollection",
+            "FormTitle": "ProductClassifications",
+            "FormEditIdShort": false,
+            "FormEditDescription": false,
+            "PresetIdShort": "ProductClassifications",
+            "KeySemanticId": {
+              "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassifications/1/1",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Multiplicity": "One",
+            "IsReadOnly": false,
+            "value": [
+              {
+                "$type": "FormSubmodelElementCollection",
+                "FormTitle": "ProductClassificationItem{00}",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
+                "PresetIdShort": "ProductClassificationItem{00}{0:00}",
+                "KeySemanticId": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassificationItem/1/1",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Multiplicity": "ZeroToMany",
+                "IsReadOnly": false,
+                "value": [
+                  {
+                    "$type": "FormProperty",
+                    "FormTitle": "ProductClassificationSystem",
+                    "FormEditIdShort": false,
+                    "FormEditDescription": false,
+                    "PresetIdShort": "ProductClassificationSystem",
+                    "KeySemanticId": {
+                      "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassificationSystem/1/1",
+                      "index": 0,
+                      "idType": "IRI"
+                    },
+                    "Multiplicity": "One",
+                    "IsReadOnly": false,
+                    "allowedValueTypes": [
+                      ""
+                    ],
+                    "presetValue": ""
+                  },
+                  {
+                    "$type": "FormProperty",
+                    "FormTitle": "ClassificationSystemVersion",
+                    "FormEditIdShort": false,
+                    "FormEditDescription": false,
+                    "PresetIdShort": "ClassificationSystemVersion",
+                    "KeySemanticId": {
+                      "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ClassificationSystemVersion/1/1",
+                      "index": 0,
+                      "idType": "IRI"
+                    },
+                    "Multiplicity": "ZeroToOne",
+                    "IsReadOnly": false,
+                    "allowedValueTypes": [
+                      ""
+                    ],
+                    "presetValue": ""
+                  },
+                  {
+                    "$type": "FormProperty",
+                    "FormTitle": "ProductClassId",
+                    "FormEditIdShort": false,
+                    "FormEditDescription": false,
+                    "PresetIdShort": "ProductClassId",
+                    "KeySemanticId": {
+                      "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassId/1/1",
+                      "index": 0,
+                      "idType": "IRI"
+                    },
+                    "Multiplicity": "One",
+                    "IsReadOnly": false,
+                    "allowedValueTypes": [
+                      ""
+                    ],
+                    "presetValue": ""
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "$type": "FormSubmodelElementCollection",
+            "FormTitle": "TechnicalProperties",
+            "FormEditIdShort": false,
+            "FormEditDescription": false,
+            "PresetIdShort": "TechnicalProperties",
+            "KeySemanticId": {
+              "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/TechnicalProperties/1/1",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Multiplicity": "One",
+            "IsReadOnly": false,
+            "value": [
+              {
+                "$type": "FormProperty",
+                "FormTitle": "SemanticIdNotAvailable",
+                "FormEditIdShort": true,
+                "FormEditDescription": true,
+                "PresetIdShort": "SemanticIdNotAvailable{0:00}",
+                "KeySemanticId": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://admin-shell.io/SemanticIdNotAvailable /1/1 ",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Multiplicity": "ZeroToMany",
+                "IsReadOnly": false,
+                "allowedValueTypes": [
+                  "string"
+                ],
+                "presetValue": ""
+              },
+              {
+                "$type": "FormSubmodelElementCollection",
+                "FormTitle": "MainSection",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
+                "PresetIdShort": "MainSection{0:00}",
+                "KeySemanticId": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/MainSection/1/1",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Multiplicity": "ZeroToMany",
+                "IsReadOnly": false,
+                "value": [
+                  {
+                    "$type": "FormProperty",
+                    "FormTitle": "SemanticIdNotAvailable",
+                    "FormEditIdShort": true,
+                    "FormEditDescription": true,
+                    "PresetIdShort": "SemanticIdNotAvailable{0:00}",
+                    "KeySemanticId": {
+                      "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "https://admin-shell.io/SemanticIdNotAvailable /1/1 ",
+                      "index": 0,
+                      "idType": "IRI"
+                    },
+                    "Multiplicity": "ZeroToMany",
+                    "IsReadOnly": false,
+                    "allowedValueTypes": [
+                      ""
+                    ],
+                    "presetValue": ""
+                  },
+                  {
+                    "$type": "FormSubmodelElementCollection",
+                    "FormTitle": "SubSection",
+                    "FormEditIdShort": false,
+                    "FormEditDescription": false,
+                    "PresetIdShort": "SubSection{0:00}",
+                    "KeySemanticId": {
+                      "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/SubSection/1/1",
+                      "index": 0,
+                      "idType": "IRI"
+                    },
+                    "Multiplicity": "ZeroToMany",
+                    "IsReadOnly": false,
+                    "value": [
+                      {
+                        "$type": "FormProperty",
+                        "FormTitle": "SemanticIdNotAvailable",
+                        "FormEditIdShort": true,
+                        "FormEditDescription": true,
+                        "PresetIdShort": "SemanticIdNotAvailable{0:00}",
+                        "KeySemanticId": {
+                          "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                          "type": "ConceptDescription",
+                          "local": true,
+                          "value": "https://admin-shell.io/SemanticIdNotAvailable /1/1 ",
+                          "index": 0,
+                          "idType": "IRI"
+                        },
+                        "Multiplicity": "ZeroToMany",
+                        "IsReadOnly": false,
+                        "allowedValueTypes": [
+                          ""
+                        ],
+                        "presetValue": ""
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "$type": "FormSubmodelElementCollection",
+            "FormTitle": "FurtherInformation",
+            "FormEditIdShort": false,
+            "FormEditDescription": false,
+            "PresetIdShort": "FurtherInformation",
+            "KeySemanticId": {
+              "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/FurtherInformation/1/1",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Multiplicity": "One",
+            "IsReadOnly": false,
+            "value": [
+              {
+                "$type": "FormProperty",
+                "FormTitle": "TextStatement",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
+                "PresetIdShort": "TextStatement{0:00}",
+                "KeySemanticId": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/TextStatement/1/1",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Multiplicity": "ZeroToMany",
+                "IsReadOnly": false,
+                "allowedValueTypes": [
+                  "string"
+                ],
+                "presetValue": ""
+              },
+              {
+                "$type": "FormProperty",
+                "FormTitle": "ValidDate",
+                "FormEditIdShort": false,
+                "FormEditDescription": false,
+                "PresetIdShort": "ValidDate",
+                "KeySemanticId": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://admin-shell.io/sandbox/SG2/TechnicalData/ValidDate/1/1",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Multiplicity": "One",
+                "IsReadOnly": false,
+                "allowedValueTypes": [
+                  "date"
+                ],
+                "presetValue": ""
+              }
+            ]
+          }
+        ]
+      },
+      "ConceptDescriptions": [
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/GeneralInformation/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "GeneralInformation",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Generelle Informationen"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "General information"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "General information"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Generelle Informationen"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Generelle Informationen, zum Beispiel Bestell- und Herstellerinformationen"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "General information, for example ordering and manufacturer information"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerName/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "ManufacturerName",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Herstellername"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Manufacturer name"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Herstellername"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Manufacturer name"
+                  }
+                ],
+                "unit": "",
+                "symbol": "string",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "legally valid designation of the natural or judicial person which is directly responsible for the design, production, packaging and labeling of a product in respect to its being brought into circulation"
+                  }
+                ]
+              }
+            }
+          ],
+          "isCaseOf": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+Reference, AasxCsharpLibrary",
+              "keys": [
+                {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "0173-1#02-AAO677#002",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              ],
+              "First": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO677#002",
+                "index": 0,
+                "idType": "IRDI"
+              },
+              "Last": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO677#002",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerLogo/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "ManufacturerLogo",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Herstellerlogo-Datei"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "File with manufactuer logo"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Herstellerlogo"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Manufactuer logo"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Bilddatei für Logo des Herstellers im gebräuchlichem Format (.png, .jpg). "
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Imagefile for logo of manufacturer provided in common format (.png, .jpg). "
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerProductDesignation/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "ManufacturerProductDesignation",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Herstellerproduktbezeichnung"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Manufacturer product designation"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Product designation"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktbezeichnung"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Kurze Beschreibung des Produktes (Kurztext)"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Short description of the product (short text)"
+                  }
+                ]
+              }
+            }
+          ],
+          "isCaseOf": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+Reference, AasxCsharpLibrary",
+              "keys": [
+                {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "0173-1#02-AAW338#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              ],
+              "First": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAW338#001",
+                "index": 0,
+                "idType": "IRDI"
+              },
+              "Last": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAW338#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerPartNumber/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "ManufacturerPartNumber",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Herstellerartikelnummer"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "product article number of manufacturer"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Manufacturer order code"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Herstellerbestellcode"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "eindeutiger Bestellschlüssel des Herstellers"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "unique product identifier of the manufacturer"
+                  }
+                ]
+              }
+            }
+          ],
+          "isCaseOf": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+Reference, AasxCsharpLibrary",
+              "keys": [
+                {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "0173-1#02-AAO676#003",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              ],
+              "First": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO676#003",
+                "index": 0,
+                "idType": "IRDI"
+              },
+              "Last": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO676#003",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerOrderCode/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "ManufacturerOrderCode",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Eindeutiger Herstellerbestellcode"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Unique manufacturer order code"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Manufacturer order code"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Herstellerbestellcode"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "eindeutiger Bestellschlüssel des Herstellers um exakt gleiches Produkt zu bestellen"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "unique product identifier of the manufacturer sufficient to order exact same produkt"
+                  }
+                ]
+              }
+            }
+          ],
+          "isCaseOf": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+Reference, AasxCsharpLibrary",
+              "keys": [
+                {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "0173-1#02-AAO676#003",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              ],
+              "First": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO676#003",
+                "index": 0,
+                "idType": "IRDI"
+              },
+              "Last": {
+                "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                "type": "GlobalReference",
+                "local": false,
+                "value": "0173-1#02-AAO676#003",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductImage/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "ProductImage",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Bilddatei für Produkt"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Imagefile for product"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Product image"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktbild"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Bilddatei für das assozierte Produkt im gebräuchlichem Format (.png, .jpg). "
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Imagefile for associated product provided in common format (.png, .jpg). "
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassifications/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "ProductClassifications",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Produktklassifizierungen"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "ProductClassifications"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "ProductClassification"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktklassifizierung"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Produktklassifizierungen durch Assoziation mit Produktklassen in gebräuchlichen Klassifizierungssystemen."
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Product classifications by association with product classes in common classification systems."
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassificationItem/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "ProductClassificationItem",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Einzelne Produktklassifizierung"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Single ProductClassification"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "ProductClassification"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktklassifizierung"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Einzelne Produktklassifizierung durch Assoziation mit einer Produktklasse"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Single product classification by association with product class"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassificationSystem/1/1"
+          },
+          "idShort": "ProductClassificationSystem",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Klassifikationssystem"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Classification system"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Classification system"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Klassifikationssystem"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Common name of the product classification system"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Gebräuchlicher Name für das Produkt-Klassifikationssystem"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ClassificationSystemVersion/1/1"
+          },
+          "idShort": "ClassificationSystemVersion",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Versionskennung des Klassifikationssystems"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Verison id  of the classification system"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Version class. system"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Version Klass.-System"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Common version identifier of the used classification system"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Gebräuchliche Versionskennung des genutzen Klassifikationssystems"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassId/1/1"
+          },
+          "idShort": "ProductClassId",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktklasse im System"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Product class in system"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Product class"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Produktklasse "
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Class of the associated product in the classification system; according to the notation of the system"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Klasse des assoziierten Produktes im Klassifikationssystem; entsprechend der Notationsweise des Systems."
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/TechnicalProperties/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "TechnicalProperties",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Technische und Produktmerkmale"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Technical and product properties"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Properties"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Merkmale"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Einzelne Merkmale die das Produkt und die technischen Eigenschaften beschreiben"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Individual characteristics that describe the product and its technical properties"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/SemanticIdNotAvailable /1/1 "
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "SemanticIdNotAvailable",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Merkmal ohne SemanticId"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Property without SemanticId"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Property without SemanticId"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Merkmal ohne SemanticId"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Merkmal, welches nicht über ein gebräuchliches Klassifikationssystem beschrieben ist"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Property that is not described using a common classification system"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/MainSection/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "MainSection",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Hauptsektion für Merkmale"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Main section for properties"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Main section"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Hauptsektion"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Haupt-Unterteilungsmöglichkeit für Merkmale. Kann über idShort benannt werden."
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Main subdivision possibility for properties. Can be named via idShort."
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/SubSection/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "SubSection",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Untersektion für Merkmale"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Subsection for properties"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Subsection "
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Untersektion "
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Untergeordnete Unterteilungsmöglichkeit für Merkmale. Kann über idShort benannt werden."
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Subordinate subdivision possibility for properties. Can be named via idShort."
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/FurtherInformation/1/1"
+          },
+          "administration": {
+            "$type": "AdminShellNS.AdminShellV20+Administration, AasxCsharpLibrary",
+            "version": "",
+            "revision": "1"
+          },
+          "idShort": "FurtherInformation",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Weitere Informationen"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Further information"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Further information"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Weitere Informationen"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "de",
+                    "text": "Weiterführende Informationen zum Produkt, der Gültigkeit der gemachten Angaben und zu diesem Datensatz"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "en",
+                    "text": "Further information on the product, the validity of the information provided and this data record"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/TextStatement/1/1"
+          },
+          "idShort": "TextStatement",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Aussage des Herstellers als Text"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Statement by the manufacturer as text"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Valid on date"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Gültig am"
+                  }
+                ],
+                "unit": "",
+                "dataType": "STRING",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Statement in text form, e.g. scope of validity of the statements."
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Aussage in Textform, etwa Gültigkeitsbereich der Aussagen."
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$type": "AdminShellNS.AdminShellV20+ConceptDescription, AasxCsharpLibrary",
+          "identification": {
+            "$type": "AdminShellNS.AdminShellV20+Identification, AasxCsharpLibrary",
+            "idType": "IRI",
+            "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ValidDate/1/1"
+          },
+          "idShort": "ValidDate",
+          "modelType": {
+            "$type": "AdminShellNS.AdminShellV20+JsonModelTypeWrapper, AasxCsharpLibrary",
+            "name": "ConceptDescription"
+          },
+          "embeddedDataSpecifications": [
+            {
+              "$type": "AdminShellNS.AdminShellV20+EmbeddedDataSpecification, AasxCsharpLibrary",
+              "dataSpecification": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationRef, AasxCsharpLibrary",
+                "keys": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "$type": "AdminShellNS.AdminShellV20+Key, AasxCsharpLibrary",
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "dataSpecificationContent": {
+                "$type": "AdminShellNS.AdminShellV20+DataSpecificationIEC61360, AasxCsharpLibrary",
+                "preferredName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Informationen gültig am"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Information valid on date"
+                  }
+                ],
+                "shortName": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Valid on date"
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Gültig am"
+                  }
+                ],
+                "unit": "",
+                "dataType": "DATE",
+                "definition": [
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "EN",
+                    "text": "Denotes a date on which the data specified in the submodel was valid for the associated product. Approximately: Date of the last update of the data."
+                  },
+                  {
+                    "$type": "AdminShellNS.AdminShellV20+LangStr, AasxCsharpLibrary",
+                    "language": "DE",
+                    "text": "Bezeichnet ein Datum, an welchem die im Submodel genannten Daten für das assoziierte Produkt gültig waren. Etwa: Tag der letzten Aktualisierung der Daten."
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasxPluginGenericForms/Plugin.cs
+++ b/src/AasxPluginGenericForms/Plugin.cs
@@ -57,7 +57,7 @@ namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 
                 // try find additional options
                 this.options.TryLoadAdditionalOptionsFromAssemblyDir<AasxPluginGenericForms.GenericFormOptions>(
-                    this.GetPluginName(), Assembly.GetExecutingAssembly(), settings);
+                    this.GetPluginName(), Assembly.GetExecutingAssembly(), settings, this.Log);
             }
             catch (Exception ex)
             {

--- a/src/AasxPluginMtpViewer/MtpViewerOptions.cs
+++ b/src/AasxPluginMtpViewer/MtpViewerOptions.cs
@@ -30,7 +30,7 @@ namespace AasxPluginMtpViewer
         /// </summary>
         public static MtpViewerOptions CreateDefault()
         {
-            var defs = new DefinitionsMTP.ModuleTypePackage(new DefinitionsMTP());
+            var defs = new DefinitionsMTP.ModuleTypePackage();
 
             var rec1 = new MtpViewerOptionsRecord();
             rec1.RecordType = MtpViewerOptionsRecord.MtpRecordType.MtpType;

--- a/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml.cs
+++ b/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml.cs
@@ -59,9 +59,8 @@ namespace AasxPluginMtpViewer
             InitializeComponent();
 
             // use pre-definitions
-            this.defsInterop = new AasxPredefinedConcepts.DefinitionsExperimental.InteropRelations(
-                new AasxPredefinedConcepts.DefinitionsExperimental());
-            this.defsMtp = new DefinitionsMTP.ModuleTypePackage(new DefinitionsMTP());
+            this.defsInterop = new AasxPredefinedConcepts.DefinitionsExperimental.InteropRelations();
+            this.defsMtp = new DefinitionsMTP.ModuleTypePackage();
         }
 
         public void Start(

--- a/src/AasxPluginTechnicalData/AasxPluginTechnicalData.options.json
+++ b/src/AasxPluginTechnicalData/AasxPluginTechnicalData.options.json
@@ -10,6 +10,17 @@
           "idType": "IRI"
         }
       ]
+    },
+    {
+      "AllowSubmodelSemanticId": [
+        {
+          "type": "Submodel",
+          "local": false,
+          "value": "http://admin-shell.io/sandbox/SG2/TechnicalData/Submodel/1/1",
+          "index": 0,
+          "idType": "IRI"
+        }
+      ]
     }
   ]
 }

--- a/src/AasxPluginTechnicalData/TechDataFooterControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechDataFooterControl.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxPredefinedConcepts;
+using AasxPredefinedConcepts.ConceptModel;
 using AdminShellNS;
 
 namespace AasxPluginTechnicalData
@@ -28,7 +29,7 @@ namespace AasxPluginTechnicalData
         }
 
         public void SetContents(
-            AdminShellPackageEnv package, DefinitionsZveiTechnicalData.SetOfDefs theDefs, string defaultLang,
+            AdminShellPackageEnv package, ConceptModelZveiTechnicalData theDefs, string defaultLang,
             AdminShell.Submodel sm)
         {
             // access

--- a/src/AasxPluginTechnicalData/TechDataHeaderControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechDataHeaderControl.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AasxPredefinedConcepts;
+using AasxPredefinedConcepts.ConceptModel;
 using AdminShellNS;
 using JetBrains.Annotations;
 
@@ -60,7 +61,7 @@ namespace AasxPluginTechnicalData
         }
 
         public void SetContents(
-            AdminShellPackageEnv package, DefinitionsZveiTechnicalData.SetOfDefs theDefs, string defaultLang,
+            AdminShellPackageEnv package, ConceptModelZveiTechnicalData theDefs, string defaultLang,
             AdminShell.Submodel sm)
         {
             // access
@@ -134,15 +135,15 @@ namespace AasxPluginTechnicalData
                     var sys = (
                         "" +
                         smc.value.FindFirstSemanticIdAs<AdminShell.Property>(
-                            theDefs.CD_ClassificationSystem.GetSingleKey())?.value).Trim();
+                            theDefs.CD_ProductClassificationSystem.GetSingleKey())?.value).Trim();
                     var ver = (
                         "" +
                         smc.value.FindFirstSemanticIdAs<AdminShell.Property>(
-                            theDefs.CD_SystemVersion.GetSingleKey())?.value).Trim();
+                            theDefs.CD_ClassificationSystemVersion.GetSingleKey())?.value).Trim();
                     var cls = (
                         "" +
                         smc.value.FindFirstSemanticIdAs<AdminShell.Property>(
-                            theDefs.CD_ProductClass.GetSingleKey())?.value).Trim();
+                            theDefs.CD_ProductClassId.GetSingleKey())?.value).Trim();
                     if (sys != "" && cls != "")
                         clr.Add(new ClassificationRecord(sys, ver, cls));
                 }

--- a/src/AasxPluginTechnicalData/TechDataPropertiesControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechDataPropertiesControl.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AasxPredefinedConcepts;
+using AasxPredefinedConcepts.ConceptModel;
 using AdminShellNS;
 
 namespace AasxPluginTechnicalData
@@ -46,7 +47,7 @@ namespace AasxPluginTechnicalData
         }
 
         public void TableAddPropertyRows_Recurse(
-            DefinitionsZveiTechnicalData.SetOfDefs theDefs, string defaultLang, AdminShellPackageEnv package,
+            ConceptModelZveiTechnicalData theDefs, string defaultLang, AdminShellPackageEnv package,
             Table table, AdminShell.SubmodelElementWrapperCollection smwc, int depth = 0)
         {
             // access
@@ -75,8 +76,8 @@ namespace AasxPluginTechnicalData
                 // make up semantics
                 if (sme.semanticId != null)
                 {
-                    if (sme.semanticId.Matches(theDefs.CD_NonstandardizedProperty.GetSingleKey()))
-                        semantics = "Non-standardized";
+                    if (sme.semanticId.Matches(theDefs.CD_SemanticIdNotAvailable.GetSingleKey()))
+                        semantics = "(not available)";
                     else
                     {
                         // the semantics display
@@ -184,7 +185,7 @@ namespace AasxPluginTechnicalData
         }
 
         public FlowDocument CreateFlowDocument(
-            AdminShellPackageEnv package, DefinitionsZveiTechnicalData.SetOfDefs theDefs,
+            AdminShellPackageEnv package, ConceptModelZveiTechnicalData theDefs,
             string defaultLang, AdminShell.Submodel sm)
         {
             // access
@@ -256,7 +257,7 @@ namespace AasxPluginTechnicalData
         }
 
         public void SetContents(
-            AdminShellPackageEnv package, DefinitionsZveiTechnicalData.SetOfDefs theDefs, string defaultLang,
+            AdminShellPackageEnv package, ConceptModelZveiTechnicalData theDefs, string defaultLang,
             AdminShell.Submodel sm)
         {
             FlowDocViewer.Document = CreateFlowDocument(package, theDefs, defaultLang, sm);

--- a/src/AasxPluginTechnicalData/TechnicalDataOptions.cs
+++ b/src/AasxPluginTechnicalData/TechnicalDataOptions.cs
@@ -21,15 +21,22 @@ namespace AasxPluginTechnicalData
         /// </summary>
         public static TechnicalDataOptions CreateDefault()
         {
-            var rec = new TechnicalDataOptionsRecord();
-            rec.AllowSubmodelSemanticId.Add(AdminShell.Key.CreateNew(
-                type: "Submodel",
-                local: false,
-                idType: "IRI",
-                value: "http://smart.festo.com/id/type/submodel/TechnicalDatat/1/1"));
+            // definitions
+            var defsV10 = new AasxPredefinedConcepts.DefinitionsZveiTechnicalData.SetOfDefs(
+                    new AasxPredefinedConcepts.DefinitionsZveiTechnicalData());
+            var defsV11 = AasxPredefinedConcepts.ZveiTechnicalDataV11.Static;
+
+            // records
 
             var opt = new TechnicalDataOptions();
-            opt.Records.Add(rec);
+
+            var rec10 = new TechnicalDataOptionsRecord();
+            rec10.AllowSubmodelSemanticId.Add(defsV10.SM_TechnicalData.GetSemanticKey());
+            opt.Records.Add(rec10);
+
+            var rec11 = new TechnicalDataOptionsRecord();
+            rec11.AllowSubmodelSemanticId.Add(defsV11.SM_TechnicalData.GetSemanticKey());
+            opt.Records.Add(rec11);
 
             return opt;
         }

--- a/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml.cs
@@ -15,6 +15,7 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AasxPluginTechnicalData.Tetra.Framework.WPF;
 using AasxPredefinedConcepts;
+using AasxPredefinedConcepts.ConceptModel;
 using AdminShellNS;
 
 namespace AasxPluginTechnicalData
@@ -29,7 +30,7 @@ namespace AasxPluginTechnicalData
             InitializeComponent();
         }
 
-        private DefinitionsZveiTechnicalData.SetOfDefs theDefs = null;
+        private ConceptModelZveiTechnicalData theDefs = null;
         private AdminShellPackageEnv thePackage = null;
         private AdminShell.Submodel theSubmodel = null;
         private TechnicalDataOptions theOptions = null;
@@ -50,7 +51,7 @@ namespace AasxPluginTechnicalData
             this.theEventStack = eventStack;
 
             // retrieve the Definitions
-            this.theDefs = new DefinitionsZveiTechnicalData.SetOfDefs(new DefinitionsZveiTechnicalData());
+            this.theDefs = new ConceptModelZveiTechnicalData(sm);
 
             // ok, directly set contents
             SetContents();

--- a/src/AasxPredefinedConcepts/AasxDefinitionBase.cs
+++ b/src/AasxPredefinedConcepts/AasxDefinitionBase.cs
@@ -38,6 +38,8 @@ namespace AasxPredefinedConcepts
 
         protected List<AdminShell.Referable> theReflectedReferables = new List<AdminShell.Referable>();
 
+        public string DomainInfo = "";
+
         //
         // Constructors
         //
@@ -165,7 +167,7 @@ namespace AasxPredefinedConcepts
             return this.theReflectedReferables?.ToArray();
         }
 
-        public void RetrieveEntriesByReflection(Type typeToReflect = null,
+        public void RetrieveEntriesFromLibraryByReflection(Type typeToReflect = null,
             bool useAttributes = false, bool useFieldNames = false)
         {
             // access
@@ -211,6 +213,43 @@ namespace AasxPredefinedConcepts
                     fi.SetValue(this, cd);
                     this.theReflectedReferables.Add(cd);
                 }
+            }
+        }
+
+        public void AddEntriesByReflection(Type typeToReflect = null,
+            bool useAttributes = false, bool useFieldNames = false)
+        {
+            // access
+            if (typeToReflect == null)
+                return;
+
+            // reflection
+            foreach (var fi in typeToReflect.GetFields())
+            {
+                // libName
+                var fiName = "" + fi.Name;
+
+                // test
+                var ok = false;
+                var isSM = fi.FieldType == typeof(AdminShell.Submodel);
+                var isCD = fi.FieldType == typeof(AdminShell.ConceptDescription);
+
+                if (useAttributes && fi.GetCustomAttribute(typeof(RetrieveReferableForField)) != null)
+                    ok = true;
+
+                if (useFieldNames && isSM && fiName.StartsWith("SM_"))
+                    ok = true;
+
+                if (useFieldNames && isCD && fiName.StartsWith("CD_"))
+                    ok = true;
+
+                if (!ok)
+                    continue;
+
+                // add
+                var rf = fi.GetValue(this) as AdminShell.Referable;
+                if (rf != null)
+                    this.theReflectedReferables.Add(rf);
             }
         }
     }

--- a/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
+++ b/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
@@ -52,11 +54,12 @@
     <Compile Include="Convert\ConvertDocumentationHsuToSg2.cs" />
     <Compile Include="Convert\ConvertPredefinedConcepts.cs" />
     <Compile Include="Convert\ConvertTechnicalDataToFlat.cs" />
-    <Compile Include="DefinitionsPackageExplorer.cs" />
+    <Compile Include="PackageExplorer.cs" />
     <Compile Include="DefinitionsImageMap.cs" />
     <Compile Include="DefinitionsMTP.cs" />
     <Compile Include="DefinitionsExperimental.cs" />
     <Compile Include="DefinitionsLanguages.cs" />
+    <Compile Include="DefinitionsPool.cs" />
     <Compile Include="DefinitionsV2770v11.cs" />
     <Compile Include="DefinitionsZveiTechnicalData.cs" />
     <Compile Include="DefinitionsZveiDigitalTypeplate.cs" />

--- a/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
+++ b/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
@@ -49,11 +49,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AasxDefinitionBase.cs" />
+    <Compile Include="ConceptModel\ConceptModelZveiTechnicalData.cs" />
     <Compile Include="Convert\ConvertDocumentationSg2ToHsu.cs" />
+    <Compile Include="Convert\ConvertTechnicalDataV10ToV11.cs" />
     <Compile Include="Convert\ConvertDocumentationSg2ToV11.cs" />
     <Compile Include="Convert\ConvertDocumentationHsuToSg2.cs" />
     <Compile Include="Convert\ConvertPredefinedConcepts.cs" />
     <Compile Include="Convert\ConvertTechnicalDataToFlat.cs" />
+    <Compile Include="DefinitionsZveiTechnicalDataV11.cs" />
     <Compile Include="PackageExplorer.cs" />
     <Compile Include="DefinitionsImageMap.cs" />
     <Compile Include="DefinitionsMTP.cs" />
@@ -84,6 +87,7 @@
     <EmbeddedResource Include="Resources\ZveiTechnicalData.json" />
     <EmbeddedResource Include="Resources\ZveiDigitalTypeplate_old.json" />
     <EmbeddedResource Include="Resources\VDI2770v11.json" />
+    <EmbeddedResource Include="Resources\ZveiTechnicalDataV11.json" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\VDI2770.json" />

--- a/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
+++ b/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>AasxPredefinedConcepts</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <Nullable>Enable</Nullable>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>8.0</LangVersion>
+    <Nullable>Enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>8.0</LangVersion>
+    <Nullable>Enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">

--- a/src/AasxPredefinedConcepts/ConceptModel/ConceptModelZveiTechnicalData.cs
+++ b/src/AasxPredefinedConcepts/ConceptModel/ConceptModelZveiTechnicalData.cs
@@ -1,0 +1,135 @@
+﻿using AdminShellNS;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AasxPredefinedConcepts.ConceptModel
+{
+    /// <summary>
+    /// This class integrates/ abstracts the concept definitions of multiple versions
+    /// of ZVEI TechnicalData
+    /// </summary>
+    public class ConceptModelZveiTechnicalData
+    {
+        public enum Version { Unknown, V1_0, V1_1 }
+
+        public Version ActiveVersion = Version.Unknown;
+
+        public AdminShell.Submodel
+            SM_TechnicalData;
+
+        public AdminShell.ConceptDescription
+            CD_GeneralInformation,
+            CD_ManufacturerName,
+            CD_ManufacturerLogo,
+            CD_ManufacturerProductDesignation,
+            CD_ManufacturerPartNumber,
+            CD_ManufacturerOrderCode,
+            CD_ProductImage,
+            CD_ProductClassifications,
+            CD_ProductClassificationItem,
+            CD_ProductClassificationSystem,
+            CD_ClassificationSystemVersion,
+            CD_ProductClassId,
+            CD_TechnicalProperties,
+            CD_SemanticIdNotAvailable,
+            CD_MainSection,
+            CD_SubSection,
+            CD_FurtherInformation,
+            CD_TextStatement,
+            CD_ValidDate;
+
+        public ConceptModelZveiTechnicalData() { }
+
+        public ConceptModelZveiTechnicalData(AdminShell.Submodel sm)
+        {
+            InitFromSubmodel(sm);
+        }
+
+        public void InitFromVersion(Version ver)
+        {
+            //
+            // V1.0
+            //
+
+            if (ver == Version.V1_0)
+            {
+                var defsV10 = new AasxPredefinedConcepts.DefinitionsZveiTechnicalData.SetOfDefs(
+                        new AasxPredefinedConcepts.DefinitionsZveiTechnicalData());
+
+                ActiveVersion = Version.V1_0;
+
+                SM_TechnicalData = defsV10.SM_TechnicalData;
+
+                CD_GeneralInformation = defsV10.CD_GeneralInformation;
+                CD_ManufacturerName = defsV10.CD_ManufacturerName;
+                CD_ManufacturerLogo = defsV10.CD_ManufacturerLogo;
+                CD_ManufacturerProductDesignation = defsV10.CD_ManufacturerProductDesignation;
+                CD_ManufacturerPartNumber = defsV10.CD_ManufacturerPartNumber;
+                CD_ManufacturerOrderCode = defsV10.CD_ManufacturerOrderCode;
+                CD_ProductImage = defsV10.CD_ProductImage;
+                CD_ProductClassifications = defsV10.CD_ProductClassifications;
+                CD_ProductClassificationItem = defsV10.CD_ProductClassificationItem;
+                CD_ProductClassificationSystem = defsV10.CD_ClassificationSystem;
+                CD_ClassificationSystemVersion = defsV10.CD_SystemVersion;
+                CD_ProductClassId = defsV10.CD_ProductClass;
+                CD_TechnicalProperties = defsV10.CD_TechnicalProperties;
+                CD_SemanticIdNotAvailable = defsV10.CD_NonstandardizedProperty;
+                CD_MainSection = defsV10.CD_MainSection;
+                CD_SubSection = defsV10.CD_SubSection;
+                CD_FurtherInformation = defsV10.CD_FurtherInformation;
+                CD_TextStatement = defsV10.CD_TextStatement;
+                CD_ValidDate = defsV10.CD_ValidDate;
+            }
+
+            //
+            // V1.1
+            //
+
+            if (ver == Version.V1_1)
+            {
+                var defsV11 = AasxPredefinedConcepts.ZveiTechnicalDataV11.Static;
+
+                ActiveVersion = Version.V1_1;
+
+                SM_TechnicalData = defsV11.SM_TechnicalData;
+
+                CD_GeneralInformation = defsV11.CD_GeneralInformation;
+                CD_ManufacturerName = defsV11.CD_ManufacturerName;
+                CD_ManufacturerLogo = defsV11.CD_ManufacturerLogo;
+                CD_ManufacturerProductDesignation = defsV11.CD_ManufacturerProductDesignation;
+                CD_ManufacturerPartNumber = defsV11.CD_ManufacturerPartNumber;
+                CD_ManufacturerOrderCode = defsV11.CD_ManufacturerOrderCode;
+                CD_ProductImage = defsV11.CD_ProductImage;
+                CD_ProductClassifications = defsV11.CD_ProductClassifications;
+                CD_ProductClassificationItem = defsV11.CD_ProductClassificationItem;
+                CD_ProductClassificationSystem = defsV11.CD_ProductClassificationSystem;
+                CD_ClassificationSystemVersion = defsV11.CD_ClassificationSystemVersion;
+                CD_ProductClassId = defsV11.CD_ProductClassId;
+                CD_TechnicalProperties = defsV11.CD_TechnicalProperties;
+                CD_SemanticIdNotAvailable = defsV11.CD_SemanticIdNotAvailable;
+                CD_MainSection = defsV11.CD_MainSection;
+                CD_SubSection = defsV11.CD_SubSection;
+                CD_FurtherInformation = defsV11.CD_FurtherInformation;
+                CD_TextStatement = defsV11.CD_TextStatement;
+                CD_ValidDate = defsV11.CD_ValidDate;
+            }
+        }
+
+        public void InitFromSubmodel(AdminShell.Submodel sm)
+        {
+            var defsV10 = new AasxPredefinedConcepts.DefinitionsZveiTechnicalData.SetOfDefs(
+                    new AasxPredefinedConcepts.DefinitionsZveiTechnicalData());
+            if (sm?.semanticId.MatchesExactlyOneKey(defsV10.SM_TechnicalData.GetSemanticKey(),
+                AdminShellV20.Key.MatchMode.Relaxed) == true)
+                InitFromVersion(Version.V1_0);
+
+            var defsV11 = AasxPredefinedConcepts.ZveiTechnicalDataV11.Static;
+            if (sm?.semanticId.MatchesExactlyOneKey(defsV11.SM_TechnicalData.GetSemanticKey(),
+                AdminShellV20.Key.MatchMode.Relaxed) == true)
+                InitFromVersion(Version.V1_1);
+        }
+    }
+}

--- a/src/AasxPredefinedConcepts/ConceptModel/ConceptModelZveiTechnicalData.cs
+++ b/src/AasxPredefinedConcepts/ConceptModel/ConceptModelZveiTechnicalData.cs
@@ -1,9 +1,9 @@
-﻿using AdminShellNS;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AdminShellNS;
 
 namespace AasxPredefinedConcepts.ConceptModel
 {

--- a/src/AasxPredefinedConcepts/Convert/ConvertDocumentationHsuToSg2.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertDocumentationHsuToSg2.cs
@@ -93,6 +93,7 @@ namespace AasxPredefinedConcepts.Convert
 
                 // make new SG2 Document + DocumentItem
                 // Document Item
+                // ReSharper disable once ConvertToUsingDeclaration
                 using (var smcDoc = AdminShell.SubmodelElementCollection.CreateNew("" + smcSource.idShort,
                             smcSource.category,
                             AdminShell.Key.GetFromRef(defsSg2.CD_VDI2770_Document.GetCdReference())))

--- a/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToHsu.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToHsu.cs
@@ -105,6 +105,7 @@ namespace AasxPredefinedConcepts.Convert
                         continue;
 
                     // make new HSU Document
+                    // ReSharper disable once ConvertToUsingDeclaration
                     // Document Item
                     using (var smcHsuDoc = AdminShell.SubmodelElementCollection.CreateNew("" + smcDoc.idShort,
                                 smcDoc.category,

--- a/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToV11.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToV11.cs
@@ -98,6 +98,7 @@ namespace AasxPredefinedConcepts.Convert
                         continue;
 
                     // make new V11 Document
+                    // ReSharper disable once ConvertToUsingDeclaration
                     // Document Item
                     using (var smcV11Doc = AdminShell.SubmodelElementCollection.CreateNew("" + smcDoc.idShort,
                                 smcDoc.category,

--- a/src/AasxPredefinedConcepts/Convert/ConvertPredefinedConcepts.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertPredefinedConcepts.cs
@@ -44,6 +44,7 @@ namespace AasxPredefinedConcepts.Convert
             yield return new ConvertDocumentationSg2ToV11Provider();
             yield return new ConvertDocumentationHsuToSg2Provider();
             yield return new ConvertTechnicalDataToFlatProvider();
+            yield return new ConvertTechnicalDataV10ToV11Provider();
         }
 
         public static List<ConvertOfferBase> CheckForOffers(AdminShell.Referable currentReferable)

--- a/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataV10ToV11.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataV10ToV11.cs
@@ -53,7 +53,7 @@ namespace AasxPredefinedConcepts.Convert
                 var special = false;
 
                 // Submodel Handling
-                if (sme?.submodelElement is AdminShell.SubmodelElementCollection smcSectSrc)
+                if (sme.submodelElement is AdminShell.SubmodelElementCollection smcSectSrc)
                 {
                     // what to create?
                     AdminShell.SubmodelElementCollection smcSectDst = null;
@@ -66,8 +66,7 @@ namespace AasxPredefinedConcepts.Convert
                         smcSectDst = smcDest.value.CreateSMEForCD<AdminShell.SubmodelElementCollection>(
                             defsV11.CD_SubSection, addSme: false);
 
-                    if (smcSectDst == null)
-                        smcSectDst = new AdminShell.SubmodelElementCollection(smcSectSrc, shallowCopy: true);
+                    smcSectDst ??= new AdminShell.SubmodelElementCollection(smcSectSrc, shallowCopy: true);
 
                     // add manually
                     smcSectDst.idShort = smcSectSrc.idShort;
@@ -82,15 +81,15 @@ namespace AasxPredefinedConcepts.Convert
                     // was special
                     special = true;
                 }
-                                    
+
                 if (!special)
                 {
                     // just move "by hand", as the old SMEs are already detached
-                    smcDest.Add(sme?.submodelElement);
+                    smcDest.Add(sme.submodelElement);
 
                     // do some fix for "non-standardized"
-                    if (sme?.submodelElement.semanticId?
-                        .MatchesExactlyOneKey(defsV10.CD_NonstandardizedProperty.GetSingleKey(), 
+                    if (sme.submodelElement.semanticId?
+                        .MatchesExactlyOneKey(defsV10.CD_NonstandardizedProperty.GetSingleKey(),
                             AdminShell.Key.MatchMode.Relaxed) == true)
                     {
                         // fix
@@ -150,7 +149,7 @@ namespace AasxPredefinedConcepts.Convert
                                     rf as AdminShell.ConceptDescription));
 
             // General Info (target cardinality: 1)
-            foreach(var smcV10gi in smcV10.FindAllSemanticIdAs<AdminShell.SubmodelElementCollection>(
+            foreach (var smcV10gi in smcV10.FindAllSemanticIdAs<AdminShell.SubmodelElementCollection>(
                         defsV10.CD_GeneralInformation.GetSingleKey()))
             {
                 // make a new one
@@ -159,7 +158,7 @@ namespace AasxPredefinedConcepts.Convert
 
                 // SME
                 smcV11gi.value.CopyOneSMEbyCopy<AdminShell.Property>(defsV11.CD_ManufacturerName,
-                    smcV10gi.value, defsV10.CD_ManufacturerName, 
+                    smcV10gi.value, defsV10.CD_ManufacturerName,
                     createDefault: true, addSme: true);
 
                 smcV11gi.value.CopyOneSMEbyCopy<AdminShell.File>(defsV11.CD_ManufacturerLogo,

--- a/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataV10ToV11.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataV10ToV11.cs
@@ -1,0 +1,247 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AdminShellNS;
+
+namespace AasxPredefinedConcepts.Convert
+{
+    public class ConvertTechnicalDataV10ToV11Provider : ConvertProviderBase
+    {
+        public class ConvertOfferTechnicalDataV10ToV11 : ConvertOfferBase
+        {
+            public ConvertOfferTechnicalDataV10ToV11() { }
+            public ConvertOfferTechnicalDataV10ToV11(ConvertProviderBase provider, string offerDisp)
+                : base(provider, offerDisp) { }
+        }
+
+        public override List<ConvertOfferBase> CheckForOffers(AdminShell.Referable currentReferable)
+        {
+            // collectResults
+            var res = new List<ConvertOfferBase>();
+
+            // use pre-definitions
+            var defs = new AasxPredefinedConcepts.DefinitionsZveiTechnicalData.SetOfDefs(
+                    new AasxPredefinedConcepts.DefinitionsZveiTechnicalData());
+
+            var sm = currentReferable as AdminShell.Submodel;
+            if (sm != null && true == sm.GetSemanticKey()?.Matches(defs.SM_TechnicalData.GetSemanticKey()))
+                res.Add(new ConvertOfferTechnicalDataV10ToV11(this,
+                            $"Convert Submodel '{"" + sm.idShort}' for Technical Data (ZVEI) V1.0 to V1.1"));
+
+            return res;
+        }
+
+        private void RecurseToCopyTechnicalProperties(
+            AasxPredefinedConcepts.ZveiTechnicalDataV11 defsV11,
+            AasxPredefinedConcepts.DefinitionsZveiTechnicalData.SetOfDefs defsV10,
+            AdminShell.SubmodelElementCollection smcDest,
+            AdminShell.SubmodelElementCollection smcSrc)
+        {
+            // access
+            if (defsV10 == null || defsV11 == null || smcDest?.value == null || smcSrc?.value == null)
+                return;
+
+            // for EACH property
+            foreach (var sme in smcSrc.value)
+            {
+                // access
+                if (sme?.submodelElement == null)
+                    continue;
+
+                var special = false;
+
+                // Submodel Handling
+                if (sme?.submodelElement is AdminShell.SubmodelElementCollection smcSectSrc)
+                {
+                    // what to create?
+                    AdminShell.SubmodelElementCollection smcSectDst = null;
+
+                    if (smcSectSrc.semanticId?.Matches(defsV10.CD_MainSection.GetSingleKey()) == true)
+                        smcSectDst = smcDest.value.CreateSMEForCD<AdminShell.SubmodelElementCollection>(
+                            defsV11.CD_MainSection, addSme: false);
+
+                    if (smcSectSrc.semanticId?.Matches(defsV10.CD_SubSection.GetSingleKey()) == true)
+                        smcSectDst = smcDest.value.CreateSMEForCD<AdminShell.SubmodelElementCollection>(
+                            defsV11.CD_SubSection, addSme: false);
+
+                    if (smcSectDst == null)
+                        smcSectDst = new AdminShell.SubmodelElementCollection(smcSectSrc, shallowCopy: true);
+
+                    // add manually
+                    smcSectDst.idShort = smcSectSrc.idShort;
+                    smcSectDst.category = smcSectSrc.category;
+                    if (smcSectSrc.description != null)
+                        smcSectDst.description = new AdminShell.Description(smcSectSrc.description);
+                    smcDest.value.Add(smcSectDst);
+
+                    // recurse
+                    RecurseToCopyTechnicalProperties(defsV11, defsV10, smcSectDst, smcSectSrc);
+
+                    // was special
+                    special = true;
+                }
+                                    
+                if (!special)
+                {
+                    // just move "by hand", as the old SMEs are already detached
+                    smcDest.Add(sme?.submodelElement);
+
+                    // do some fix for "non-standardized"
+                    if (sme?.submodelElement.semanticId?
+                        .MatchesExactlyOneKey(defsV10.CD_NonstandardizedProperty.GetSingleKey(), 
+                            AdminShell.Key.MatchMode.Relaxed) == true)
+                    {
+                        // fix
+                        sme.submodelElement.semanticId = new AdminShell.SemanticId(
+                            defsV11.CD_SemanticIdNotAvailable.GetReference());
+                    }
+                }
+            }
+        }
+
+        public override bool ExecuteOffer(AdminShellPackageEnv package, AdminShell.Referable currentReferable,
+                ConvertOfferBase offerBase, bool deleteOldCDs, bool addNewCDs)
+        {
+            // access
+            var offer = offerBase as ConvertOfferTechnicalDataV10ToV11;
+            if (package == null || package.AasEnv == null || currentReferable == null || offer == null)
+                return false;
+
+            // use pre-definitions
+            var defsV10 = new AasxPredefinedConcepts.DefinitionsZveiTechnicalData.SetOfDefs(
+                    new AasxPredefinedConcepts.DefinitionsZveiTechnicalData());
+            var defsV11 = AasxPredefinedConcepts.ZveiTechnicalDataV11.Static;
+
+            // access Submodel (again)
+            var sm = currentReferable as AdminShell.Submodel;
+            if (sm == null || sm.submodelElements == null ||
+                    true != sm.GetSemanticKey()?.Matches(defsV10.SM_TechnicalData.GetSemanticKey()))
+                /* disable line above to allow more models, such as MCAD/ECAD */
+                return false;
+
+            // convert in place: detach old SMEs, change semanticId
+            var smcV10 = sm.submodelElements;
+            sm.submodelElements = new AdminShell.SubmodelElementWrapperCollection();
+            sm.semanticId = new AdminShell.SemanticId(defsV11.SM_TechnicalData.GetSemanticKey());
+
+            // delete (old) CDs
+            if (deleteOldCDs)
+            {
+                smcV10.RecurseOnSubmodelElements(null, null, (state, parents, current) =>
+                {
+                    var sme = current;
+                    if (sme != null && sme.semanticId != null)
+                    {
+                        var cd = package.AasEnv.FindConceptDescription(sme.semanticId);
+                        if (cd != null)
+                            if (package.AasEnv.ConceptDescriptions.Contains(cd))
+                                package.AasEnv.ConceptDescriptions.Remove(cd);
+                    }
+                });
+            }
+
+            // add (all) new CDs?
+            if (addNewCDs)
+                foreach (var rf in defsV11.GetAllReferables())
+                    if (rf is AdminShell.ConceptDescription)
+                        package.AasEnv.ConceptDescriptions.AddIfNew(new AdminShell.ConceptDescription(
+                                    rf as AdminShell.ConceptDescription));
+
+            // General Info (target cardinality: 1)
+            foreach(var smcV10gi in smcV10.FindAllSemanticIdAs<AdminShell.SubmodelElementCollection>(
+                        defsV10.CD_GeneralInformation.GetSingleKey()))
+            {
+                // make a new one
+                var smcV11gi = sm.submodelElements.CreateSMEForCD<AdminShell.SubmodelElementCollection>(
+                                defsV11.CD_GeneralInformation, addSme: true);
+
+                // SME
+                smcV11gi.value.CopyOneSMEbyCopy<AdminShell.Property>(defsV11.CD_ManufacturerName,
+                    smcV10gi.value, defsV10.CD_ManufacturerName, 
+                    createDefault: true, addSme: true);
+
+                smcV11gi.value.CopyOneSMEbyCopy<AdminShell.File>(defsV11.CD_ManufacturerLogo,
+                    smcV10gi.value, defsV10.CD_ManufacturerLogo,
+                    createDefault: true, addSme: true);
+
+                smcV11gi.value.CopyOneSMEbyCopy<AdminShell.Property>(defsV11.CD_ManufacturerPartNumber,
+                    smcV10gi.value, defsV10.CD_ManufacturerPartNumber,
+                    createDefault: true, addSme: true);
+
+                smcV11gi.value.CopyOneSMEbyCopy<AdminShell.Property>(defsV11.CD_ManufacturerOrderCode,
+                    smcV10gi.value, defsV10.CD_ManufacturerOrderCode,
+                    createDefault: true, addSme: true);
+
+                smcV11gi.value.CopyManySMEbyCopy<AdminShell.File>(defsV11.CD_ProductImage,
+                    smcV10gi.value, defsV10.CD_ProductImage,
+                    createDefault: true);
+            }
+
+            // Product Classifications (target cardinality: 1)
+            foreach (var smcV10pcs in smcV10.FindAllSemanticIdAs<AdminShell.SubmodelElementCollection>(
+                        defsV10.CD_ProductClassifications.GetSingleKey()))
+            {
+                // make a new one
+                var smcV11pcs = sm.submodelElements.CreateSMEForCD<AdminShell.SubmodelElementCollection>(
+                                defsV11.CD_ProductClassifications, addSme: true);
+
+                // Product Classification Items (target cardinality: 1..n)
+                foreach (var smcV10pci in smcV10pcs.value.FindAllSemanticIdAs<AdminShell.SubmodelElementCollection>(
+                            defsV10.CD_ProductClassificationItem.GetSingleKey()))
+                {
+                    // make a new one
+                    var smcV11pci = smcV11pcs.value.CreateSMEForCD<AdminShell.SubmodelElementCollection>(
+                                defsV11.CD_ProductClassificationItem, addSme: true);
+
+                    // SME
+                    smcV11pci.value.CopyOneSMEbyCopy<AdminShell.Property>(defsV11.CD_ProductClassificationSystem,
+                        smcV10pci.value, defsV10.CD_ClassificationSystem,
+                        createDefault: true, addSme: true);
+
+                    smcV11pci.value.CopyOneSMEbyCopy<AdminShell.Property>(defsV11.CD_ClassificationSystemVersion,
+                        smcV10pci.value, defsV10.CD_SystemVersion,
+                        createDefault: true, addSme: true);
+
+                    smcV11pci.value.CopyOneSMEbyCopy<AdminShell.Property>(defsV11.CD_ProductClassId,
+                        smcV10pci.value, defsV10.CD_ProductClass,
+                        createDefault: true, addSme: true);
+                }
+            }
+
+            // TechnicalProperties (target cardinality: 1)
+            foreach (var smcV10prop in smcV10.FindAllSemanticIdAs<AdminShell.SubmodelElementCollection>(
+                        defsV10.CD_TechnicalProperties.GetSingleKey()))
+            {
+                // make a new one
+                var smcV11prop = sm.submodelElements.CreateSMEForCD<AdminShell.SubmodelElementCollection>(
+                                defsV11.CD_TechnicalProperties, addSme: true);
+
+                // use recursion
+                RecurseToCopyTechnicalProperties(defsV11, defsV10, smcV11prop, smcV10prop);
+            }
+
+            // Further Info (target cardinality: 1)
+            foreach (var smcV10fi in smcV10.FindAllSemanticIdAs<AdminShell.SubmodelElementCollection>(
+                        defsV10.CD_FurtherInformation.GetSingleKey()))
+            {
+                // make a new one
+                var smcV11fi = sm.submodelElements.CreateSMEForCD<AdminShell.SubmodelElementCollection>(
+                                defsV11.CD_FurtherInformation, addSme: true);
+
+                // SME
+                smcV11fi.value.CopyManySMEbyCopy<AdminShell.MultiLanguageProperty>(defsV11.CD_TextStatement,
+                    smcV10fi.value, defsV10.CD_TextStatement,
+                    createDefault: true);
+
+                smcV11fi.value.CopyOneSMEbyCopy<AdminShell.Property>(defsV11.CD_ValidDate,
+                    smcV10fi.value, defsV10.CD_ValidDate,
+                    createDefault: true, addSme: true);
+            }
+
+            // obviously well
+            return true;
+        }
+    }
+}

--- a/src/AasxPredefinedConcepts/DefinitionsExperimental.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsExperimental.cs
@@ -15,14 +15,14 @@ namespace AasxPredefinedConcepts
     /// plugins, to develop some functionalities.
     /// Later, these definitions shall be replaced by substantial definitions, e.g. imported from JSON.
     /// </summary>
-    public class DefinitionsExperimental : AasxDefinitionBase
+    public class DefinitionsExperimental 
     {
         /// <summary>
         /// This class holds definitions from the Submodel Template Specification: 
         /// Identifiers for Interoperable relationships  
         /// for the use of Composite Components of Manufacturing Equipment
         /// </summary>
-        public class InteropRelations
+        public class InteropRelations : AasxDefinitionBase
         {
             public AdminShell.ConceptDescription
                 CD_FileToNavigateElement,
@@ -36,8 +36,12 @@ namespace AasxPredefinedConcepts
                 CD_TubePipeConnectionPneumatic,
                 CD_TubePipeConnectionHydraulic;
 
-            public InteropRelations(AasxDefinitionBase bs)
+            public InteropRelations()
             {
+                // info
+                this.DomainInfo = "Interoperable Relations (experimental)";
+
+                // Referable
                 CD_FileToNavigateElement = CreateSparseConceptDescription("en", "IRI",
                     "FileToNavigateElement",
                     "http://admin-shell.io/sandbox/CompositeComponent/General/FileToNavigateElement/1/0",
@@ -96,6 +100,9 @@ namespace AasxPredefinedConcepts
                     "http://admin-shell.io/sandbox/CompositeComponent/Fluidic/TubePipeConnectionHydraulic/1/0",
                     "States, that there is a hydraulic connection between two Electrical Entities.",
                     isCaseOf: CD_TubePipeConnection.GetReference());
+
+                // reflect
+                AddEntriesByReflection(this.GetType(), useAttributes: false, useFieldNames: true);
             }
         }
     }

--- a/src/AasxPredefinedConcepts/DefinitionsExperimental.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsExperimental.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using AdminShellNS;
 
 // reSharper disable UnusedType.Global
+// reSharper disable ClassNeverInstantiated.Global
 
 namespace AasxPredefinedConcepts
 {
@@ -15,7 +16,7 @@ namespace AasxPredefinedConcepts
     /// plugins, to develop some functionalities.
     /// Later, these definitions shall be replaced by substantial definitions, e.g. imported from JSON.
     /// </summary>
-    public class DefinitionsExperimental 
+    public class DefinitionsExperimental
     {
         /// <summary>
         /// This class holds definitions from the Submodel Template Specification: 

--- a/src/AasxPredefinedConcepts/DefinitionsImageMap.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsImageMap.cs
@@ -27,6 +27,10 @@ namespace AasxPredefinedConcepts
 
         public ImageMap()
         {
+            // info
+            this.DomainInfo = "Plugin ImageMap";
+
+            // Referable
             SEM_ImageMapSubmodel = new AdminShell.SemanticId(
                 AdminShell.Key.CreateNew(
                     type: "Submodel",
@@ -64,6 +68,9 @@ namespace AasxPredefinedConcepts
                 "http://admin-shell.io/aasx-package-explorer/plugins/ImageMap/NavigateTo/1/0",
                 @"If ReferenceElement subordinate to Entity, overrules Entity AssetId and navigates to value " +
                 "reference .");
+
+            // reflect
+            AddEntriesByReflection(this.GetType(), useAttributes: false, useFieldNames: true);
         }
     }
 }

--- a/src/AasxPredefinedConcepts/DefinitionsMTP.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsMTP.cs
@@ -10,12 +10,12 @@ namespace AasxPredefinedConcepts
     /// <summary>
     /// Definitions for MTP. Somehow preliminary, to be replaced by "full" JSON definitions
     /// </summary>
-    public class DefinitionsMTP : AasxDefinitionBase
+    public class DefinitionsMTP 
     {
         /// <summary>
         /// Definitions for MTP. Somehow preliminary, to be replaced by "full" JSON definitions
         /// </summary>
-        public class ModuleTypePackage
+        public class ModuleTypePackage : AasxDefinitionBase
         {
             public AdminShell.SemanticId
                 SEM_MtpSubmodel,
@@ -32,8 +32,12 @@ namespace AasxPredefinedConcepts
                 CD_RenamingOldText,
                 CD_RenamingNewText;
 
-            public ModuleTypePackage(AasxDefinitionBase bs)
+            public ModuleTypePackage()
             {
+                // info
+                this.DomainInfo = "Module Type Package (MTP)";
+
+                // Referable
                 SEM_MtpSubmodel = new AdminShell.SemanticId(
                     AdminShell.Key.CreateNew(
                         type: "Submodel",
@@ -97,6 +101,9 @@ namespace AasxPredefinedConcepts
                     "http://www.admin-shell.io/mtp/v1/New/RenamingNewText",
                     "Within a renaming of OPC UA identifiers or namespaces, designates the new text, which shall be " +
                     "substituted.");
+
+                // reflect
+                AddEntriesByReflection(this.GetType(), useAttributes: false, useFieldNames: true);
             }
         }
     }

--- a/src/AasxPredefinedConcepts/DefinitionsMTP.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsMTP.cs
@@ -5,12 +5,15 @@ using System.Text;
 using System.Threading.Tasks;
 using AdminShellNS;
 
+// reSharper disable UnusedType.Global
+// reSharper disable ClassNeverInstantiated.Global
+
 namespace AasxPredefinedConcepts
 {
     /// <summary>
     /// Definitions for MTP. Somehow preliminary, to be replaced by "full" JSON definitions
     /// </summary>
-    public class DefinitionsMTP 
+    public class DefinitionsMTP
     {
         /// <summary>
         /// Definitions for MTP. Somehow preliminary, to be replaced by "full" JSON definitions

--- a/src/AasxPredefinedConcepts/DefinitionsPool.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsPool.cs
@@ -98,6 +98,8 @@ namespace AasxPredefinedConcepts
 
             thePool.IndexReferables("ZVEI TechnicalData v1.0",
                 new DefinitionsZveiTechnicalData.SetOfDefs(new DefinitionsZveiTechnicalData()).GetAllReferables());
+
+            thePool.IndexDefinitions(AasxPredefinedConcepts.ZveiTechnicalDataV11.Static);
         }
 
         //

--- a/src/AasxPredefinedConcepts/DefinitionsPool.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsPool.cs
@@ -1,11 +1,11 @@
-﻿using AasxIntegrationBase;
-using AdminShellNS;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Authentication.ExtendedProtection;
 using System.Text;
 using System.Threading.Tasks;
+using AasxIntegrationBase;
+using AdminShellNS;
 
 #nullable enable
 
@@ -63,7 +63,7 @@ namespace AasxPredefinedConcepts
         }
     }
 
-    public class DefinitionsPool 
+    public class DefinitionsPool
     {
         // 
         // Singleton
@@ -106,7 +106,7 @@ namespace AasxPredefinedConcepts
         // Member
         //
 
-        private Dictionary<string, List<DefinitionsPoolEntityBase>> pool = 
+        private Dictionary<string, List<DefinitionsPoolEntityBase>> pool =
             new Dictionary<string, List<DefinitionsPoolEntityBase>>();
 
         //
@@ -122,7 +122,7 @@ namespace AasxPredefinedConcepts
         {
             // access
             if (ent?.Domain == null)
-                return;            
+                return;
 
             // new hash value
             if (!this.pool.ContainsKey(ent.Domain))
@@ -151,7 +151,7 @@ namespace AasxPredefinedConcepts
         // Methods
         //
 
-        public void IndexReferables (string Domain, IEnumerable<AdminShell.Referable> indexRef)
+        public void IndexReferables(string Domain, IEnumerable<AdminShell.Referable> indexRef)
         {
             foreach (var ir in indexRef)
             {

--- a/src/AasxPredefinedConcepts/DefinitionsPool.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsPool.cs
@@ -1,0 +1,169 @@
+﻿using AasxIntegrationBase;
+using AdminShellNS;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Authentication.ExtendedProtection;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace AasxPredefinedConcepts
+{
+    public class DefinitionsPoolEntityBase
+    {
+        public string Domain = "";
+
+        public virtual string DisplayDomain { get { return Domain; } }
+        public virtual string DisplayType { get { return ""; } }
+        public virtual string DisplayName { get { return ""; } }
+        public virtual string DisplayId { get { return ""; } }
+
+        public DefinitionsPoolEntityBase() { }
+
+        public DefinitionsPoolEntityBase(string Domain = "")
+        {
+            this.Domain = Domain;
+        }
+    }
+
+    public class DefinitionsPoolReferableEntity : DefinitionsPoolEntityBase
+    {
+        public AdminShell.Referable? Ref = null;
+        public string Name = "";
+
+        public override string DisplayType
+        {
+            get
+            {
+                return (Ref != null) ? "" + Ref.GetSelfDescription()?.ElementAbbreviation : "";
+            }
+        }
+
+        public override string DisplayName { get { return (Ref != null) ? Ref.idShort : ""; } }
+
+        public override string DisplayId
+        {
+            get
+            {
+                if (Ref is AdminShell.Identifiable id)
+                    return "" + id.identification?.ToString();
+                return "";
+            }
+        }
+
+        public DefinitionsPoolReferableEntity() { }
+
+        public DefinitionsPoolReferableEntity(AdminShell.Referable? Ref, string Domain = "", string Name = "")
+        {
+            this.Domain = Domain;
+            this.Name = Name;
+            this.Ref = Ref;
+        }
+    }
+
+    public class DefinitionsPool 
+    {
+        // 
+        // Singleton
+        //
+
+        private static DefinitionsPool thePool = new DefinitionsPool();
+        public static DefinitionsPool Static { get { return thePool; } }
+
+        static DefinitionsPool()
+        {
+            thePool.IndexDefinitions(new DefinitionsExperimental.InteropRelations());
+
+            thePool.IndexDefinitions(AasxPredefinedConcepts.ImageMap.Static);
+
+            thePool.IndexDefinitions(new AasxPredefinedConcepts.DefinitionsMTP.ModuleTypePackage());
+
+            thePool.IndexDefinitions(AasxPredefinedConcepts.PackageExplorer.Static);
+
+            thePool.IndexReferables("Manufacturer Documentation (VDI2770) v1.0",
+                new AasxPredefinedConcepts.DefinitionsVDI2770.SetOfDefsVDI2770(
+                    new AasxPredefinedConcepts.DefinitionsVDI2770()).GetAllReferables());
+
+            thePool.IndexDefinitions(AasxPredefinedConcepts.VDI2770v11.Static);
+
+            thePool.IndexReferables("ZVEI Digital Nameplate v1.0",
+                new AasxPredefinedConcepts.DefinitionsZveiDigitalTypeplate.SetOfNameplate(
+                    new AasxPredefinedConcepts.DefinitionsZveiDigitalTypeplate()).GetAllReferables());
+
+            thePool.IndexReferables("ZVEI Digital Identification v1.0",
+                new AasxPredefinedConcepts.DefinitionsZveiDigitalTypeplate.SetOfIdentification(
+                    new AasxPredefinedConcepts.DefinitionsZveiDigitalTypeplate()).GetAllReferables());
+
+            thePool.IndexReferables("ZVEI TechnicalData v1.0",
+                new DefinitionsZveiTechnicalData.SetOfDefs(new DefinitionsZveiTechnicalData()).GetAllReferables());
+        }
+
+        //
+        // Member
+        //
+
+        private Dictionary<string, List<DefinitionsPoolEntityBase>> pool = 
+            new Dictionary<string, List<DefinitionsPoolEntityBase>>();
+
+        //
+        // Basic Methods
+        //
+
+        public void Clear()
+        {
+            this.pool.Clear();
+        }
+
+        public void Add(DefinitionsPoolEntityBase ent)
+        {
+            // access
+            if (ent?.Domain == null)
+                return;            
+
+            // new hash value
+            if (!this.pool.ContainsKey(ent.Domain))
+                this.pool.Add(ent.Domain, new List<DefinitionsPoolEntityBase>());
+
+            // ok, shall be present
+            this.pool[ent.Domain].Add(ent);
+        }
+
+        public IEnumerable<string> GetDomains()
+        {
+            foreach (var k in this.pool.Keys)
+                yield return k;
+        }
+
+        public IEnumerable<DefinitionsPoolEntityBase> GetEntitiesForDomain(string domain)
+        {
+            // check
+            if (!this.pool.ContainsKey(domain))
+                yield break;
+            foreach (var ent in this.pool[domain])
+                yield return ent;
+        }
+
+        //
+        // Methods
+        //
+
+        public void IndexReferables (string Domain, IEnumerable<AdminShell.Referable> indexRef)
+        {
+            foreach (var ir in indexRef)
+            {
+                if (ir == null)
+                    continue;
+                this.Add(new DefinitionsPoolReferableEntity(ir, Domain, ir.idShort));
+            }
+        }
+
+        public void IndexDefinitions(AasxDefinitionBase bs)
+        {
+            if (bs == null || !bs.DomainInfo.HasContent())
+                return;
+            IndexReferables(bs.DomainInfo, bs.GetAllReferables());
+        }
+    }
+}

--- a/src/AasxPredefinedConcepts/DefinitionsV2770v11.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsV2770v11.cs
@@ -49,7 +49,7 @@ namespace AasxPredefinedConcepts
             CD_BasedOn,
             CD_Affecting,
             CD_TranslationOf,
-            CD_Entity;        
+            CD_Entity;
 
         public VDI2770v11()
         {

--- a/src/AasxPredefinedConcepts/DefinitionsV2770v11.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsV2770v11.cs
@@ -16,6 +16,8 @@ namespace AasxPredefinedConcepts
     /// </summary>
     public class VDI2770v11 : AasxDefinitionBase
     {
+        public static VDI2770v11 Static = new VDI2770v11();
+
         public AdminShell.Submodel
             SM_ManufacturerDocumentation;
 
@@ -47,16 +49,17 @@ namespace AasxPredefinedConcepts
             CD_BasedOn,
             CD_Affecting,
             CD_TranslationOf,
-            CD_Entity;
+            CD_Entity;        
 
-        public static VDI2770v11 Static = null;
-
-        static VDI2770v11()
+        public VDI2770v11()
         {
-            Static = new VDI2770v11();
-            Static.ReadLibrary(
+            // info
+            this.DomainInfo = "Manufacturer Documentation (VDI2770) v1.1";
+
+            // Referable
+            this.ReadLibrary(
                 Assembly.GetExecutingAssembly(), "AasxPredefinedConcepts.Resources." + "VDI2770v11.json");
-            Static.RetrieveEntriesByReflection(typeof(VDI2770v11), useFieldNames: true);
+            this.RetrieveEntriesFromLibraryByReflection(typeof(VDI2770v11), useFieldNames: true);
         }
     }
 }

--- a/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalDataV11.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalDataV11.cs
@@ -40,7 +40,7 @@ namespace AasxPredefinedConcepts
             CD_SubSection,
             CD_FurtherInformation,
             CD_TextStatement,
-            CD_ValidDate;        
+            CD_ValidDate;
 
         public ZveiTechnicalDataV11()
         {

--- a/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalDataV11.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalDataV11.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using AdminShellNS;
+
+// ReSharper disable UnassignedField.Global
+// (working by reflection)
+
+namespace AasxPredefinedConcepts
+{
+    /// <summary>
+    /// Definitions of Submodel VDI2770 according to new alignment with VDI
+    /// </summary>
+    public class ZveiTechnicalDataV11 : AasxDefinitionBase
+    {
+        public static ZveiTechnicalDataV11 Static = new ZveiTechnicalDataV11();
+
+        public AdminShell.Submodel
+            SM_TechnicalData;
+
+        public AdminShell.ConceptDescription
+            CD_GeneralInformation,
+            CD_ManufacturerName,
+            CD_ManufacturerLogo,
+            CD_ManufacturerProductDesignation,
+            CD_ManufacturerPartNumber,
+            CD_ManufacturerOrderCode,
+            CD_ProductImage,
+            CD_ProductClassifications,
+            CD_ProductClassificationItem,
+            CD_ProductClassificationSystem,
+            CD_ClassificationSystemVersion,
+            CD_ProductClassId,
+            CD_TechnicalProperties,
+            CD_SemanticIdNotAvailable,
+            CD_MainSection,
+            CD_SubSection,
+            CD_FurtherInformation,
+            CD_TextStatement,
+            CD_ValidDate;        
+
+        public ZveiTechnicalDataV11()
+        {
+            // info
+            this.DomainInfo = "Generic Frame for Technical Data for Industrial Equipment (ZVEI) v1.1";
+
+            // Referable
+            this.ReadLibrary(
+                Assembly.GetExecutingAssembly(), "AasxPredefinedConcepts.Resources." + "ZveiTechnicalDataV11.json");
+            this.RetrieveEntriesFromLibraryByReflection(typeof(ZveiTechnicalDataV11), useFieldNames: true);
+        }
+    }
+}

--- a/src/AasxPredefinedConcepts/ExportPredefinedConcepts.cs
+++ b/src/AasxPredefinedConcepts/ExportPredefinedConcepts.cs
@@ -18,6 +18,7 @@ namespace AasxPredefinedConcepts
                 return;
 
             // make text file
+            // ReSharper disable once ConvertToUsingDeclaration
             using (var snippets = new System.IO.StreamWriter(fn))
             {
                 // Phase (1) which ConceptDescriptions need to be exported

--- a/src/AasxPredefinedConcepts/PackageExplorer.cs
+++ b/src/AasxPredefinedConcepts/PackageExplorer.cs
@@ -10,20 +10,27 @@ namespace AasxPredefinedConcepts
     /// <summary>
     /// Definitions for operation of Package Explorer
     /// </summary>
-    public class DefinitionsPackageExplorer : AasxDefinitionBase
+    public class PackageExplorer : AasxDefinitionBase
     {
-        public static DefinitionsPackageExplorer Static = new DefinitionsPackageExplorer();
+        public static PackageExplorer Static = new PackageExplorer();
 
         public AdminShell.ConceptDescription
             CD_AasxLoadedNavigateTo;
 
-        public DefinitionsPackageExplorer()
+        public PackageExplorer()
         {
+            // info
+            this.DomainInfo = "AASX Package Explorer";
+
+            // Referable
             CD_AasxLoadedNavigateTo = CreateSparseConceptDescription("en", "IRI",
                 "AasxLoadedNavigateTo",
                 "http://admin-shell.io/aasx-package-explorer/main/AasxLoadedNavigateTo/1/0",
                 "Specifies a ReferenceElement, to which the Package Explorer will refer directly " +
                 "after loading. Can be situated in any Submodel, but on first hierarchy level.");
+
+            // reflect
+            AddEntriesByReflection(this.GetType(), useAttributes: false, useFieldNames: true);
         }
     }
 }

--- a/src/AasxPredefinedConcepts/Resources/ZveiTechnicalDataV11.json
+++ b/src/AasxPredefinedConcepts/Resources/ZveiTechnicalDataV11.json
@@ -1,0 +1,1761 @@
+﻿{
+  "SM_TechnicalData": {
+    "semanticId": {
+      "keys": [
+        {
+          "type": "Submodel",
+          "local": false,
+          "value": "http://admin-shell.io/sandbox/SG2/TechnicalData/Submodel/1/1",
+          "index": 0,
+          "idType": "IRI"
+        }
+      ],
+      "First": {
+        "type": "Submodel",
+        "local": false,
+        "value": "http://admin-shell.io/sandbox/SG2/TechnicalData/Submodel/1/1",
+        "index": 0,
+        "idType": "IRI"
+      },
+      "Last": {
+        "type": "Submodel",
+        "local": false,
+        "value": "http://admin-shell.io/sandbox/SG2/TechnicalData/Submodel/1/1",
+        "index": 0,
+        "idType": "IRI"
+      }
+    },
+    "qualifiers": [
+      {
+        "semanticId": null,
+        "type": "FormTag",
+        "valueType": "",
+        "valueId": null,
+        "value": "TEC",
+        "modelType": {
+          "name": "Qualifier"
+        }
+      },
+      {
+        "semanticId": null,
+        "type": "FormTitle",
+        "valueType": "",
+        "valueId": null,
+        "value": "Technical data (sheet) model",
+        "modelType": {
+          "name": "Qualifier"
+        }
+      }
+    ],
+    "hasDataSpecification": [],
+    "identification": {
+      "idType": "IRI",
+      "id": "www.company.com/ids/sm/8552_9161_4002_5836"
+    },
+    "administration": {
+      "version": "1",
+      "revision": "1"
+    },
+    "idShort": "TechnicalData",
+    "category": null,
+    "modelType": {
+      "name": "Submodel"
+    },
+    "kind": "Instance",
+    "descriptions": [
+      {
+        "language": "DE",
+        "text": "Submodel für technische Daten eines Assets und zugehörige Konformitäten zu Produktklassifikationen"
+      },
+      {
+        "language": "EN",
+        "text": "Submodel containing techical data to the asset and associated product classificatons"
+      }
+    ]
+  },
+  "CD_GeneralInformation": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/GeneralInformation/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "GeneralInformation",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Generelle Informationen"
+            },
+            {
+              "language": "en",
+              "text": "General information"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "General information"
+            },
+            {
+              "language": "DE",
+              "text": "Generelle Informationen"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Generelle Informationen, zum Beispiel Bestell- und Herstellerinformationen"
+            },
+            {
+              "language": "en",
+              "text": "General information, for example ordering and manufacturer information"
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_ManufacturerName": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerName/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "ManufacturerName",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Herstellername"
+            },
+            {
+              "language": "en",
+              "text": "Manufacturer name"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Herstellername"
+            },
+            {
+              "language": "DE",
+              "text": "Manufacturer name"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": "string",
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist"
+            },
+            {
+              "language": "en",
+              "text": "legally valid designation of the natural or judicial person which is directly responsible for the design, production, packaging and labeling of a product in respect to its being brought into circulation"
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [
+      {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "0173-1#02-AAO677#002",
+            "index": 0,
+            "idType": "IRDI"
+          }
+        ],
+        "First": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "0173-1#02-AAO677#002",
+          "index": 0,
+          "idType": "IRDI"
+        },
+        "Last": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "0173-1#02-AAO677#002",
+          "index": 0,
+          "idType": "IRDI"
+        }
+      }
+    ],
+    "descriptions": null
+  },
+  "CD_ManufacturerLogo": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerLogo/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "ManufacturerLogo",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Herstellerlogo-Datei"
+            },
+            {
+              "language": "en",
+              "text": "File with manufactuer logo"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Herstellerlogo"
+            },
+            {
+              "language": "DE",
+              "text": "Manufactuer logo"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Bilddatei für Logo des Herstellers im gebräuchlichem Format (.png, .jpg). "
+            },
+            {
+              "language": "en",
+              "text": "Imagefile for logo of manufacturer provided in common format (.png, .jpg). "
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_ManufacturerProductDesignation": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerProductDesignation/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "ManufacturerProductDesignation",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Herstellerproduktbezeichnung"
+            },
+            {
+              "language": "en",
+              "text": "Manufacturer product designation"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Product designation"
+            },
+            {
+              "language": "DE",
+              "text": "Produktbezeichnung"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Kurze Beschreibung des Produktes (Kurztext)"
+            },
+            {
+              "language": "en",
+              "text": "Short description of the product (short text)"
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [
+      {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "0173-1#02-AAW338#001",
+            "index": 0,
+            "idType": "IRDI"
+          }
+        ],
+        "First": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "0173-1#02-AAW338#001",
+          "index": 0,
+          "idType": "IRDI"
+        },
+        "Last": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "0173-1#02-AAW338#001",
+          "index": 0,
+          "idType": "IRDI"
+        }
+      }
+    ],
+    "descriptions": null
+  },
+  "CD_ManufacturerPartNumber": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerPartNumber/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "ManufacturerPartNumber",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Herstellerartikelnummer"
+            },
+            {
+              "language": "en",
+              "text": "product article number of manufacturer"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Manufacturer order code"
+            },
+            {
+              "language": "DE",
+              "text": "Herstellerbestellcode"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "eindeutiger Bestellschlüssel des Herstellers"
+            },
+            {
+              "language": "en",
+              "text": "unique product identifier of the manufacturer"
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [
+      {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "0173-1#02-AAO676#003",
+            "index": 0,
+            "idType": "IRDI"
+          }
+        ],
+        "First": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "0173-1#02-AAO676#003",
+          "index": 0,
+          "idType": "IRDI"
+        },
+        "Last": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "0173-1#02-AAO676#003",
+          "index": 0,
+          "idType": "IRDI"
+        }
+      }
+    ],
+    "descriptions": null
+  },
+  "CD_ManufacturerOrderCode": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ManufacturerOrderCode/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "ManufacturerOrderCode",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Eindeutiger Herstellerbestellcode"
+            },
+            {
+              "language": "en",
+              "text": "Unique manufacturer order code"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Manufacturer order code"
+            },
+            {
+              "language": "DE",
+              "text": "Herstellerbestellcode"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "eindeutiger Bestellschlüssel des Herstellers um exakt gleiches Produkt zu bestellen"
+            },
+            {
+              "language": "en",
+              "text": "unique product identifier of the manufacturer sufficient to order exact same produkt"
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [
+      {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "0173-1#02-AAO676#003",
+            "index": 0,
+            "idType": "IRDI"
+          }
+        ],
+        "First": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "0173-1#02-AAO676#003",
+          "index": 0,
+          "idType": "IRDI"
+        },
+        "Last": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "0173-1#02-AAO676#003",
+          "index": 0,
+          "idType": "IRDI"
+        }
+      }
+    ],
+    "descriptions": null
+  },
+  "CD_ProductImage": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductImage/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "ProductImage",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Bilddatei für Produkt"
+            },
+            {
+              "language": "en",
+              "text": "Imagefile for product"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Product image"
+            },
+            {
+              "language": "DE",
+              "text": "Produktbild"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Bilddatei für das assozierte Produkt im gebräuchlichem Format (.png, .jpg). "
+            },
+            {
+              "language": "en",
+              "text": "Imagefile for associated product provided in common format (.png, .jpg). "
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_ProductClassifications": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassifications/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "ProductClassifications",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Produktklassifizierungen"
+            },
+            {
+              "language": "en",
+              "text": "ProductClassifications"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "ProductClassification"
+            },
+            {
+              "language": "DE",
+              "text": "Produktklassifizierung"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Produktklassifizierungen durch Assoziation mit Produktklassen in gebräuchlichen Klassifizierungssystemen."
+            },
+            {
+              "language": "en",
+              "text": "Product classifications by association with product classes in common classification systems."
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_ProductClassificationItem": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassificationItem/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "ProductClassificationItem",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Einzelne Produktklassifizierung"
+            },
+            {
+              "language": "en",
+              "text": "Single ProductClassification"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "ProductClassification"
+            },
+            {
+              "language": "DE",
+              "text": "Produktklassifizierung"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Einzelne Produktklassifizierung durch Assoziation mit einer Produktklasse"
+            },
+            {
+              "language": "en",
+              "text": "Single product classification by association with product class"
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_ProductClassificationSystem": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassificationSystem/1/1"
+    },
+    "administration": null,
+    "idShort": "ProductClassificationSystem",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "DE",
+              "text": "Klassifikationssystem"
+            },
+            {
+              "language": "EN",
+              "text": "Classification system"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Classification system"
+            },
+            {
+              "language": "DE",
+              "text": "Klassifikationssystem"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "EN",
+              "text": "Common name of the product classification system"
+            },
+            {
+              "language": "DE",
+              "text": "Gebräuchlicher Name für das Produkt-Klassifikationssystem"
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_ClassificationSystemVersion": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ClassificationSystemVersion/1/1"
+    },
+    "administration": null,
+    "idShort": "ClassificationSystemVersion",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "DE",
+              "text": "Versionskennung des Klassifikationssystems"
+            },
+            {
+              "language": "EN",
+              "text": "Verison id  of the classification system"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Version class. system"
+            },
+            {
+              "language": "DE",
+              "text": "Version Klass.-System"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "EN",
+              "text": "Common version identifier of the used classification system"
+            },
+            {
+              "language": "DE",
+              "text": "Gebräuchliche Versionskennung des genutzen Klassifikationssystems"
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_ProductClassId": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ProductClassId/1/1"
+    },
+    "administration": null,
+    "idShort": "ProductClassId",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "DE",
+              "text": "Produktklasse im System"
+            },
+            {
+              "language": "EN",
+              "text": "Product class in system"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Product class"
+            },
+            {
+              "language": "DE",
+              "text": "Produktklasse "
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "EN",
+              "text": "Class of the associated product in the classification system; according to the notation of the system"
+            },
+            {
+              "language": "DE",
+              "text": "Klasse des assoziierten Produktes im Klassifikationssystem; entsprechend der Notationsweise des Systems."
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_TechnicalProperties": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/TechnicalProperties/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "TechnicalProperties",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Technische und Produktmerkmale"
+            },
+            {
+              "language": "en",
+              "text": "Technical and product properties"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Properties"
+            },
+            {
+              "language": "DE",
+              "text": "Merkmale"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Einzelne Merkmale die das Produkt und die technischen Eigenschaften beschreiben"
+            },
+            {
+              "language": "en",
+              "text": "Individual characteristics that describe the product and its technical properties"
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_SemanticIdNotAvailable": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/SemanticIdNotAvailable /1/1 "
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "SemanticIdNotAvailable",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Merkmal ohne SemanticId"
+            },
+            {
+              "language": "en",
+              "text": "Property without SemanticId"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Property without SemanticId"
+            },
+            {
+              "language": "DE",
+              "text": "Merkmal ohne SemanticId"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Merkmal, welches nicht über ein gebräuchliches Klassifikationssystem beschrieben ist"
+            },
+            {
+              "language": "en",
+              "text": "Property that is not described using a common classification system"
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_MainSection": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/MainSection/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "MainSection",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Hauptsektion für Merkmale"
+            },
+            {
+              "language": "en",
+              "text": "Main section for properties"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Main section"
+            },
+            {
+              "language": "DE",
+              "text": "Hauptsektion"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Haupt-Unterteilungsmöglichkeit für Merkmale. Kann über idShort benannt werden."
+            },
+            {
+              "language": "en",
+              "text": "Main subdivision possibility for properties. Can be named via idShort."
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_SubSection": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/SubSection/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "SubSection",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Untersektion für Merkmale"
+            },
+            {
+              "language": "en",
+              "text": "Subsection for properties"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Subsection "
+            },
+            {
+              "language": "DE",
+              "text": "Untersektion "
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Untergeordnete Unterteilungsmöglichkeit für Merkmale. Kann über idShort benannt werden."
+            },
+            {
+              "language": "en",
+              "text": "Subordinate subdivision possibility for properties. Can be named via idShort."
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_FurtherInformation": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/FurtherInformation/1/1"
+    },
+    "administration": {
+      "version": "",
+      "revision": "1"
+    },
+    "idShort": "FurtherInformation",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "de",
+              "text": "Weitere Informationen"
+            },
+            {
+              "language": "en",
+              "text": "Further information"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Further information"
+            },
+            {
+              "language": "DE",
+              "text": "Weitere Informationen"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "de",
+              "text": "Weiterführende Informationen zum Produkt, der Gültigkeit der gemachten Angaben und zu diesem Datensatz"
+            },
+            {
+              "language": "en",
+              "text": "Further information on the product, the validity of the information provided and this data record"
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_TextStatement": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/TextStatement/1/1"
+    },
+    "administration": null,
+    "idShort": "TextStatement",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "DE",
+              "text": "Aussage des Herstellers als Text"
+            },
+            {
+              "language": "EN",
+              "text": "Statement by the manufacturer as text"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Valid on date"
+            },
+            {
+              "language": "DE",
+              "text": "Gültig am"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "STRING",
+          "definition": [
+            {
+              "language": "EN",
+              "text": "Statement in text form, e.g. scope of validity of the statements."
+            },
+            {
+              "language": "DE",
+              "text": "Aussage in Textform, etwa Gültigkeitsbereich der Aussagen."
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  },
+  "CD_ValidDate": {
+    "identification": {
+      "idType": "IRI",
+      "id": "https://admin-shell.io/sandbox/SG2/TechnicalData/ValidDate/1/1"
+    },
+    "administration": null,
+    "idShort": "ValidDate",
+    "category": null,
+    "modelType": {
+      "name": "ConceptDescription"
+    },
+    "embeddedDataSpecifications": [
+      {
+        "dataSpecification": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        "dataSpecificationContent": {
+          "preferredName": [
+            {
+              "language": "DE",
+              "text": "Informationen gültig am"
+            },
+            {
+              "language": "EN",
+              "text": "Information valid on date"
+            }
+          ],
+          "shortName": [
+            {
+              "language": "EN",
+              "text": "Valid on date"
+            },
+            {
+              "language": "DE",
+              "text": "Gültig am"
+            }
+          ],
+          "unit": "",
+          "unitId": null,
+          "valueFormat": null,
+          "sourceOfDefinition": null,
+          "symbol": null,
+          "dataType": "DATE",
+          "definition": [
+            {
+              "language": "EN",
+              "text": "Denotes a date on which the data specified in the submodel was valid for the associated product. Approximately: Date of the last update of the data."
+            },
+            {
+              "language": "DE",
+              "text": "Bezeichnet ein Datum, an welchem die im Submodel genannten Daten für das assoziierte Produkt gültig waren. Etwa: Tag der letzten Aktualisierung der Daten."
+            }
+          ]
+        }
+      }
+    ],
+    "isCaseOf": [],
+    "descriptions": null
+  }
+}

--- a/src/AasxWpfControlLibrary/AasxWpfControlLibrary.csproj
+++ b/src/AasxWpfControlLibrary/AasxWpfControlLibrary.csproj
@@ -95,6 +95,9 @@
     <Compile Include="ProgressBarFlyout.xaml.cs">
       <DependentUpon>ProgressBarFlyout.xaml</DependentUpon>
     </Compile>
+    <Compile Include="SelectFromReferablesPoolFlyout.xaml.cs">
+      <DependentUpon>SelectFromReferablesPoolFlyout.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ShowValidationResultsFlyout.xaml.cs">
       <DependentUpon>ShowValidationResultsFlyout.xaml</DependentUpon>
     </Compile>
@@ -158,6 +161,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="ProgressBarFlyout.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="SelectFromReferablesPoolFlyout.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
@@ -267,6 +274,10 @@
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj">
       <Project>{5a05df78-216b-4a0b-9e30-7b2557c7e867}</Project>
       <Name>AasxIntegrationBase</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\AasxPredefinedConcepts\AasxPredefinedConcepts.csproj">
+      <Project>{a8583f61-e5d8-44a0-98e3-a795578be3f0}</Project>
+      <Name>AasxPredefinedConcepts</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/AasxWpfControlLibrary/DispEditHelperBasics.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperBasics.cs
@@ -1090,6 +1090,7 @@ namespace AasxPackageExplorer
             AdminShellPackageEnv package = null,
             string addExistingEntities = null,
             bool addEclassIrdi = false,
+            bool addFromPool = false,
             string[] addPresetNames = null, AdminShell.Key[] addPresetKeys = null,
             Func<AdminShell.KeyList, ModifyRepo.LambdaAction> jumpLambda = null,
             ModifyRepo.LambdaAction takeOverLambdaAction = null,
@@ -1168,7 +1169,7 @@ namespace AasxPackageExplorer
             if (keys != null)
             {
                 // populate [+], [Select], [eCl@ss], [Copy] buttons
-                var colDescs = new List<string>(new[] { "*", "#", "#", "#", "#" });
+                var colDescs = new List<string>(new[] { "*", "#", "#", "#", "#", "#" });
                 for (int i = 0; i < presetNo; i++)
                     colDescs.Add("#");
 
@@ -1178,10 +1179,35 @@ namespace AasxPackageExplorer
                 Grid.SetColumnSpan(g2, 7);
                 g.Children.Add(g2);
 
-                if (addEclassIrdi)
+                if (addFromPool)
                     repo.RegisterControl(
                         AddSmallButtonTo(
                             g2, 0, 1,
+                            margin: new Thickness(2, 2, 2, 2),
+                            padding: new Thickness(5, 0, 5, 0),
+                            content: "Add known"),
+                        (o) =>
+                        {
+                            var uc = new SelectFromReferablesPoolFlyout();
+                            uc.DataSourcePools = AasxPredefinedConcepts.DefinitionsPool.Static;
+                            this.flyoutProvider.StartFlyoverModal(uc);
+
+                            if (uc.ResultItem is AasxPredefinedConcepts.DefinitionsPoolReferableEntity pe
+                                && pe.Ref is AdminShell.Identifiable id
+                                && id.identification != null)
+                                keys.Add(AdminShell.Key.CreateNew(id.GetElementName(), false,
+                                    id.identification.idType, id.identification.id));
+
+                            if (takeOverLambdaAction != null)
+                                return takeOverLambdaAction;
+                            else
+                                return new ModifyRepo.LambdaActionRedrawEntity();
+                        });
+
+                if (addEclassIrdi)
+                    repo.RegisterControl(
+                        AddSmallButtonTo(
+                            g2, 0, 2,
                             margin: new Thickness(2, 2, 2, 2),
                             padding: new Thickness(5, 0, 5, 0),
                             content: "Add eCl@ss IRDI"),
@@ -1206,7 +1232,7 @@ namespace AasxPackageExplorer
                 if (addExistingEntities != null && package != null)
                     repo.RegisterControl(
                         AddSmallButtonTo(
-                            g2, 0, 2,
+                            g2, 0, 3,
                             margin: new Thickness(2, 2, 2, 2),
                             padding: new Thickness(5, 0, 5, 0),
                             content: "Add existing"),
@@ -1226,7 +1252,7 @@ namespace AasxPackageExplorer
 
                 repo.RegisterControl(
                     AddSmallButtonTo(
-                        g2, 0, 3,
+                        g2, 0, 4,
                         margin: new Thickness(2, 2, 2, 2),
                         padding: new Thickness(5, 0, 5, 0),
                         content: "Add blank"),
@@ -1242,7 +1268,7 @@ namespace AasxPackageExplorer
 
                 repo.RegisterControl(
                     AddSmallButtonTo(
-                        g2, 0, 4,
+                        g2, 0, 5,
                         margin: new Thickness(2, 2, 2, 2),
                         padding: new Thickness(5, 0, 5, 0),
                         content: "Clipboard"),
@@ -1259,7 +1285,7 @@ namespace AasxPackageExplorer
                     var closureKey = addPresetKeys[i];
                     repo.RegisterControl(
                         AddSmallButtonTo(
-                            g2, 0, 5 + i,
+                            g2, 0, 6 + i,
                             margin: new Thickness(2, 2, 2, 2),
                             padding: new Thickness(5, 0, 5, 0),
                             content: "" + addPresetNames[i]),

--- a/src/AasxWpfControlLibrary/DispEditHelperModules.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperModules.cs
@@ -523,7 +523,7 @@ namespace AasxPackageExplorer
                 this.AddKeyListKeys(
                     stack, "semanticId", semanticId.Keys, repo,
                     package: package,
-                    addExistingEntities: addExistingEntities);
+                    addExistingEntities: addExistingEntities, addFromPool: true);
         }
 
         //

--- a/src/AasxWpfControlLibrary/Plugins.cs
+++ b/src/AasxWpfControlLibrary/Plugins.cs
@@ -353,6 +353,8 @@ namespace AasxPackageExplorer
                             if (duplicateLog != null)
                                 duplicateLog(xsp);
                             Log.LogInstance.Append(xsp);
+                            if (xsp.isError)
+                                Log.LogInstance.NumberErrors++;
                         }
                     }
                 }

--- a/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml
@@ -1,0 +1,73 @@
+﻿<UserControl
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:AasxPackageExplorer"
+             xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2" 
+             x:Class="AasxPackageExplorer.SelectFromReferablesPoolFlyout"
+             mc:Ignorable="d" 
+             d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+
+    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
+The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
+The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
+The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
+The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+
+
+    <UserControl.Resources>
+        <ResourceDictionary Source="Themes/Generic.xaml"/>
+    </UserControl.Resources>
+
+    <Grid Margin="10">
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="2*" MinHeight="120"/>
+            <RowDefinition Height="4*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="40"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="1*"/>
+            <ColumnDefinition Width="10*"/>
+            <ColumnDefinition Width="1*"/>
+        </Grid.ColumnDefinitions>
+
+        <Viewbox Grid.Row="0" Grid.Column="2" Margin="2" HorizontalAlignment="Right">
+            <Button x:Name="ButtonClose" Style="{DynamicResource TranspRoundCorner}" Height="20" Width="20" Foreground="White" Click="ButtonClose_Click">X</Button>
+        </Viewbox>
+
+        <TextBlock x:Name="TextBlockCaption" Grid.Row="1" Grid.Column="1" Margin="189,4,193,4" FontSize="24" Foreground="White" HorizontalAlignment="Center" TextWrapping="Wrap"><Run Text="Caption .."/></TextBlock>
+
+        <Label Grid.Row="2" Grid.Column="1" Content="Domains:" Foreground="White" FontSize="14"/>
+        <ListBox x:Name="ListBoxDomains" Grid.Row="3" Grid.Column="1" Margin="5,0,5,10" Background="#c0202030" Foreground="White" FontWeight="Bold" FontSize="16" ScrollViewer.VerticalScrollBarVisibility="Auto" SelectionChanged="ListBoxDomains_SelectionChanged">
+        </ListBox>
+        
+        <DataGrid x:Name="DataGridEntities" Grid.Row="4" Grid.Column="1" AutoGenerateColumns="False"
+                  Margin="5,0,5,10" Background="#c0202030" Foreground="White" FontWeight="Regular" FontSize="14" 
+                  RowHeaderWidth="0" IsReadOnly="True"
+                  ScrollViewer.VerticalScrollBarVisibility="Auto" MouseDoubleClick="DataGrid_MouseDoubleClick">
+            <DataGrid.Resources>
+                <Style BasedOn="{StaticResource {x:Type DataGridColumnHeader}}" TargetType="{x:Type DataGridColumnHeader}">
+                    <Setter Property="Background" Value="#c0303040" />
+                </Style>
+                <Style BasedOn="{StaticResource {x:Type DataGridRow}}" TargetType="{x:Type DataGridRow}">
+                    <Setter Property="Background" Value="#c0202030" />
+                </Style>
+            </DataGrid.Resources>
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Type" Width="1*" MaxWidth="60" Binding="{Binding DisplayType, Mode=OneWay}"/>
+                <DataGridTextColumn Header="Name" Width="2*" Binding="{Binding DisplayName, Mode=OneWay}"/>
+                <DataGridTextColumn Header="Identification" Width="5*" Binding="{Binding DisplayId, Mode=OneWay}"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <DockPanel x:Name="ButtonsPanel" Grid.Row="6" Grid.Column="1">
+            <Button x:Name="ButtonSelect" IsDefault="True" Content="Select!" Style="{DynamicResource TranspRoundCorner}" Foreground="White" FontSize="18" Padding="6" Margin="4" Click="ButtonSelect_Click"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using AasxIntegrationBase;
+using AdminShellNS;
+using Newtonsoft.Json;
+
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+The browser functionality is under the cefSharp license
+(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
+
+The JSON serialization is under the MIT license
+(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
+
+The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
+
+The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
+*/
+
+namespace AasxPackageExplorer
+{
+    /// <summary>
+    /// Creates a flyout in order to select items from a list
+    /// </summary>
+    public partial class SelectFromReferablesPoolFlyout : UserControl, IFlyoutControl
+    {
+        public event IFlyoutControlClosed ControlClosed;
+
+        public string Caption = "Select item ..";
+
+        public AasxPredefinedConcepts.DefinitionsPool DataSourcePools = null;
+
+        public int ResultIndex = -1;
+        public object ResultItem = null;
+
+        public SelectFromReferablesPoolFlyout()
+        {
+            InitializeComponent();
+        }
+
+        //
+        // Outer
+        //
+
+        public void ControlStart()
+        {
+        }
+
+        public void ControlPreviewKeyDown(KeyEventArgs e)
+        {
+        }
+
+        //
+        // Mechanics
+        //
+
+        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            // fill caption
+            if (this.Caption != null)
+                TextBlockCaption.Text = "" + this.Caption;
+
+            // entities
+            DataGridEntities.Items.Clear();
+
+            // fill listbox
+            this.ListBoxDomains.Items.Clear();
+            if (DataSourcePools != null)
+            {
+                foreach (var d in DataSourcePools.GetDomains())
+                    this.ListBoxDomains.Items.Add(d);
+                if (this.ListBoxDomains.Items.Count > 0)
+                    this.ListBoxDomains.SelectedIndex = 0;
+            }
+
+        }
+
+        private void ListBoxDomains_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var dom = this.ListBoxDomains.SelectedItem as string;
+            if (dom == null)
+                return;
+            var ld = this.DataSourcePools?.GetEntitiesForDomain(dom);
+            if (ld != null)
+            {
+                DataGridEntities.Items.Clear();
+                foreach (var ent in ld)
+                    DataGridEntities.Items.Add(ent);
+            }
+        }
+
+        private bool PrepareResult()
+        {
+            if (DataGridEntities.SelectedItem != null && DataGridEntities.SelectedIndex >= 0)
+            {
+                this.ResultIndex = DataGridEntities.SelectedIndex;
+                this.ResultItem = DataGridEntities.SelectedItem;
+                return true;
+            }
+
+            // uups
+            return false;
+        }
+
+        private void ButtonSelect_Click(object sender, RoutedEventArgs e)
+        {
+            if (PrepareResult())
+                ControlClosed?.Invoke();
+        }
+
+        private void ButtonClose_Click(object sender, RoutedEventArgs e)
+        {
+            this.ResultIndex = -1;
+            this.ResultItem = null;
+            ControlClosed?.Invoke();
+        }
+
+        private void DataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (PrepareResult())
+                ControlClosed?.Invoke();
+        }
+
+    }
+}


### PR DESCRIPTION
The AasxPrewdefinedConcepts namespace holds multiple classes, 
which store information on (standardized or nearly standardized) 
Submodels. This allows using these Submodel definitons to be 
used clearly and easily from source code.

The classes for some of these models was restructured in order 
to be clearer and to be used as static singleton. Concepts can be 
created more easily and reflections is used to keep the effort of 
initialzing these classes from Json more effective.

Additionally, declarations for MTP (Module Type Package), 
experimental relations and Submodel Technical (ZVEI) Data in V1.1 
were added. The ConceptModel... class shows up, how a 
Submodel-version-independent source code could be handled.

Even more, a "pool of definitions" is now generated from the 
predefined concepts. In the PackageExplorer, these conceptes 
can now be used directly as semanticIds 
(via button "Add known ..").

* refacture some of AasxPredefinedConcepts/
  definitions
* pool of definitions
* Select-Flyout to chose known semanticId

Update for Submodel Tech Data V1.1 
* new pre definitions
* new convert V1.0->V1.1
* new class ConceptModel ..
* plugin-in uses ConceptModel
* add generic form