### PR TITLE
Fix AasxToolkit when empty args

### DIFF
--- a/src/AasxToolkit.Tests/TestCli.cs
+++ b/src/AasxToolkit.Tests/TestCli.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace AasxToolkit.Tests
@@ -14,7 +15,7 @@ namespace AasxToolkit.Tests
                 new List<Cli.Command>()
             );
 
-            var parsing = Cli.ParseInstructions(cmdLine, new[] { "test-program" });
+            var parsing = Cli.ParseInstructions(cmdLine, new string[] { });
             Assert.IsNull(parsing.Errors);
             Assert.IsEmpty(parsing.Instructions);
         }
@@ -58,7 +59,7 @@ namespace AasxToolkit.Tests
         {
             var cmdLine = setUpCommandLine();
 
-            var parsing = Cli.ParseInstructions(cmdLine, new[] { "test-program" });
+            var parsing = Cli.ParseInstructions(cmdLine, new string[] { });
             Assert.IsNull(parsing.Errors);
             Assert.IsEmpty(parsing.Instructions);
         }
@@ -92,7 +93,7 @@ namespace AasxToolkit.Tests
         {
             var cmdLine = setUpCommandLine();
 
-            var parsing = Cli.ParseInstructions(cmdLine, new[] { "test-program", "say", "one", "say", "two" });
+            var parsing = Cli.ParseInstructions(cmdLine, new[] { "say", "one", "say", "two" });
             Assert.IsNull(parsing.Errors);
             Assert.AreEqual(2, parsing.Instructions.Count);
 
@@ -107,13 +108,26 @@ namespace AasxToolkit.Tests
         }
 
         [Test]
+        public void TestParsingNoArgumentsGivesEmptyInstructions()
+        {
+            var cmdLine = setUpCommandLine();
+
+            var args = new string[] { };
+            var parsing = Cli.ParseInstructions(cmdLine, args);
+            Assert.IsEmpty(parsing.Instructions);
+            Assert.AreEqual(0, parsing.AcceptedArgs);
+            Assert.IsNull(parsing.Errors);
+        }
+
+        [Test]
         public void TestParsingFailedDueToTooFewArguments()
         {
             var cmdLine = setUpCommandLine();
 
-            var args = new[] { "test-program", "say" };
+            var args = new[] { "say" };
             var parsing = Cli.ParseInstructions(cmdLine, args);
             Assert.IsNull(parsing.Instructions);
+            Assert.AreEqual(0, parsing.AcceptedArgs);
 
             var errorMsg = Cli.FormatParsingErrors(args, parsing.AcceptedArgs, parsing.Errors);
 
@@ -121,7 +135,6 @@ namespace AasxToolkit.Tests
             Assert.AreEqual(
                 $"The command-line arguments could not be parsed.{nl}" +
                 $"Arguments (vertically ordered):{nl}" +
-                $"test-program{nl}" +
                 $"say <<< PROBLEM <<<{nl}" +
                 nl +
                 "Too few arguments specified for the command say. It requires at least one argument.",
@@ -133,7 +146,7 @@ namespace AasxToolkit.Tests
         {
             var cmdLine = setUpCommandLine();
 
-            var args = new[] { "test-program", "say", "one", "unknown-command", "foobar" };
+            var args = new[] { "say", "one", "unknown-command", "foobar" };
             var parsing = Cli.ParseInstructions(cmdLine, args);
             Assert.IsNull(parsing.Instructions);
 
@@ -143,7 +156,6 @@ namespace AasxToolkit.Tests
             Assert.AreEqual(
                 $"The command-line arguments could not be parsed.{nl}" +
                 $"Arguments (vertically ordered):{nl}" +
-                $"test-program{nl}" +
                 $"say{nl}" +
                 $"one{nl}" +
                 $"unknown-command <<< PROBLEM <<<{nl}" +

--- a/src/AasxToolkit.Tests/TestProgram.cs
+++ b/src/AasxToolkit.Tests/TestProgram.cs
@@ -54,7 +54,6 @@ namespace AasxToolkit.Tests
                         int code = AasxToolkit.Program.MainWithExitCode(
                             new[]
                             {
-                                nameof(AasxToolkit),
                                 "load", pth,
                                 "save", Path.Combine(tmpDir.Path, "saved.xml")
                             });
@@ -81,7 +80,6 @@ namespace AasxToolkit.Tests
                         int code = AasxToolkit.Program.MainWithExitCode(
                             new[]
                             {
-                                nameof(AasxToolkit),
                                 "load", pth,
                                 "export-template", Path.Combine(tmpDir.Path, "exported.template")
                             });
@@ -108,7 +106,6 @@ namespace AasxToolkit.Tests
                         int code = AasxToolkit.Program.MainWithExitCode(
                             new[]
                             {
-                                nameof(AasxToolkit),
                                 "load", pth,
                                 "check",
                                 "save", Path.Combine(tmpDir.Path, "saved.xml")
@@ -135,7 +132,6 @@ namespace AasxToolkit.Tests
                             int code = AasxToolkit.Program.MainWithExitCode(
                                 new[]
                                 {
-                                    nameof(AasxToolkit),
                                     "load", pth,
                                     "check+fix",
                                     "save", Path.Combine(tmpDir.Path, "saved.xml")
@@ -156,7 +152,7 @@ namespace AasxToolkit.Tests
             {
                 using (var consoleCap = new ConsoleCapture())
                 {
-                    int code = AasxToolkit.Program.MainWithExitCode(new[] { nameof(AasxToolkit) });
+                    int code = AasxToolkit.Program.MainWithExitCode(new string[] { });
 
                     Assert.AreEqual(0, code);
                     Assert.AreEqual("", consoleCap.Error());
@@ -174,7 +170,7 @@ namespace AasxToolkit.Tests
             {
                 using (var consoleCap = new ConsoleCapture())
                 {
-                    int code = AasxToolkit.Program.MainWithExitCode(new[] { nameof(AasxToolkit), helpArg });
+                    int code = AasxToolkit.Program.MainWithExitCode(new[] { helpArg });
 
                     Assert.AreEqual(0, code);
                     Assert.AreEqual("", consoleCap.Error());
@@ -188,7 +184,7 @@ namespace AasxToolkit.Tests
                 using (var consoleCap = new ConsoleCapture())
                 {
                     int code = AasxToolkit.Program.MainWithExitCode(
-                        new[] { nameof(AasxToolkit), "load", "doesnt-exist.aasx", "help" });
+                        new[] { "load", "doesnt-exist.aasx", "help" });
 
                     Assert.AreEqual(0, code);
                     Assert.AreEqual("", consoleCap.Error());

--- a/src/AasxToolkit/Cli.cs
+++ b/src/AasxToolkit/Cli.cs
@@ -299,17 +299,12 @@ namespace AasxToolkit
         {
             if (args.Count == 0)
             {
-                throw new ArgumentException(
-                    "Unexpected zero command-line arguments. " +
-                    "The command-line arguments should contain at least one element, namely the program.");
+                return new ParsingOfInstructions(0, new List<IInstruction>());
             }
 
             var instructions = new List<IInstruction>();
 
-            // Skip the first argument assuming it denotes the program and start with the second argument
-            int cursor = 1;
-
-            while (cursor < args.Count)
+            for (int cursor = 0; cursor < args.Count;)
             {
                 bool found = false;
                 foreach (var cmd in commandLine.Commands)
@@ -384,41 +379,27 @@ namespace AasxToolkit
             var writer = new System.IO.StringWriter();
 
             writer.WriteLine("The command-line arguments could not be parsed.");
-            if (acceptedArgs == 0)
-            {
-                for (var i = 0; i < errors.Count; i++)
-                {
-                    writer.Write(errors[i]);
 
-                    if (i < errors.Count - 1)
-                    {
-                        writer.WriteLine();
-                    }
+            writer.WriteLine("Arguments (vertically ordered):");
+            for (var i = 0; i < args.Count; i++)
+            {
+                if (i != acceptedArgs)
+                {
+                    writer.WriteLine(args[i]);
+                }
+                else
+                {
+                    writer.WriteLine($"{args[i]} <<< PROBLEM <<<");
                 }
             }
-            else
+            writer.WriteLine();
+            for (var i = 0; i < errors.Count; i++)
             {
-                writer.WriteLine("Arguments (vertically ordered):");
-                for (var i = 0; i < args.Count; i++)
-                {
-                    if (i != acceptedArgs)
-                    {
-                        writer.WriteLine(args[i]);
-                    }
-                    else
-                    {
-                        writer.WriteLine($"{args[i]} <<< PROBLEM <<<");
-                    }
-                }
-                writer.WriteLine();
-                for (var i = 0; i < errors.Count; i++)
-                {
-                    writer.Write(errors[i]);
+                writer.Write(errors[i]);
 
-                    if (i < errors.Count - 1)
-                    {
-                        writer.WriteLine();
-                    }
+                if (i < errors.Count - 1)
+                {
+                    writer.WriteLine();
                 }
             }
 

--- a/src/AasxToolkit/Program.cs
+++ b/src/AasxToolkit/Program.cs
@@ -35,13 +35,6 @@ namespace AasxToolkit
 
         public static int MainWithExitCode(string[] args)
         {
-            if (args.Length == 0)
-            {
-                throw new ArgumentException(
-                    "Unexpected no command-line arguments. There should be at least one, first argument " +
-                    "referring to the program.");
-            }
-
             var nl = System.Environment.NewLine;
 
             var cmdGen = new Cli.Command(
@@ -214,7 +207,7 @@ namespace AasxToolkit
             // # Handle the special "help" command
 
             var helpAliases = new HashSet<string> { "help", "--help", "-help", "/help", "-h", "/h" };
-            if (args.Length == 1 || args.Any(arg => helpAliases.Contains(arg)))
+            if (args.Length == 0 || args.Any(arg => helpAliases.Contains(arg)))
             {
                 Console.WriteLine(Cli.GenerateUsageMessage(cmdLine));
                 return 0;


### PR DESCRIPTION
The C and C# conventions about command-line arguments differ -- C#
excludes the executable name from the arguments passed to `Main()`. This
patch fixes the bugs caused by erroneous assumption that `Main` gets the
executable name in C#.