### PR TITLE
Add exhaustive matching to AasxToolkit

### DIFF
--- a/src/AasxToolkit.Tests/AasxToolkit.Tests.csproj
+++ b/src/AasxToolkit.Tests/AasxToolkit.Tests.csproj
@@ -1,72 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" />
-  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectGuid>
+      <TargetFramework>net461</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>AasxToolkit.Tests</RootNamespace>
-    <AssemblyName>AasxToolkit.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml" />
+    <ProjectReference Include="..\AasxToolkit\AasxToolkit.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="*.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj">
-      <Project>{9863799b-4e44-4da2-9120-c85c7985bc6d}</Project>
-      <Name>AasxCsharpLibrary</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\AasxToolkit\AasxToolkit.csproj">
-      <Project>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</Project>
-      <Name>AasxToolkit</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props'))" />
-  </Target>
 </Project>

--- a/src/AasxToolkit.Tests/DocTestCli.cs
+++ b/src/AasxToolkit.Tests/DocTestCli.cs
@@ -8,26 +8,26 @@ namespace AasxToolkit.Tests
     public class DocTest_Cli_cs
     {
         [Test]
-        public void AtLine196AndColumn16()
+        public void AtLine189AndColumn16()
         {
             Assert.AreEqual("", Cli.Indentation.Indent("", "  "));
         }
 
         [Test]
-        public void AtLine197AndColumn16()
+        public void AtLine190AndColumn16()
         {
             Assert.AreEqual("  test", Cli.Indentation.Indent("test", "  "));
         }
 
         [Test]
-        public void AtLine198AndColumn16()
+        public void AtLine191AndColumn16()
         {
             var nl = System.Environment.NewLine;
             Assert.AreEqual($"  test{nl}  me", Cli.Indentation.Indent("test\nme", "  "));
         }
 
         [Test]
-        public void AtLine202AndColumn16()
+        public void AtLine195AndColumn16()
         {
             var nl = System.Environment.NewLine;
             Assert.AreEqual($"  test{nl}  me", Cli.Indentation.Indent("test\r\nme", "  "));

--- a/src/AasxToolkit/AasxToolkit.csproj
+++ b/src/AasxToolkit/AasxToolkit.csproj
@@ -1,127 +1,71 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{294FC59A-5645-412F-8216-702FB66528C1}</ProjectGuid>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RootNamespace>AasxToolkit</RootNamespace>
-    <AssemblyName>AasxToolkit</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.IO.Packaging, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Packaging.4.7.0\lib\net46\System.IO.Packaging.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Cli.cs" />
-    <Compile Include="Execution.cs" />
-    <Compile Include="Generate.cs" />
-    <Compile Include="Instruction.cs" />
-    <Compile Include="Log.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="UriIdentifierRepository.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-    <None Include="data\CopyExternalData.bat">
+    <None Update="data\CopyExternalData.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="data\README.md">
+    <None Update="data\README.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
-    <None Include="schemaV10\AAS.xsd">
+    <None Update="schemaV10\AAS.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV10\AASEnv_Final_v1.4.json">
+    <None Update="schemaV10\AASEnv_Final_v1.4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV10\AAS_Example_v1.4.json">
+    <None Update="schemaV10\AAS_Example_v1.4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV10\IEC61360.xsd">
+    <None Update="schemaV10\IEC61360.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV10\validate_samle_json.bat">
+    <None Update="schemaV10\validate_samle_json.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV10\validate_samle_xml.bat">
+    <None Update="schemaV10\validate_samle_xml.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV201\AAS.xsd">
+    <None Update="schemaV201\AAS.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV201\AAS_ABAC.xsd">
+    <None Update="schemaV201\AAS_ABAC.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV201\IEC61360.xsd">
+    <None Update="schemaV201\IEC61360.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV201\validate_samle_xml.bat">
+    <None Update="schemaV201\validate_samle_xml.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV20\AAS.xsd">
+    <None Update="schemaV20\AAS.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV20\AAS_ABAC.xsd">
+    <None Update="schemaV20\AAS_ABAC.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV20\IEC61360.xsd">
+    <None Update="schemaV20\IEC61360.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="schemaV20\validate_samle_xml.bat">
+    <None Update="schemaV20\validate_samle_xml.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="ValidateSampleAAS.ps1">
+    <None Update="ValidateSampleAAS.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
@@ -145,34 +89,27 @@
     <Content Include="schemaV20\SimpleDrehzahl.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="LICENSE.txt">
+    <None Update="LICENSE.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Content Include="schemaV10\out.txt" />
     <Content Include="schemaV10\SimpleDrehzahl.xml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\AasxAmlImExport\AasxAmlImExport.csproj">
-      <Project>{6d1a03b2-eba7-4ce2-9237-df9ad7128947}</Project>
-      <Name>AasxAmlImExport</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj">
-      <Project>{9863799b-4e44-4da2-9120-c85c7985bc6d}</Project>
-      <Name>AasxCsharpLibrary</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\AasxIntegrationBaseWpf\AasxIntegrationBaseWpf.csproj">
-      <Project>{e3ab36ea-e98a-4cc2-bc18-1d0e40eeae1a}</Project>
-      <Name>AasxIntegrationBaseWpf</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj">
-      <Project>{5a05df78-216b-4a0b-9e30-7b2557c7e867}</Project>
-      <Name>AasxIntegrationBase</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\AasxPredefinedConcepts\AasxPredefinedConcepts.csproj">
-      <Project>{a8583f61-e5d8-44a0-98e3-a795578be3f0}</Project>
-      <Name>AasxPredefinedConcepts</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\AasxAmlImExport\AasxAmlImExport.csproj" />
+    <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
+    <ProjectReference Include="..\AasxIntegrationBaseWpf\AasxIntegrationBaseWpf.csproj" />
+    <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />
+    <ProjectReference Include="..\AasxPredefinedConcepts\AasxPredefinedConcepts.csproj" />
   </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.IO.Packaging" Version="4.7.0" />
+  </ItemGroup>
 </Project>

--- a/src/AasxToolkit/Cli.cs
+++ b/src/AasxToolkit/Cli.cs
@@ -32,7 +32,7 @@ namespace AasxToolkit
     /// To add a new command-instruction-execution to the program, follow these steps:
     /// <ol>
     /// <li>Start by conceptualizing what data your instruction needs. Write it down by writing a class
-    ///     implementing <see cref="IInstruction"/> and put it in <see cref="Instruction"/>.</li>
+    ///     implementing <see cref="Instruction.IInstruction"/> and put it in <see cref="Instruction"/>.</li>
     /// <li>Add the command to <see cref="Program"/>. Provide parse function that translates command-line arguments
     ///     into your instruction.</li>
     /// <li>Implement the execution of your instruction by adding a case corresponding to your instruction to
@@ -44,21 +44,14 @@ namespace AasxToolkit
     public static class Cli
     {
         /// <summary>
-        /// Represents a single instruction to the program.
-        /// </summary>
-        /// <remarks>The instruction interface is intentionally defined here (and not in a different file) so that we
-        /// can extract this code to a completely separate NuGet package in the future, if necessary.</remarks>
-        public interface IInstruction { }
-
-        /// <summary>
         /// Represents a parsing of a command as specified on the command-line.
         /// </summary>
         public class Parsing
         {
-            public readonly IInstruction Instruction;
+            public readonly Instruction.IInstruction Instruction;
             public readonly IReadOnlyList<string> Errors;
 
-            public Parsing(IInstruction instruction)
+            public Parsing(Instruction.IInstruction instruction)
             {
                 Instruction = instruction;
                 Errors = null;
@@ -165,10 +158,10 @@ namespace AasxToolkit
             /// </remarks>
             public readonly int AcceptedArgs;
 
-            public readonly IReadOnlyList<IInstruction> Instructions;
+            public readonly IReadOnlyList<Instruction.IInstruction> Instructions;
             public readonly IReadOnlyList<string> Errors;
 
-            public ParsingOfInstructions(int acceptedArgs, IReadOnlyList<IInstruction> instructions)
+            public ParsingOfInstructions(int acceptedArgs, IReadOnlyList<Instruction.IInstruction> instructions)
             {
                 AcceptedArgs = acceptedArgs;
                 Instructions = instructions;
@@ -311,10 +304,10 @@ namespace AasxToolkit
         {
             if (args.Count == 0)
             {
-                return new ParsingOfInstructions(0, new List<IInstruction>());
+                return new ParsingOfInstructions(0, new List<Instruction.IInstruction>());
             }
 
-            var instructions = new List<IInstruction>();
+            var instructions = new List<Instruction.IInstruction>();
 
             for (int cursor = 0; cursor < args.Count;)
             {

--- a/src/AasxToolkit/Execution.cs
+++ b/src/AasxToolkit/Execution.cs
@@ -24,7 +24,7 @@ namespace AasxToolkit
     /// </summary>
     public static class Execution
     {
-        public static int Execute(IReadOnlyList<Cli.IInstruction> instructions)
+        public static int Execute(IReadOnlyList<Instruction.IInstruction> instructions)
         {
             // # Context
             AdminShellPackageEnv package = null;
@@ -287,9 +287,7 @@ namespace AasxToolkit
                             break;
                         }
                     default:
-                        throw new InvalidOperationException(
-                            "The execution of the instruction has not been handled: " +
-                            instruction.GetType());
+                        throw ExhaustiveMatching.ExhaustiveMatch.Failed(instruction);
                 }
             }
 

--- a/src/AasxToolkit/Instruction.cs
+++ b/src/AasxToolkit/Instruction.cs
@@ -1,14 +1,21 @@
-﻿using System;
-using System.IO;
-
-using AasxAmlImExport;
-using AasxIntegrationBase.AasForms;
-using AdminShellNS;
-
-namespace AasxToolkit.Instruction
+﻿namespace AasxToolkit.Instruction
 {
+    /// <summary>
+    /// Represents a single instruction to the program.
+    /// </summary>
+    /// <remarks>The instruction interface is intentionally defined here (and not in a different file) so that we
+    /// can extract this code to a completely separate NuGet package in the future, if necessary.</remarks>
+    [ExhaustiveMatching.Closed(
+        typeof(Generate),
+        typeof(Load),
+        typeof(Save),
+        typeof(Validate),
+        typeof(ExportTemplate),
+        typeof(CheckAndFix),
+        typeof(Test))]
+    public interface IInstruction { }
 
-    class Generate : Cli.IInstruction
+    public class Generate : IInstruction
     {
         public readonly string JsonInitFile;
 
@@ -18,7 +25,7 @@ namespace AasxToolkit.Instruction
         }
     }
 
-    class Load : Cli.IInstruction
+    public class Load : IInstruction
     {
         public readonly string Path;
 
@@ -28,7 +35,7 @@ namespace AasxToolkit.Instruction
         }
     }
 
-    class Save : Cli.IInstruction
+    public class Save : IInstruction
     {
         public readonly string Path;
 
@@ -38,7 +45,7 @@ namespace AasxToolkit.Instruction
         }
     }
 
-    class Validate : Cli.IInstruction
+    public class Validate : IInstruction
     {
         public readonly string Path;
 
@@ -48,7 +55,7 @@ namespace AasxToolkit.Instruction
         }
     }
 
-    class ExportTemplate : Cli.IInstruction
+    public class ExportTemplate : IInstruction
     {
         public readonly string Path;
 
@@ -58,7 +65,7 @@ namespace AasxToolkit.Instruction
         }
     }
 
-    class CheckAndFix : Cli.IInstruction
+    public class CheckAndFix : IInstruction
     {
         public readonly bool ShouldFix;
 
@@ -68,7 +75,7 @@ namespace AasxToolkit.Instruction
         }
     }
 
-    class Test : Cli.IInstruction
+    public class Test : IInstruction
     {
         // Intentionally left empty
     }

--- a/src/AasxToolkit/packages.config
+++ b/src/AasxToolkit/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ExhaustiveMatching.Analyzer" version="0.5.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.IO.Packaging" version="4.7.0" targetFramework="net461" />


### PR DESCRIPTION
This introduces `ExhaustiveMatching.Analyzer` to automatically check
that switches on types and enums are exhaustive.

This is important in dispatching situations where we can easily avoid
future run-time errors caused by the developer forgetting to handle one
or more cases (*e.g.*, when a new class is added to the hierarchy).