### PR TITLE
Remove CEF-related code

### DIFF
--- a/src/AasxPackageExplorer/AasxPackageExplorer.csproj
+++ b/src/AasxPackageExplorer/AasxPackageExplorer.csproj
@@ -15,9 +15,6 @@
 	<Platform>x64</Platform>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants>WITHBROWSERPLUGIN</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup>
     <ApplicationIcon>aasx.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>

--- a/src/AasxPackageExplorer/BrowserContainer.cs
+++ b/src/AasxPackageExplorer/BrowserContainer.cs
@@ -10,17 +10,6 @@ using System.Windows;
 using System.Windows.Controls;
 using AasxIntegrationBase;
 
-#if WITHCEF
-using CefSharp;
-using CefSharp.Wpf;
-using CefSharp.Internals;
-using CefSharp.Event;
-using CefSharp.Wpf.Internals;
-using CefSharp.Wpf.Rendering;
-using CefSharp.OffScreen;
-using CefSharp.RenderProcess;
-#endif
-
 namespace AasxPackageExplorer
 {
     /// <summary>
@@ -32,18 +21,6 @@ namespace AasxPackageExplorer
         #region Members
         //=============
 
-#if WITHCEF
-        private CefSharp.Wpf.ChromiumWebBrowser theOnscreenBrowser = null;
-        private CefSharp.OffScreen.ChromiumWebBrowser theOffscreenBrowser = null;
-        private string browserHandlesFiles = ".jpeg .jpg .png .bmp .pdf .xml .txt *";
-        public CefSharp.Wpf.ChromiumWebBrowser BrowserControl { get { return theOnscreenBrowser; } }
-
-        public double ZoomLevel
-        {
-            get { return (theOnscreenBrowser == null) ? 0.0 : theOnscreenBrowser.ZoomLevel; }
-            set { if (theOnscreenBrowser != null) theOnscreenBrowser.ZoomLevel = value; }
-        }
-#elif WITHBROWSERPLUGIN
         private static Plugins.PluginInstance browserPlugin = null;
         private static Grid theOnscreenBrowser = null;
         private string browserHandlesFiles = ".jpeg .jpg .png .bmp .pdf .xml .txt .md *";
@@ -77,22 +54,8 @@ namespace AasxPackageExplorer
                 }
             }
         }
-#else
-        private FakeBrowser theBrowser = null;
-        private string browserHandlesFiles = ".jpeg .jpg .png .bmp";
-        public FakeBrowser BrowserControl { get { return theBrowser; } }
-
-        public double ZoomLevel
-        {
-            get { return 1.0; }
-            // ReSharper disable once ValueParameterNotUsed
-            set {; }
-        }
-#endif
 
         private bool useAlwaysInternalBrowser = false;
-        private bool useOffscreen = false;
-
 
 
         #endregion
@@ -101,22 +64,6 @@ namespace AasxPackageExplorer
 
         public void Start(string startUrl, bool useAlwaysInternalBrowser, bool useOffscreen = false)
         {
-#if WITHFAKEBROWSER
-            this.theBrowser = new FakeBrowser();
-            GoToContentBrowserAddress(startUrl);
-#endif
-
-#if WITHCEF
-            if (!useOffscreen)
-            {
-                this.theOnscreenBrowser = new CefSharp.Wpf.ChromiumWebBrowser();
-                GoToContentBrowserAddress(startUrl);
-            }
-
-#endif
-
-#if WITHBROWSERPLUGIN
-
             // due to the nature of the plug-in, this forms as SINGLETON
             if (BrowserContainer.browserPlugin != null && BrowserContainer.theOnscreenBrowser != null)
                 // always fine
@@ -145,36 +92,12 @@ namespace AasxPackageExplorer
                     BrowserContainer.theOnscreenBrowser = (res as AasxPluginResultBaseObject).obj as Grid;
                 }
             }
-#endif
 
             this.useAlwaysInternalBrowser = useAlwaysInternalBrowser;
-            this.useOffscreen = useOffscreen;
         }
 
         public void GoToContentBrowserAddress(string url)
         {
-#if WITHFAKEBROWSER
-            if (this.theBrowser != null)
-            {
-                this.theBrowser.Address = url;
-                this.theBrowser.InvalidateVisual();
-            }
-#endif
-#if WITHCEF
-            if (theOnscreenBrowser == null)
-                return;
-
-            try
-            {
-                theOnscreenBrowser.Address = url;
-                theOnscreenBrowser.InvalidateVisual();
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Showing content page " + url);
-            }
-#endif
-#if WITHBROWSERPLUGIN
             if (BrowserContainer.browserPlugin != null && BrowserContainer.theOnscreenBrowser != null)
             {
                 BrowserContainer.browserPlugin.InvokeAction("go-to-address", url);
@@ -184,7 +107,6 @@ namespace AasxPackageExplorer
                 this.theFallbackBrowser.Address = url;
                 this.theFallbackBrowser.InvalidateVisual();
             }
-#endif
         }
 
         #endregion
@@ -205,111 +127,6 @@ namespace AasxPackageExplorer
                 return false;
         }
 
-        public void StartOffscreenRender(string url)
-        {
-#if WITHCEF
-            var settings = new CefSharp.OffScreen.CefSettings()
-            {
-                //By default CefSharp will use an in-memory cache, you need to specify a Cache Folder to persist data
-                CachePath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CefSharp\\Cache"),
-            };
-
-            // play with surfaces
-            settings.SetOffScreenRenderingBestPerformanceArgs();
-
-            //Perform dependency check to make sure all relevant resources are in our output directory.
-            // Cef.Initialize(settings, performDependencyCheck: true, browserProcessHandler: null);
-
-            var rqs = new RequestContextSettings();
-            rqs.CachePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CefSharp\\Cache");
-            var rq = new RequestContext(rqs, null);
-
-            var bs = new BrowserSettings();
-            bs.BackgroundColor = 0xff000000;
-
-            this.theOffscreenBrowser = new CefSharp.OffScreen.ChromiumWebBrowser(url, bs, rq);
-            this.theOffscreenBrowser.Size = new System.Drawing.Size(400, 800);
-            this.theOffscreenBrowser.LoadingStateChanged += TheBrowser_LoadingStateChanged;
-            this.theOffscreenBrowser.FrameLoadEnd += TheOffscreenBrowser_FrameLoadEnd;
-
-            private void TheOffscreenBrowser_FrameLoadEnd(object sender, FrameLoadEndEventArgs e)
-            {
-                ;
-            }
-#endif
-        }
-
-
-
         #endregion
-        #region Callbacks from the browse
-        //==============================
-
-#if WITHCEF
-        private void TheBrowser_LoadingStateChanged(object sender, CefSharp.LoadingStateChangedEventArgs e)
-        {
-            // see: https://github.com/cefsharp/CefSharp.MinimalExample/blob/master/
-            // CefSharp.MinimalExample.OffScreen/Program.cs
-            if (theOffscreenBrowser == null)
-                return;
-
-            // Check to see if loading is complete - this event is called twice, one when loading starts
-            // second time when it's finished
-            // (rather than an iframe within the main frame).
-            if (!e.IsLoading)
-            {
-                // Remove the load event handler, because we only want one snapshot of the initial page.
-                this.theOffscreenBrowser.LoadingStateChanged -= TheBrowser_LoadingStateChanged;
-
-                var scriptTask = this.theOffscreenBrowser.EvaluateScriptAsync(
-                    "document.getElementById('lst-ib').value = 'CefSharp Was Here!'");
-
-                scriptTask.ContinueWith(t =>
-                {
-                    //Give the browser a little time to render
-                    Thread.Sleep(5000);
-                    // Wait for the screenshot to be taken.
-                    var task = this.theOffscreenBrowser.ScreenshotAsync();
-                    task.ContinueWith(x =>
-                    {
-                        // Make a file to save it to (e.g. C:\Users\jan\Desktop\CefSharp screenshot.png)
-                        var screenshotPath = Path.Combine(
-                            Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "CefSharp screenshot.png");
-
-                        Console.WriteLine();
-                        Console.WriteLine("Screenshot ready. Saving to {0}", screenshotPath);
-
-                        // Save the Bitmap to the path.
-                        // The image type is auto-detected via the ".png" extension.
-                        System.Drawing.Bitmap orig = task.Result;
-                        var rect = new System.Drawing.Rectangle(
-                            new System.Drawing.Point(3, 59), new System.Drawing.Size(376, 532));
-                        var cutout = CropImage(orig, rect);
-
-                        cutout.Save(screenshotPath);
-
-                        // We no longer need the Bitmap.
-                        // Dispose it to avoid keeping the memory alive.  Especially important in 32-bit applications.
-                        task.Result.Dispose();
-                        cutout.Dispose();
-
-                    }, TaskScheduler.Default);
-                });
-            }
-        }
-#endif
-        #endregion
-
-        public Bitmap CropImage(Bitmap source, Rectangle section)
-        {
-            var bitmap = new Bitmap(section.Width, section.Height);
-            using (var g = Graphics.FromImage(bitmap))
-            {
-                g.DrawImage(source, 0, 0, section, GraphicsUnit.Pixel);
-                return bitmap;
-            }
-        }
     }
 }

--- a/src/AasxPackageExplorer/MainWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MainWindow.xaml.cs
@@ -53,9 +53,6 @@ namespace AasxPackageExplorer
         private IFlyoutControl currentFlyoutControl = null;
 
         private BrowserContainer theContentBrowser = new BrowserContainer();
-#if OFFSCREENBROWSER
-        private BrowserContainer theOffscreenBrowser = new BrowserContainer();
-#endif
 
         private AasxIntegrationBase.IAasxOnlineConnection theOnlineConnection = null;
 
@@ -556,10 +553,6 @@ namespace AasxPackageExplorer
             theContentBrowser.Start(Options.Curr.ContentHome, Options.Curr.InternalBrowser);
             CefContainer.Child = theContentBrowser.BrowserControl;
 
-#if OFFSCREENBROWSER
-            theOffscreenBrowser.Start(Options.Curr.ContentHome, true, useOffscreen: true);
-#endif
-
             // window size?
             if (Options.Curr.WindowLeft > 0) this.Left = Options.Curr.WindowLeft;
             if (Options.Curr.WindowTop > 0) this.Top = Options.Curr.WindowTop;
@@ -969,22 +962,6 @@ namespace AasxPackageExplorer
                             Log.Error(ex, $"While displaying content file {evtDispCont.fn} requested by plug-in");
                         }
 
-                    #endregion
-                    #region Offscreen render file
-                    //===========================
-#if OFFSCREENBROWSER
-                    var evtRender = evt as AasxIntegrationBase.AasxPluginResultEventOffscreenRenderFile;
-                    if (evtRender != null && evtRender.fn != null)
-                        try
-                        {
-                            theOffscreenBrowser?.StartOffscreenRender(evtRender.fn);
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Error(
-                                ex, $"While starting offscreen render of file {evtRender.fn} requested by plug-in");
-                        }
-#endif
                     #endregion
                     #region Redisplay explorer contents
                     //=================================


### PR DESCRIPTION
[CEF][1] was initially used to embed Chromium in the Package
Explorer, but it was too heavy to be included in the releases. To allow
for more light-weight release bundles, the web browser was refactored
out into a plugin (`AasxPluginWebBrowser`).

In this patch, we remove all references to this obsolete code.

[1]: https://github.com/cefsharp/CefSharp