### PR TITLE
Fix InspectCode issues missed due to caching

### DIFF
--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -104,14 +104,6 @@ jobs:
           echo "Commit is: $commit"
           dotnet tool run csmacnz.Coveralls --opencover -i ..\artefacts\CoverageResults.xml --useRelativePaths --repoToken $env:COVERALLS_REPO_TOKEN --commitId $commit --commitBranch $branch
 
-      - name: Cache inspect code
-        uses: actions/cache@v2
-        env:
-          cache-name: inspect-code
-        with:
-          path: artefacts/inspectcode-caches
-          key: ${{ env.cache-name }}-2020-07-06-T-14-40Z
-
       - name: Inspect code
         working-directory: src
         run: powershell .\InspectCode.ps1

--- a/src/AasxPackageExplorer.sln.DotSettings
+++ b/src/AasxPackageExplorer.sln.DotSettings
@@ -2,6 +2,8 @@
 <!-- see for reference: https://github.com/JetBrains/resharper-ultimate-whatsnew/blob/master/Inspections.DotSettings -->
 <!-- In Issue names quote "." -> "_002E" -->
 <wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<!-- This seems to generate too many false positives. -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConstantConditionalAccessQualifier/@EntryIndexedValue">HINT</s:String>
 
 	<!-- IMHO, we should ignore this globally, as we could nicely manager this direct in VS. Sometimes, we would like to have a "standard set" of usings. I'm fine with a bit slack here. -->
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">HINT</s:String>
@@ -154,15 +156,19 @@
 	
 	<!-- Implicit object conversion is not explicit enough --> 
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantToStringCall/@EntryIndexedValue">HINT</s:String>
-	
+
 	<!-- again, I do like explicit things --> 
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBaseQualifier/@EntryIndexedValue">HINT</s:String>
+
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Aasx/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=doctest/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dsiec/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Festo/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hoffmeister/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Referables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=smref/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Submodel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ZVEI/@EntryIndexedValue">True</s:Boolean>
 	
 	
 </wpf:ResourceDictionary>

--- a/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml.cs
+++ b/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml.cs
@@ -230,7 +230,7 @@ namespace AasxPluginMtpViewer
                         var newtxt = ren?.value.FindFirstSemanticIdAs<AdminShell.Property>(
                             this.defsMtp.CD_RenamingNewText?.GetReference(), AdminShell.Key.MatchMode.Relaxed)?.value;
                         if (oldtxt.HasContent() && newtxt.HasContent() &&
-                            preLoadInfo.NamespaceRenaming != null)
+                            preLoadInfo?.NamespaceRenaming != null)
                             preLoadInfo.NamespaceRenaming.Add(new MtpDataSourceStringReplacement(oldtxt, newtxt));
                     }
 

--- a/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
+++ b/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
@@ -23,7 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>8.0</LangVersion>
-    <Nullable>Enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/AasxPredefinedConcepts/ConceptModel/ConceptModelZveiTechnicalData.cs
+++ b/src/AasxPredefinedConcepts/ConceptModel/ConceptModelZveiTechnicalData.cs
@@ -41,8 +41,6 @@ namespace AasxPredefinedConcepts.ConceptModel
             CD_TextStatement,
             CD_ValidDate;
 
-        public ConceptModelZveiTechnicalData() { }
-
         public ConceptModelZveiTechnicalData(AdminShell.Submodel sm)
         {
             InitFromSubmodel(sm);
@@ -122,13 +120,13 @@ namespace AasxPredefinedConcepts.ConceptModel
         {
             var defsV10 = new AasxPredefinedConcepts.DefinitionsZveiTechnicalData.SetOfDefs(
                     new AasxPredefinedConcepts.DefinitionsZveiTechnicalData());
-            if (sm?.semanticId.MatchesExactlyOneKey(defsV10.SM_TechnicalData.GetSemanticKey(),
-                AdminShellV20.Key.MatchMode.Relaxed) == true)
+            if (sm.semanticId.MatchesExactlyOneKey(
+                    defsV10.SM_TechnicalData.GetSemanticKey(), AdminShellV20.Key.MatchMode.Relaxed))
                 InitFromVersion(Version.V1_0);
 
             var defsV11 = AasxPredefinedConcepts.ZveiTechnicalDataV11.Static;
-            if (sm?.semanticId.MatchesExactlyOneKey(defsV11.SM_TechnicalData.GetSemanticKey(),
-                AdminShellV20.Key.MatchMode.Relaxed) == true)
+            if (sm.semanticId.MatchesExactlyOneKey(
+                    defsV11.SM_TechnicalData.GetSemanticKey(), AdminShellV20.Key.MatchMode.Relaxed))
                 InitFromVersion(Version.V1_1);
         }
     }


### PR DESCRIPTION
InspectCode caches (both local and remote, on GitHub servers) were not
invalidated when we turned on Nullable setting in
`AasxPredefinedConcepts`. This eclipsed many issues with improper
handling of nullable values.

We turn off nullables for `AasxPredefinedConcepts` again as it is too
much refactoring work to handle it at the moment.

Finally, the caching on the remote GitHub servers during the continuous
integration is also turned off to prevend similar problems in the
future.