### PR TITLE
Test Load-Fix-Validate chain in AasxToolkit

### DIFF
--- a/src/AasxToolkit.Tests/AasxToolkit.Tests.csproj
+++ b/src/AasxToolkit.Tests/AasxToolkit.Tests.csproj
@@ -10,5 +10,11 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TestResources\AasxToolkit.Tests\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/AasxToolkit.Tests/TestProgram.cs
+++ b/src/AasxToolkit.Tests/TestProgram.cs
@@ -58,8 +58,14 @@ namespace AasxToolkit.Tests
                                 "save", Path.Combine(tmpDir.Path, "saved.xml")
                             });
 
+                        if (consoleCap.Error() != "")
+                        {
+                            throw new AssertionException(
+                                $"Expected no stderr, but got:{System.Environment.NewLine}" +
+                                consoleCap.Error());
+                        }
+
                         Assert.AreEqual(0, code);
-                        Assert.AreEqual("", consoleCap.Error());
                     }
                 }
             }
@@ -84,8 +90,14 @@ namespace AasxToolkit.Tests
                                 "export-template", Path.Combine(tmpDir.Path, "exported.template")
                             });
 
+                        if (consoleCap.Error() != "")
+                        {
+                            throw new AssertionException(
+                                $"Expected no stderr, but got:{System.Environment.NewLine}" +
+                                consoleCap.Error());
+                        }
+
                         Assert.AreEqual(0, code);
-                        Assert.AreEqual("", consoleCap.Error());
                     }
                 }
             }
@@ -111,8 +123,14 @@ namespace AasxToolkit.Tests
                                 "save", Path.Combine(tmpDir.Path, "saved.xml")
                             });
 
+                        if (consoleCap.Error() != "")
+                        {
+                            throw new AssertionException(
+                                $"Expected no stderr, but got:{System.Environment.NewLine}" +
+                                consoleCap.Error());
+                        }
+
                         Assert.AreEqual(0, code);
-                        Assert.AreEqual("", consoleCap.Error());
                     }
                 }
             }
@@ -137,8 +155,14 @@ namespace AasxToolkit.Tests
                                     "save", Path.Combine(tmpDir.Path, "saved.xml")
                                 });
 
+                            if (consoleCap.Error() != "")
+                            {
+                                throw new AssertionException(
+                                    $"Expected no stderr, but got:{System.Environment.NewLine}" +
+                                    consoleCap.Error());
+                            }
+
                             Assert.AreEqual(0, code);
-                            Assert.AreEqual("", consoleCap.Error());
                         }
                     }
                 }
@@ -154,8 +178,15 @@ namespace AasxToolkit.Tests
                 {
                     int code = AasxToolkit.Program.MainWithExitCode(new string[] { });
 
+                    if (consoleCap.Error() != "")
+                    {
+                        throw new AssertionException(
+                            $"Expected no stderr, but got:{System.Environment.NewLine}" +
+                            consoleCap.Error());
+                    }
+
                     Assert.AreEqual(0, code);
-                    Assert.AreEqual("", consoleCap.Error());
+
                     Assert.IsTrue(consoleCap.Output().StartsWith("AasxToolkit:"));  // Start of the help message
                 }
             }
@@ -172,8 +203,15 @@ namespace AasxToolkit.Tests
                 {
                     int code = AasxToolkit.Program.MainWithExitCode(new[] { helpArg });
 
+                    if (consoleCap.Error() != "")
+                    {
+                        throw new AssertionException(
+                            $"Expected no stderr, but got:{System.Environment.NewLine}" +
+                            consoleCap.Error());
+                    }
+
                     Assert.AreEqual(0, code);
-                    Assert.AreEqual("", consoleCap.Error());
+
                     Assert.IsTrue(consoleCap.Output().StartsWith("AasxToolkit:"));  // Start of the help message
                 }
             }
@@ -186,9 +224,70 @@ namespace AasxToolkit.Tests
                     int code = AasxToolkit.Program.MainWithExitCode(
                         new[] { "load", "doesnt-exist.aasx", "help" });
 
+                    if (consoleCap.Error() != "")
+                    {
+                        throw new AssertionException(
+                            $"Expected no stderr, but got:{System.Environment.NewLine}" +
+                            consoleCap.Error());
+                    }
+
                     Assert.AreEqual(0, code);
-                    Assert.AreEqual("", consoleCap.Error());
+
                     Assert.IsTrue(consoleCap.Output().StartsWith("AasxToolkit:"));  // Start of the help message
+                }
+            }
+        }
+
+        public class TestValidation
+        {
+            [Test]
+            public void TestAgainstSampleData()
+            {
+                var samplePaths = new List<string>
+                {
+                    Path.Combine(
+                        TestContext.CurrentContext.TestDirectory,
+                        "TestResources\\AasxToolkit.Tests\\sample.xml")
+                    /*
+                     TODO (mristin, 2020-10-30): add json once the validation is in place.
+                     Michael Hoffmeister had it almost done today.
+                     
+                    Path.Combine(
+                        TestContext.CurrentContext.TestDirectory,
+                        "TestResources\\AasxToolkit.Tests\\sample.json")
+                        
+                        dead-csharp ignore this comment
+                        */
+                };
+
+                foreach (string samplePath in samplePaths)
+                {
+                    if (!File.Exists(samplePath))
+                    {
+                        throw new FileNotFoundException($"The sample file could not be found: {samplePath}");
+                    }
+
+                    using (var tmpDir = new TemporaryDirectory())
+                    {
+                        using (var consoleCap = new ConsoleCapture())
+                        {
+                            string extension = Path.GetExtension(samplePath);
+                            string tmpPath = Path.Combine(tmpDir.Path, $"to-be-validated{extension}");
+
+                            int code = AasxToolkit.Program.MainWithExitCode(
+                                new[] { "load", samplePath, "check+fix", "save", tmpPath, "validate", tmpPath });
+
+                            if (consoleCap.Error() != "")
+                            {
+                                var nl = System.Environment.NewLine;
+                                throw new AssertionException(
+                                    $"Expected no stderr for the sample file {samplePath}, but got:{nl}" +
+                                    $"{consoleCap.Error()}");
+                            }
+
+                            Assert.AreEqual(0, code);
+                        }
+                    }
                 }
             }
         }

--- a/src/AasxToolkit.Tests/TestResources/AasxToolkit.Tests/sample.json
+++ b/src/AasxToolkit.Tests/TestResources/AasxToolkit.Tests/sample.json
@@ -1,0 +1,18714 @@
+{
+  "assetAdministrationShells": [
+    {
+      "asset": {
+        "keys": [
+          {
+            "type": "Asset",
+            "local": true,
+            "value": "https://admin-shell.hitachi-industrial.eu/asset/000000001",
+            "index": 0,
+            "idType": "IRI"
+          }
+        ],
+        "First": {
+          "type": "Asset",
+          "local": true,
+          "value": "https://admin-shell.hitachi-industrial.eu/asset/000000001",
+          "index": 0,
+          "idType": "IRI"
+        },
+        "Last": {
+          "type": "Asset",
+          "local": true,
+          "value": "https://admin-shell.hitachi-industrial.eu/asset/000000001",
+          "index": 0,
+          "idType": "IRI"
+        }
+      },
+      "submodels": [
+        {
+          "keys": [
+            {
+              "type": "Submodel",
+              "local": true,
+              "value": "www.company.com/ids/sm/4343_5072_7091_3242",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "Submodel",
+            "local": true,
+            "value": "www.company.com/ids/sm/4343_5072_7091_3242",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "Submodel",
+            "local": true,
+            "value": "www.company.com/ids/sm/4343_5072_7091_3242",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        {
+          "keys": [
+            {
+              "type": "Submodel",
+              "local": true,
+              "value": "www.company.com/ids/sm/2543_5072_7091_2660",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "Submodel",
+            "local": true,
+            "value": "www.company.com/ids/sm/2543_5072_7091_2660",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "Submodel",
+            "local": true,
+            "value": "www.company.com/ids/sm/2543_5072_7091_2660",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        {
+          "keys": [
+            {
+              "type": "Submodel",
+              "local": true,
+              "value": "www.company.com/ids/sm/6053_5072_7091_5102",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "Submodel",
+            "local": true,
+            "value": "www.company.com/ids/sm/6053_5072_7091_5102",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "Submodel",
+            "local": true,
+            "value": "www.company.com/ids/sm/6053_5072_7091_5102",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        {
+          "keys": [
+            {
+              "type": "Submodel",
+              "local": true,
+              "value": "www.company.com/ids/sm/6563_5072_7091_4267",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "Submodel",
+            "local": true,
+            "value": "www.company.com/ids/sm/6563_5072_7091_4267",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "Submodel",
+            "local": true,
+            "value": "www.company.com/ids/sm/6563_5072_7091_4267",
+            "index": 0,
+            "idType": "IRI"
+          }
+        },
+        {
+          "keys": [
+            {
+              "type": "Submodel",
+              "local": true,
+              "value": "https://automation.hitachi-industrial.eu/_Resources/Static/Packages/Moon.HitachiEurope/Downloads/automation/[2]%20Software/[5]%20Configuration%20Files/[1]%20Device%20Descriptions/Device%20files.zip",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "Submodel",
+            "local": true,
+            "value": "https://automation.hitachi-industrial.eu/_Resources/Static/Packages/Moon.HitachiEurope/Downloads/automation/[2]%20Software/[5]%20Configuration%20Files/[1]%20Device%20Descriptions/Device%20files.zip",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "Submodel",
+            "local": true,
+            "value": "https://automation.hitachi-industrial.eu/_Resources/Static/Packages/Moon.HitachiEurope/Downloads/automation/[2]%20Software/[5]%20Configuration%20Files/[1]%20Device%20Descriptions/Device%20files.zip",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ],
+      "conceptDictionaries": [],
+      "identification": {
+        "idType": "IRI",
+        "id": "https://admin-shell.hitachi-industrial.eu/aas/1/1/000000001"
+      },
+      "idShort": "000000001",
+      "modelType": {
+        "name": "AssetAdministrationShell"
+      }
+    }
+  ],
+  "assets": [
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://admin-shell.hitachi-industrial.eu/asset/000000001"
+      },
+      "idShort": "Hitachi_000000001",
+      "modelType": {
+        "name": "Asset"
+      },
+      "kind": "Instance",
+      "descriptions": [
+        {
+          "language": "EN",
+          "text": "Hitachi HX PLC"
+        },
+        {
+          "language": "DE",
+          "text": "Hitachi HX SPS"
+        }
+      ]
+    }
+  ],
+  "submodels": [
+    {
+      "semanticId": {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "https://www.hsu-hh.de/aut/aas/nameplate",
+            "index": 0,
+            "idType": "IRI"
+          }
+        ],
+        "First": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "https://www.hsu-hh.de/aut/aas/nameplate",
+          "index": 0,
+          "idType": "IRI"
+        },
+        "Last": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "https://www.hsu-hh.de/aut/aas/nameplate",
+          "index": 0,
+          "idType": "IRI"
+        }
+      },
+      "qualifiers": [],
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/sm/4343_5072_7091_3242"
+      },
+      "idShort": "Nameplate",
+      "modelType": {
+        "name": "Submodel"
+      },
+      "kind": "Instance",
+      "submodelElements": [
+        {
+          "value": "Hitachi Industrial Equipment Systems Co.,Ltd.",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAO677#002",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO677#002",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO677#002",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "ManufacturerName",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "HX-CP1H16",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAW338#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAW338#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAW338#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "ManufacturerProductDesignation",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "ordered": false,
+          "allowDuplicates": false,
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/physicaladdress",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/physicaladdress",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/physicaladdress",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "PhysicalAddress",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "SubmodelElementCollection"
+          },
+          "value": [
+            {
+              "value": "JP",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAO730#001",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO730#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO730#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "CountryCode",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "AKS Bldg, 3 Kanda Neribei-cho",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAO128#001",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO128#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO128#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "Street",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "101-0022",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAO129#002",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO129#002",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO129#002",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "Zip",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Chiyoda-ku, Tokyo",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAO132#001",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO132#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO132#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "CityTown",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Tokyo",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAO133#002",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO133#002",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO133#002",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "StateCounty",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            }
+          ],
+          "kind": "Instance"
+        },
+        {
+          "value": "PAC IoT Controller HX Series",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAU731#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAU731#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAU731#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "ManufacturerProductFamily",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": ""
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "HX-CP1H16",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAM556#002",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAM556#002",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAM556#002",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "SerialNumber",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "N/A",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAQ196#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAQ196#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAQ196#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "BatchNumber",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "JP",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAO841#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO841#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO841#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "ProductCountryOfOrigin",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "2018",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAP906#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAP906#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAP906#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "YearOfConstruction",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "integer"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "ordered": false,
+          "allowDuplicates": false,
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/productmarking",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/productmarking",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/productmarking",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "Marking_CE",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "SubmodelElementCollection"
+          },
+          "value": [
+            {
+              "value": "1",
+              "valueId": {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "0173-1#07-CAA016#001",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "0173-1#07-CAA016#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "0173-1#07-CAA016#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-BAF053#008",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-BAF053#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-BAF053#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "CEQualificationPresent",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "boolean"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "mimeType": "image/png",
+              "value": "/aasx/Nameplate/marking_ce.png",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAD005#008",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "File",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "File"
+              },
+              "kind": "Instance"
+            }
+          ],
+          "kind": "Instance"
+        },
+        {
+          "ordered": false,
+          "allowDuplicates": false,
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/productmarking",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/productmarking",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/productmarking",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "Marking_CRUUS",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "SubmodelElementCollection"
+          },
+          "value": [
+            {
+              "value": "1",
+              "valueId": {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "local": false,
+                    "value": "0173-1#07-CAA016#001",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "0173-1#07-CAA016#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "GlobalReference",
+                  "local": false,
+                  "value": "0173-1#07-CAA016#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAR528#005",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAR528#005",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAR528#005",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "CRUUSLabelingPresent",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "boolean"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "mimeType": "image/png",
+              "value": "/aasx/Nameplate/marking_cruus.jpg",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAD005#008",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "File",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "File"
+              },
+              "kind": "Instance"
+            }
+          ],
+          "kind": "Instance"
+        }
+      ]
+    },
+    {
+      "semanticId": {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "https://www.hsu-hh.de/aut/aas/document",
+            "index": 0,
+            "idType": "IRI"
+          }
+        ],
+        "First": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "https://www.hsu-hh.de/aut/aas/document",
+          "index": 0,
+          "idType": "IRI"
+        },
+        "Last": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "https://www.hsu-hh.de/aut/aas/document",
+          "index": 0,
+          "idType": "IRI"
+        }
+      },
+      "qualifiers": [],
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/sm/2543_5072_7091_2660"
+      },
+      "idShort": "Document",
+      "modelType": {
+        "name": "Submodel"
+      },
+      "kind": "Instance",
+      "submodelElements": [
+        {
+          "ordered": false,
+          "allowDuplicates": false,
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAD001#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "DeclarationCEMarking",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "SubmodelElementCollection"
+          },
+          "value": [
+            {
+              "value": "Single",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_DomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Primary",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_IdType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentDomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Responsible",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Role",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Hitachi",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Hitachi Industrial Equipment Systems Co.,Ltd.",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationOfficialName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Description",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden."
+                }
+              ]
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentPartId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "02-04",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentClassification_ClassId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "eindeutige ID der Klasse in einer Klassifikation"
+                }
+              ]
+            },
+            {
+              "value": "Zeugnisse, Zertifikate, Bescheinigungen",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ClassName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "VDI2770:2018",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "ClassificationSystem",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersionId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "en",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersion_LanguageCode",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "HX CE declaration",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Title",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Summary",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Keywords",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Released",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_StatusValue",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_SetDate",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Purpose",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_BasedOnProcedure",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Comments",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Product",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_Type",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_RefType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_ObjectId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "CE_DLR_EH-150_REV17.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "application/pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileFormat",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "mimeType": "application/pdf",
+              "value": "/aasx/Document/CE_DLR_EH-150_REV17.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAD005#008",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "File",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "File"
+              },
+              "kind": "Instance"
+            }
+          ],
+          "kind": "Instance"
+        },
+        {
+          "ordered": false,
+          "allowDuplicates": false,
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAD001#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "DeclarationRoHS",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "SubmodelElementCollection"
+          },
+          "value": [
+            {
+              "value": "Single",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_DomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Primary",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_IdType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentDomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Responsible",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Role",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Hitachi",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Hitachi Industrial Equipment Systems Co.,Ltd.",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationOfficialName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Description",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden."
+                }
+              ]
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentPartId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "02-04",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentClassification_ClassId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "eindeutige ID der Klasse in einer Klassifikation"
+                }
+              ]
+            },
+            {
+              "value": "Zeugnisse, Zertifikate, Bescheinigungen",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ClassName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "VDI2770:2018",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "ClassificationSystem",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersionId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "en",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersion_LanguageCode",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "RoHS 2011/65/EU Declaration of conformity",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Title",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Summary",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Keywords",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Released",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_StatusValue",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_SetDate",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Purpose",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_BasedOnProcedure",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Comments",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Product",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_Type",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_RefType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_ObjectId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "CE_DLR_EH-150_REV17.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "application/pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileFormat",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "mimeType": "application/pdf",
+              "value": "/aasx/Document/CE_DLR_EH-150_REV17.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAD005#008",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "File",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "File"
+              },
+              "kind": "Instance"
+            }
+          ],
+          "kind": "Instance"
+        },
+        {
+          "ordered": false,
+          "allowDuplicates": false,
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAD001#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "EN_Manual_Hitachi_HX_Hardware",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "SubmodelElementCollection"
+          },
+          "value": [
+            {
+              "value": "Single",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_DomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Primary",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_IdType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "NJI-637(X)",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentDomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Responsible",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Role",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Hitachi",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Hitachi Industrial Equipment Systems Co.,Ltd.",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationOfficialName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Description",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden."
+                }
+              ]
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentPartId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "03-02",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentClassification_ClassId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "eindeutige ID der Klasse in einer Klassifikation"
+                }
+              ]
+            },
+            {
+              "value": "Bedienung",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ClassName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "VDI2770:2018",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "ClassificationSystem",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "2016.11",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersionId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "en",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersion_LanguageCode",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "HX Series Application Manual (Hardware)",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Title",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "This application manual informs about the hardware of HX series which is a high-performance PAC system suitable for IoT. The contents relevant to programming has been separated as an application manual (software) and a command reference manual. ",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Summary",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Keywords",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Released",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_StatusValue",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_SetDate",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Purpose",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_BasedOnProcedure",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Comments",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Product",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_Type",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_RefType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_ObjectId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "NJI-637A(X)_HX-CPU_Hardware_Rev_01.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "application/pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileFormat",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "mimeType": "application/pdf",
+              "value": "/aasx/Document/NJI-637A(X)_HX-CPU_Hardware_Rev_01.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAD005#008",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "File",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "File"
+              },
+              "kind": "Instance"
+            }
+          ],
+          "kind": "Instance"
+        },
+        {
+          "ordered": false,
+          "allowDuplicates": false,
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAD001#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "EN_Manual_Hitachi_HX_Software",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "SubmodelElementCollection"
+          },
+          "value": [
+            {
+              "value": "Single",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_DomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Primary",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_IdType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "NJI-638(X)",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentDomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Responsible",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Role",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Hitachi",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Hitachi Industrial Equipment Systems Co.,Ltd.",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationOfficialName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Description",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden."
+                }
+              ]
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentPartId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "03-02",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentClassification_ClassId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "eindeutige ID der Klasse in einer Klassifikation"
+                }
+              ]
+            },
+            {
+              "value": "Bedienung",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ClassName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "VDI2770:2018",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "ClassificationSystem",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "2016.12 ",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersionId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "en",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersion_LanguageCode",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "HX Series Application Manual (Software) ",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Title",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "This application manual informs about the software of HX series which is a high-performance PAC system suitable for IoT. The contents relevant to installation has been separated as an hardware manual.",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Summary",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Keywords",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Released",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_StatusValue",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_SetDate",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Purpose",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_BasedOnProcedure",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Comments",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Product",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_Type",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_RefType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_ObjectId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "NJI-638X_HX-CPU_Software.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "application/pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileFormat",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "mimeType": "application/pdf",
+              "value": "/aasx/Document/NJI-638X_HX-CPU_Software.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAD005#008",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "File",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "File"
+              },
+              "kind": "Instance"
+            }
+          ],
+          "kind": "Instance"
+        },
+        {
+          "ordered": false,
+          "allowDuplicates": false,
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAD001#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "DE_CODESYS_V3_Installation_und_Erste_Schritte ",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "SubmodelElementCollection"
+          },
+          "value": [
+            {
+              "value": "Single",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_DomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Primary",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_IdType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "0000000",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentDomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Responsible",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Role",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "3S-Smart Software Solutions GmbH ",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "3S-Smart Software Solutions GmbH ",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationOfficialName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Description",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden."
+                }
+              ]
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentPartId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "03-02",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentClassification_ClassId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "eindeutige ID der Klasse in einer Klassifikation"
+                }
+              ]
+            },
+            {
+              "value": "Bedienung",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ClassName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "VDI2770:2018",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "ClassificationSystem",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "20XX",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersionId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "de",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersion_LanguageCode",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "CODESYS V3, Installation und Erste Schritte - Anwenderdokumentation ",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Title",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Summary",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Keywords",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Released",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_StatusValue",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_SetDate",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Purpose",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_BasedOnProcedure",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Comments",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Product",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_Type",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_RefType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_ObjectId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "CODESYS_Installation_und_Erste_Schritte_20V11.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "application/pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileFormat",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "mimeType": "application/pdf",
+              "value": "/aasx/Document/CODESYS_Installation_und_Erste_Schritte_V11.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAD005#008",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "File",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "File"
+              },
+              "kind": "Instance"
+            }
+          ],
+          "kind": "Instance"
+        },
+        {
+          "ordered": false,
+          "allowDuplicates": false,
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAD001#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAD001#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "EN_Datasheet_IoT_PAC_Controller_HX_Series",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "SubmodelElementCollection"
+          },
+          "value": [
+            {
+              "value": "Single",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_DomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Primary",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_IdType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentDomainId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Responsible",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Role",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Hitachi",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Hitachi Europe GmbH",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_OrganisationOfficialName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "The new Hitachi HX series PAC Controller combines powerful features and efficiency to meet the demands of a global supply chain in manufacturing industries. In addition, HX series is already prepared for the next generation requirements in automation thanks to its IoT capabilities. Manufacturing & service innovations can be achieved with integrated functions and seamless connectivity from field machine level to cloud services. ",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Description",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden."
+                }
+              ]
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentPartId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "03-02",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentClassification_ClassId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance",
+              "descriptions": [
+                {
+                  "language": "DE",
+                  "text": "eindeutige ID der Klasse in einer Klassifikation"
+                }
+              ]
+            },
+            {
+              "value": "Bedienung",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ClassName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "VDI2770:2018",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "ClassificationSystem",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "1.10",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersionId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "en",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "DocumentVersion_LanguageCode",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Datasheet: IoT PAC Controller HX Series - Next generation industrial controller.",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Title",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Summary",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Keywords",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Released",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_StatusValue",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "2017.03",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_SetDate",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Purpose",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_BasedOnProcedure",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_Comments",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Product",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_Type",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_RefType",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_ReferencedObject_ObjectId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileId",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": ""
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "HX%20Datasheet.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileName",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "application/pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "VDI2770_FileFormat",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "mimeType": "application/pdf",
+              "value": "/aasx/Document/HX_Datasheet.pdf",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAD005#008",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAD005#008",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "File",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "File"
+              },
+              "kind": "Instance"
+            }
+          ],
+          "kind": "Instance"
+        }
+      ]
+    },
+    {
+      "semanticId": {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "https://www.hsu-hh.de/aut/aas/service",
+            "index": 0,
+            "idType": "IRI"
+          }
+        ],
+        "First": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "https://www.hsu-hh.de/aut/aas/service",
+          "index": 0,
+          "idType": "IRI"
+        },
+        "Last": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "https://www.hsu-hh.de/aut/aas/service",
+          "index": 0,
+          "idType": "IRI"
+        }
+      },
+      "qualifiers": [],
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/sm/6053_5072_7091_5102"
+      },
+      "idShort": "Service",
+      "modelType": {
+        "name": "Submodel"
+      },
+      "kind": "Instance",
+      "submodelElements": [
+        {
+          "ordered": false,
+          "allowDuplicates": false,
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/contactinfo",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/contactinfo",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/contactinfo",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "ContactInfo",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "SubmodelElementCollection"
+          },
+          "value": [
+            {
+              "value": "Hitachi Europe GmbH",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAO735#003",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO735#003",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO735#003",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "NameOfSupplier",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Sales organization",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "https://www.hsu-hh.de/aut/aas/role",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/role",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/role",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "ContactInfo_Role",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "ordered": false,
+              "allowDuplicates": false,
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "https://www.hsu-hh.de/aut/aas/physicaladdress",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/physicaladdress",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/physicaladdress",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "PhysicalAddress",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "SubmodelElementCollection"
+              },
+              "value": [
+                {
+                  "value": "DE",
+                  "semanticId": {
+                    "keys": [
+                      {
+                        "type": "ConceptDescription",
+                        "local": true,
+                        "value": "0173-1#02-AAO730#001",
+                        "index": 0,
+                        "idType": "IRDI"
+                      }
+                    ],
+                    "First": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO730#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    },
+                    "Last": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO730#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    }
+                  },
+                  "constraints": [],
+                  "idShort": "CountryCode",
+                  "category": "PARAMETER",
+                  "modelType": {
+                    "name": "Property"
+                  },
+                  "valueType": {
+                    "dataObjectType": {
+                      "name": "string"
+                    }
+                  },
+                  "kind": "Instance"
+                },
+                {
+                  "value": "Niederkasseler Lohweg 191",
+                  "semanticId": {
+                    "keys": [
+                      {
+                        "type": "ConceptDescription",
+                        "local": true,
+                        "value": "0173-1#02-AAO128#001",
+                        "index": 0,
+                        "idType": "IRDI"
+                      }
+                    ],
+                    "First": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO128#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    },
+                    "Last": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO128#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    }
+                  },
+                  "constraints": [],
+                  "idShort": "Street",
+                  "category": "PARAMETER",
+                  "modelType": {
+                    "name": "Property"
+                  },
+                  "valueType": {
+                    "dataObjectType": {
+                      "name": "string"
+                    }
+                  },
+                  "kind": "Instance"
+                },
+                {
+                  "value": "40547",
+                  "semanticId": {
+                    "keys": [
+                      {
+                        "type": "ConceptDescription",
+                        "local": true,
+                        "value": "0173-1#02-AAO129#002",
+                        "index": 0,
+                        "idType": "IRDI"
+                      }
+                    ],
+                    "First": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO129#002",
+                      "index": 0,
+                      "idType": "IRDI"
+                    },
+                    "Last": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO129#002",
+                      "index": 0,
+                      "idType": "IRDI"
+                    }
+                  },
+                  "constraints": [],
+                  "idShort": "Zip",
+                  "category": "PARAMETER",
+                  "modelType": {
+                    "name": "Property"
+                  },
+                  "valueType": {
+                    "dataObjectType": {
+                      "name": "string"
+                    }
+                  },
+                  "kind": "Instance"
+                },
+                {
+                  "value": "Düsseldorf",
+                  "semanticId": {
+                    "keys": [
+                      {
+                        "type": "ConceptDescription",
+                        "local": true,
+                        "value": "0173-1#02-AAO132#001",
+                        "index": 0,
+                        "idType": "IRDI"
+                      }
+                    ],
+                    "First": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO132#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    },
+                    "Last": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO132#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    }
+                  },
+                  "constraints": [],
+                  "idShort": "CityTown",
+                  "category": "PARAMETER",
+                  "modelType": {
+                    "name": "Property"
+                  },
+                  "valueType": {
+                    "dataObjectType": {
+                      "name": "string"
+                    }
+                  },
+                  "kind": "Instance"
+                },
+                {
+                  "value": "North Rhine-Westphalia",
+                  "semanticId": {
+                    "keys": [
+                      {
+                        "type": "ConceptDescription",
+                        "local": true,
+                        "value": "0173-1#02-AAO133#002",
+                        "index": 0,
+                        "idType": "IRDI"
+                      }
+                    ],
+                    "First": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO133#002",
+                      "index": 0,
+                      "idType": "IRDI"
+                    },
+                    "Last": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO133#002",
+                      "index": 0,
+                      "idType": "IRDI"
+                    }
+                  },
+                  "constraints": [],
+                  "idShort": "StateCounty",
+                  "category": "PARAMETER",
+                  "modelType": {
+                    "name": "Property"
+                  },
+                  "valueType": {
+                    "dataObjectType": {
+                      "name": "string"
+                    }
+                  },
+                  "kind": "Instance"
+                }
+              ],
+              "kind": "Instance"
+            },
+            {
+              "value": "automation.industrial@hitachi-eu.com",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "https://www.hsu-hh.de/aut/aas/email",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/email",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/email",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "Email",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "https://automation.hitachi-industrial.eu/",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAO694#001",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO694#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO694#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "URL",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "+49-211-5283-0",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAO136#002",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO136#002",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO136#002",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "PhoneNumber",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "+49-211-2049-049",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "https://www.hsu-hh.de/aut/aas/fax",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/fax",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/fax",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "Fax",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            }
+          ],
+          "kind": "Instance"
+        }
+      ]
+    },
+    {
+      "semanticId": {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "local": false,
+            "value": "https://www.hsu-hh.de/aut/aas/identification",
+            "index": 0,
+            "idType": "IRI"
+          }
+        ],
+        "First": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "https://www.hsu-hh.de/aut/aas/identification",
+          "index": 0,
+          "idType": "IRI"
+        },
+        "Last": {
+          "type": "GlobalReference",
+          "local": false,
+          "value": "https://www.hsu-hh.de/aut/aas/identification",
+          "index": 0,
+          "idType": "IRI"
+        }
+      },
+      "qualifiers": [],
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/sm/6563_5072_7091_4267"
+      },
+      "idShort": "Identification",
+      "modelType": {
+        "name": "Submodel"
+      },
+      "kind": "Instance",
+      "submodelElements": [
+        {
+          "value": "Hitachi Industrial Equipment Systems Co.,Ltd.",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAO677#002",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO677#002",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO677#002",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "ManufacturerName",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "N/A",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAY812#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAY812#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAY812#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "GLNOfManufacturer",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "N/A",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAP796#004",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAP796#004",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAP796#004",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "SupplierOfTheIdentifier",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": ""
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "1696-0702",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAO676#003",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO676#003",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO676#003",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "MAN_PROD_NUM",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": ""
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "HX-CP1H16",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAW338#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAW338#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAW338#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "ManufacturerProductDesignation",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "PLC Based PAC System for IoT Applications",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAU734#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAU734#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAU734#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "ManufacturerProductDescription",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "langString"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "Hitachi Europe GmbH",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAO735#003",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO735#003",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO735#003",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "NameOfSupplier",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "N/A",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAY813#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAY813#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAY813#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "GLNOfSupplier",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "316033943",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/supplieridprovider",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/supplieridprovider",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/supplieridprovider",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "SupplierIdProvider",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": ""
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "1696-0702",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAO736#004",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO736#004",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO736#004",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "SUP_PROD_NUM",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": ""
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "HX-CP1H16",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAM551#002",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAM551#002",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAM551#002",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "SupplierProductDesignation",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "Programmable automation controller (PAC) System for IoT Applications",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAU730#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAU730#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAU730#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "SupplierProductDescription",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "langString"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "PAC IoT Controller HX Series",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAU731#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAU731#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAU731#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "ManufacturerProductFamily",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "eclass",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAO715#002",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO715#002",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO715#002",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "ClassificationSystem",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/secondarykeytyp",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/secondarykeytyp",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/secondarykeytyp",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "SecondaryKeyTyp",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": ""
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "mimeType": "image/png",
+          "value": "/HX_200432.png",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/thumbnail",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/thumbnail",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/thumbnail",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "TypThumbnail",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "File"
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "https://automation.hitachi-industrial.eu/demo/asset/0000_0000_0000_0000_0000",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/assetid",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/assetid",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/assetid",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "AssetId",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "anyURI"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "1696-0702",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAM556#002",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAM556#002",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAM556#002",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "SerialNumber",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "string"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "N/A",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAQ196#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAQ196#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAQ196#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "BatchNumber",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": ""
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/secondarykeyinstance",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/secondarykeyinstance",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/secondarykeyinstance",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "SecondaryKeyInstance",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": ""
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "N/A",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAR972#002",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAR972#002",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAR972#002",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "DateOfManufacture",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "date"
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "N/A",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/devicerevision",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/devicerevision",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/devicerevision",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "DeviceRevision",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": ""
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "3.5.13.40",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/softwarerevision",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/softwarerevision",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/softwarerevision",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "SoftwareRevision",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": ""
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "N/A",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/hardwarerevision",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/hardwarerevision",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/hardwarerevision",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "HardwareRevision",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": ""
+            }
+          },
+          "kind": "Instance"
+        },
+        {
+          "ordered": false,
+          "allowDuplicates": false,
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/contactinfo",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/contactinfo",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/contactinfo",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "ContactInfo",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "SubmodelElementCollection"
+          },
+          "value": [
+            {
+              "value": "Hitachi Europe GmbH",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAO735#003",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO735#003",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO735#003",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "NameOfSupplier",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "Manufacturer",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "https://www.hsu-hh.de/aut/aas/role",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/role",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/role",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "ContactInfo_Role",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "ordered": false,
+              "allowDuplicates": false,
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "https://www.hsu-hh.de/aut/aas/physicaladdress",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/physicaladdress",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/physicaladdress",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "PhysicalAddress",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "SubmodelElementCollection"
+              },
+              "value": [
+                {
+                  "value": "DE",
+                  "semanticId": {
+                    "keys": [
+                      {
+                        "type": "ConceptDescription",
+                        "local": true,
+                        "value": "0173-1#02-AAO730#001",
+                        "index": 0,
+                        "idType": "IRDI"
+                      }
+                    ],
+                    "First": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO730#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    },
+                    "Last": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO730#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    }
+                  },
+                  "constraints": [],
+                  "idShort": "CountryCode",
+                  "category": "PARAMETER",
+                  "modelType": {
+                    "name": "Property"
+                  },
+                  "valueType": {
+                    "dataObjectType": {
+                      "name": "string"
+                    }
+                  },
+                  "kind": "Instance"
+                },
+                {
+                  "value": "Niederkasseler Lohweg 191",
+                  "semanticId": {
+                    "keys": [
+                      {
+                        "type": "ConceptDescription",
+                        "local": true,
+                        "value": "0173-1#02-AAO128#001",
+                        "index": 0,
+                        "idType": "IRDI"
+                      }
+                    ],
+                    "First": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO128#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    },
+                    "Last": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO128#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    }
+                  },
+                  "constraints": [],
+                  "idShort": "Street",
+                  "category": "PARAMETER",
+                  "modelType": {
+                    "name": "Property"
+                  },
+                  "valueType": {
+                    "dataObjectType": {
+                      "name": "langString"
+                    }
+                  },
+                  "kind": "Instance"
+                },
+                {
+                  "value": "40547",
+                  "semanticId": {
+                    "keys": [
+                      {
+                        "type": "ConceptDescription",
+                        "local": true,
+                        "value": "0173-1#02-AAO129#002",
+                        "index": 0,
+                        "idType": "IRDI"
+                      }
+                    ],
+                    "First": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO129#002",
+                      "index": 0,
+                      "idType": "IRDI"
+                    },
+                    "Last": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO129#002",
+                      "index": 0,
+                      "idType": "IRDI"
+                    }
+                  },
+                  "constraints": [],
+                  "idShort": "Zip",
+                  "category": "PARAMETER",
+                  "modelType": {
+                    "name": "Property"
+                  },
+                  "valueType": {
+                    "dataObjectType": {
+                      "name": "string"
+                    }
+                  },
+                  "kind": "Instance"
+                },
+                {
+                  "value": "Düsseldorf",
+                  "semanticId": {
+                    "keys": [
+                      {
+                        "type": "ConceptDescription",
+                        "local": true,
+                        "value": "0173-1#02-AAO132#001",
+                        "index": 0,
+                        "idType": "IRDI"
+                      }
+                    ],
+                    "First": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO132#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    },
+                    "Last": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO132#001",
+                      "index": 0,
+                      "idType": "IRDI"
+                    }
+                  },
+                  "constraints": [],
+                  "idShort": "CityTown",
+                  "category": "PARAMETER",
+                  "modelType": {
+                    "name": "Property"
+                  },
+                  "valueType": {
+                    "dataObjectType": {
+                      "name": "string"
+                    }
+                  },
+                  "kind": "Instance"
+                },
+                {
+                  "value": "North Rhine-Westphalia",
+                  "semanticId": {
+                    "keys": [
+                      {
+                        "type": "ConceptDescription",
+                        "local": true,
+                        "value": "0173-1#02-AAO133#002",
+                        "index": 0,
+                        "idType": "IRDI"
+                      }
+                    ],
+                    "First": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO133#002",
+                      "index": 0,
+                      "idType": "IRDI"
+                    },
+                    "Last": {
+                      "type": "ConceptDescription",
+                      "local": true,
+                      "value": "0173-1#02-AAO133#002",
+                      "index": 0,
+                      "idType": "IRDI"
+                    }
+                  },
+                  "constraints": [],
+                  "idShort": "StateCounty",
+                  "category": "PARAMETER",
+                  "modelType": {
+                    "name": "Property"
+                  },
+                  "valueType": {
+                    "dataObjectType": {
+                      "name": "string"
+                    }
+                  },
+                  "kind": "Instance"
+                }
+              ],
+              "kind": "Instance"
+            },
+            {
+              "value": "automation.industrial@hitachi-eu.com",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "https://www.hsu-hh.de/aut/aas/email",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/email",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/email",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "Email",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "https://automation.hitachi-industrial.eu/",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAO694#001",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO694#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO694#001",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "URL",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "anyURI"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "+49-211-5283-0",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "0173-1#02-AAO136#002",
+                    "index": 0,
+                    "idType": "IRDI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO136#002",
+                  "index": 0,
+                  "idType": "IRDI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "0173-1#02-AAO136#002",
+                  "index": 0,
+                  "idType": "IRDI"
+                }
+              },
+              "constraints": [],
+              "idShort": "PhoneNumber",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            },
+            {
+              "value": "+49-211-2049-049",
+              "semanticId": {
+                "keys": [
+                  {
+                    "type": "ConceptDescription",
+                    "local": true,
+                    "value": "https://www.hsu-hh.de/aut/aas/fax",
+                    "index": 0,
+                    "idType": "IRI"
+                  }
+                ],
+                "First": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/fax",
+                  "index": 0,
+                  "idType": "IRI"
+                },
+                "Last": {
+                  "type": "ConceptDescription",
+                  "local": true,
+                  "value": "https://www.hsu-hh.de/aut/aas/fax",
+                  "index": 0,
+                  "idType": "IRI"
+                }
+              },
+              "constraints": [],
+              "idShort": "Fax",
+              "category": "PARAMETER",
+              "modelType": {
+                "name": "Property"
+              },
+              "valueType": {
+                "dataObjectType": {
+                  "name": "string"
+                }
+              },
+              "kind": "Instance"
+            }
+          ],
+          "kind": "Instance"
+        },
+        {
+          "mimeType": "image/png",
+          "value": "/aasx/assetIdentification/Hitachi_logo.png",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "https://www.hsu-hh.de/aut/aas/companylogo",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/companylogo",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "https://www.hsu-hh.de/aut/aas/companylogo",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "CompanyLogo",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "File"
+          },
+          "kind": "Instance"
+        },
+        {
+          "value": "https://automation.hitachi-industrial.eu/demo/0000_0000_0000_0000_0000",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": true,
+                "value": "0173-1#02-AAO694#001",
+                "index": 0,
+                "idType": "IRDI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO694#001",
+              "index": 0,
+              "idType": "IRDI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO694#001",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          },
+          "constraints": [],
+          "idShort": "URL",
+          "category": "PARAMETER",
+          "modelType": {
+            "name": "Property"
+          },
+          "valueType": {
+            "dataObjectType": {
+              "name": "anyURI"
+            }
+          },
+          "kind": "Instance"
+        }
+      ]
+    },
+    {
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Submodel",
+            "local": false,
+            "value": "https://automation.hitachi-industrial.eu/en/products/software/configuration-files/device-descriptions",
+            "index": 0,
+            "idType": "IRI"
+          }
+        ],
+        "First": {
+          "type": "Submodel",
+          "local": false,
+          "value": "https://automation.hitachi-industrial.eu/en/products/software/configuration-files/device-descriptions",
+          "index": 0,
+          "idType": "IRI"
+        },
+        "Last": {
+          "type": "Submodel",
+          "local": false,
+          "value": "https://automation.hitachi-industrial.eu/en/products/software/configuration-files/device-descriptions",
+          "index": 0,
+          "idType": "IRI"
+        }
+      },
+      "qualifiers": [],
+      "identification": {
+        "idType": "IRI",
+        "id": "https://automation.hitachi-industrial.eu/_Resources/Static/Packages/Moon.HitachiEurope/Downloads/automation/[2]%20Software/[5]%20Configuration%20Files/[1]%20Device%20Descriptions/Device%20files.zip"
+      },
+      "idShort": "DeviceDescriptionFiles",
+      "modelType": {
+        "name": "Submodel"
+      },
+      "kind": "Instance",
+      "submodelElements": [
+        {
+          "mimeType": "application/general",
+          "value": "/aasx/Document/Device_files.zip",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "ConceptDescription",
+                "local": false,
+                "value": "http://admin-shell.io/sample/conceptdescriptions/437857438753457473",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "ConceptDescription",
+              "local": false,
+              "value": "http://admin-shell.io/sample/conceptdescriptions/437857438753457473",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "ConceptDescription",
+              "local": false,
+              "value": "http://admin-shell.io/sample/conceptdescriptions/437857438753457473",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "constraints": [],
+          "idShort": "CodeSysDD",
+          "modelType": {
+            "name": "File"
+          },
+          "kind": "Instance"
+        }
+      ]
+    }
+  ],
+  "conceptDescriptions": [
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO677#002"
+      },
+      "idShort": "ManufacturerName",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Herstellername"
+              },
+              {
+                "language": "EN",
+                "text": "Manufacturer Name"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Manufacturer Name"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist"
+              },
+              {
+                "language": "EN",
+                "text": "legally valid designation of the natural or judicial person which is directly responsible for the design, production, packaging and labeling of a product in respect to its being brought into circulation"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAY812#001"
+      },
+      "idShort": "GLNOfManufacturer",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "GLN of manufacturer"
+              },
+              {
+                "language": "DE",
+                "text": "GLN des Herstellers"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "GLN of manufacturer"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "international eindeutige Nummer für den Geräte- oder Produkthersteller sowie für den Standort"
+              },
+              {
+                "language": "EN",
+                "text": "internationally unique identification number for the manufacturer of the device or the product and for the physical location"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAP796#004"
+      },
+      "idShort": "SupplierOfTheIdentifier",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Supplier of the identifier"
+              },
+              {
+                "language": "DE",
+                "text": "Anbieter der Identifikationsnummer für Hersteller"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Supplier of the identifier"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING_TRANSLATABLE",
+            "definition": [
+              {
+                "language": "EN",
+                "text": "DUNS-no., supplier number, or other number as identifier of an offeror or supplier of the identification"
+              },
+              {
+                "language": "DE",
+                "text": "DUNS-Nr., Lieferantennummer oder andere Nummer zur Identifikation eines Anbieters bzw. Lieferanten der Identifikationsnummer"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO676#003"
+      },
+      "idShort": "MAN_PROD_NUM",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "product article number of manufacturer"
+              },
+              {
+                "language": "DE",
+                "text": "Herstellerartikelnummer"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "MAN_PROD_NUM"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING_TRANSLATABLE",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "eindeutiger Bestellschlüssel des Herstellers"
+              },
+              {
+                "language": "EN",
+                "text": "unique product identifier of the manufacturer"
+              }
+            ]
+          }
+        }
+      ],
+      "descriptions": [
+        {
+          "language": "EN",
+          "text": "product article number of manufacturer"
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAW338#001"
+      },
+      "idShort": "ManufacturerProductDesignation",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Manufacturer product designation"
+              },
+              {
+                "language": "DE",
+                "text": "Herstellerproduktbezeichnung"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "ManufacturerTypName"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING_TRANSLATABLE",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Kurze Beschreibung des Produktes (Kurztext)"
+              },
+              {
+                "language": "EN",
+                "text": "Short description of the product (short text)"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAU734#001"
+      },
+      "idShort": "ManufacturerProductDescription",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Manufacturer product description"
+              },
+              {
+                "language": "DE",
+                "text": "Herstellerproduktbeschreibung"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Manufacturer product description"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Beschreibung des Produktes, seiner technischen Eigenschaften und ggf. seiner Anwendung (Langtext)"
+              },
+              {
+                "language": "EN",
+                "text": "Description of the product, it's technical features and implementation if needed (long text)"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO735#003"
+      },
+      "administration": {
+        "version": "",
+        "revision": ""
+      },
+      "idShort": "NameOfSupplier",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "name of supplier"
+              },
+              {
+                "language": "DE",
+                "text": "Lieferantenname"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "name of supplier"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Name des Lieferanten, welcher dem Kunden ein Produkt oder eine Dienstleistung bereitstellt"
+              },
+              {
+                "language": "EN",
+                "text": "name of supplier which provides the customer with a product or a service"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAY813#001"
+      },
+      "idShort": "GLNOfSupplier",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "GLN of supplier"
+              },
+              {
+                "language": "DE",
+                "text": "GLN des Lieferanten"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "GLN of supplier"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "international eindeutige Nummer für den Geräte- oder Produktlieferanten sowie für den Standort"
+              },
+              {
+                "language": "EN",
+                "text": "internationally unique identification number for the supplier of the device or the product and for the physical location"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/supplieridprovider"
+      },
+      "idShort": "SupplierIdProvider",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "SupplierIdProvider"
+              },
+              {
+                "language": "DE",
+                "text": "Anbieter der Identifikationsnummer"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "SupplierIdProvider"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING_TRANSLATABLE",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "DUNS-Nr., Lieferantennummer oder andere Nummer zur Identifikation eines Anbieters bzw. Lieferanten der Identifikationsnummer"
+              },
+              {
+                "language": "EN",
+                "text": "DUNS-no., supplier number, or other number as identifier of an offeror or supplier of the identification"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO736#004"
+      },
+      "idShort": "SUP_PROD_NUM",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "product article number of supplier"
+              },
+              {
+                "language": "DE",
+                "text": "Lieferantenartikelnummer"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "product article number of supplier"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "eindeutiger Bestellschlüssel des Lieferanten"
+              },
+              {
+                "language": "EN",
+                "text": "unique product order identifier of the supplier"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAM551#002"
+      },
+      "idShort": "SupplierProductDesignation",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Supplier product designation"
+              },
+              {
+                "language": "DE",
+                "text": "Lieferantenproduktbezeichnung"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "SupplierTypName"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING_TRANSLATABLE",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Kurze Beschreibung des Produktes (Kurztext)"
+              },
+              {
+                "language": "EN",
+                "text": "Short description of the product (short text)"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAU730#001"
+      },
+      "idShort": "SupplierProductDescription",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Supplier product description"
+              },
+              {
+                "language": "DE",
+                "text": "Lieferantenproduktbeschreibung"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Supplier product description"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Beschreibung des Produktes, seiner technischen Eigenschaften und ggf. seiner Anwendung (Langtext)"
+              },
+              {
+                "language": "EN",
+                "text": "Description of the product, it's technical features and implementation if needed (long text)"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAU731#001"
+      },
+      "idShort": "ManufacturerProductFamily",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Manufacturer product family"
+              },
+              {
+                "language": "DE",
+                "text": "Herstellerproduktfamilie"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "TypClass"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "2. Ebene einer 3 stufigen herstellerspezifischen Produkthierarchie"
+              },
+              {
+                "language": "EN",
+                "text": "2nd level of a 3 level manufacturer specific product hierarchy"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO715#002"
+      },
+      "idShort": "ClassificationSystem",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "classification system"
+              },
+              {
+                "language": "DE",
+                "text": "Klassifizierungssystem"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "ClassificationSystem"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Klassifizierungssystem"
+              },
+              {
+                "language": "EN",
+                "text": "Classification System"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/secondarykeytyp"
+      },
+      "idShort": "SecondaryKeyTyp",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "SecondaryKeyTyp"
+              },
+              {
+                "language": "DE",
+                "text": "Typnummer des IT Systems"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "SecondaryKeyTyp"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Führende technische ID im IT System des Typs"
+              },
+              {
+                "language": "EN",
+                "text": "SecondaryKeyTyp"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/thumbnail"
+      },
+      "idShort": "TypThumbnail",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "TypThumbnail"
+              },
+              {
+                "language": "DE",
+                "text": "Vorschaubild"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "TypThumbnail"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Darstellung des Produkttyps in kleinem Format"
+              },
+              {
+                "language": "EN",
+                "text": "Small picture of the product type"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/assetid"
+      },
+      "idShort": "AssetId",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "AssetId"
+              },
+              {
+                "language": "DE",
+                "text": "Asset ID"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "AssetId"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Global eindeutige ID eines Asset, die machienenlesbar oder durch Menschen lesbar ist."
+              },
+              {
+                "language": "EN",
+                "text": "Global unique ID of an asset, which can be read by both human and machine."
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAM556#002"
+      },
+      "idShort": "SerialNumber",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Serial number"
+              },
+              {
+                "language": "DE",
+                "text": "Seriennummer"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "InstanceId"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "eindeutige Zahlen- und Buchstabenkombination mit der das Gerät nach seiner Herstellung identifiziert ist"
+              },
+              {
+                "language": "EN",
+                "text": "unique combination of numbers and letters used to identify the device once it has been manufactured"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAQ196#001"
+      },
+      "idShort": "BatchNumber",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Batch number"
+              },
+              {
+                "language": "DE",
+                "text": "Chargen-Nummer"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "ChargeId"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Eine vom Hersteller eines Stoffes vergebene Nummer zur Identifikation einer Charge"
+              },
+              {
+                "language": "EN",
+                "text": "Number assigned by the manufacturer of a material to identify the manufacturer's batch"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/secondarykeyinstance"
+      },
+      "idShort": "SecondaryKeyInstance",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "SecondaryKeyInstance"
+              },
+              {
+                "language": "DE",
+                "text": "Instanznummer des IT Systems"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "SecondaryKeyInstance"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Führende technische ID im IT System der Instanz"
+              },
+              {
+                "language": "EN",
+                "text": "SecondaryKeyInstance"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAR972#002"
+      },
+      "idShort": "DateOfManufacture",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Date of manufacture"
+              },
+              {
+                "language": "DE",
+                "text": "Herstellungsdatum"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Date of manufacture"
+              }
+            ],
+            "unit": "",
+            "dataType": "DATE",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Datum, ab der der Herstellungs- und/oder Entstehungsprozess abgeschlossen ist bzw. ab dem eine Dienstleistung vollständig erbracht ist"
+              },
+              {
+                "language": "EN",
+                "text": "Date from which the production and / or development process is completed or from which a service is provided completely"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/devicerevision"
+      },
+      "idShort": "DeviceRevision",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "DeviceRevision"
+              },
+              {
+                "language": "DE",
+                "text": "DeviceRevision"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DeviceRevision"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "DeviceRevision"
+              },
+              {
+                "language": "EN",
+                "text": "DeviceRevision"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/softwarerevision"
+      },
+      "idShort": "SoftwareRevision",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "SoftwareRevision"
+              },
+              {
+                "language": "EN",
+                "text": "SoftwareRevision"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "SoftwareRevision"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "SoftwareRevision"
+              },
+              {
+                "language": "EN",
+                "text": "SoftwareRevision"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/hardwarerevision"
+      },
+      "idShort": "HardwareRevision",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "HardwareRevision"
+              },
+              {
+                "language": "EN",
+                "text": "HardwareRevision"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "HardwareRevision"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "HardwareRevision"
+              },
+              {
+                "language": "EN",
+                "text": "HardwareRevision"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/qrcode"
+      },
+      "idShort": "QrCode",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "QrCode"
+              },
+              {
+                "language": "EN",
+                "text": "QrCode"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "QrCode"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "In dem QRCode ist die URL, die die Instanz des Assets genau beschreibt, hinterlegt."
+              },
+              {
+                "language": "EN",
+                "text": "QrCode"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/contactinfo"
+      },
+      "idShort": "OrganisationContactInfo",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Contact Info"
+              },
+              {
+                "language": "DE",
+                "text": "Kontakt Info"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "OrganisationContactInfo"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Sammlung für die allgemeinen Kontaktdaten"
+              },
+              {
+                "language": "EN",
+                "text": "Collection for general contact data"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/physicaladdress"
+      },
+      "idShort": "PhysicalAddress",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "PhysicalAddress"
+              },
+              {
+                "language": "DE",
+                "text": "Physische Adresse"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "PhysicalAddress"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Sammlung für reale physische Adresse"
+              },
+              {
+                "language": "EN",
+                "text": "Collection for real physical address"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO730#001"
+      },
+      "administration": {
+        "version": "",
+        "revision": ""
+      },
+      "idShort": "CountryCode",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Landeskennung"
+              },
+              {
+                "language": "EN",
+                "text": "Country code"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Country code"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Vereinbartes Merkmal zur eindeutigen Identifizierung eines Landes"
+              },
+              {
+                "language": "EN",
+                "text": "agreed upon symbol for unambiguous identification of a country"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO128#001"
+      },
+      "idShort": "Street",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Strasse"
+              },
+              {
+                "language": "EN",
+                "text": "Street"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Street"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Name der Strasse und Hausnummer"
+              },
+              {
+                "language": "EN",
+                "text": "Street name and house number"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO129#002"
+      },
+      "idShort": "Zip",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Zip"
+              },
+              {
+                "language": "DE",
+                "text": "Postleitzahl"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "PostalCode"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "EN",
+                "text": "ZIP code of address"
+              },
+              {
+                "language": "DE",
+                "text": "Postleitzahl der Anschrift"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO132#001"
+      },
+      "idShort": "CityTown",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Ort"
+              },
+              {
+                "language": "EN",
+                "text": "City/town"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "City/town"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "EN",
+                "text": "Town or city of the company"
+              },
+              {
+                "language": "DE",
+                "text": "Ortsangabe"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO133#002"
+      },
+      "idShort": "StateCounty",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "state/county"
+              },
+              {
+                "language": "DE",
+                "text": "Bundesland"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "StateCounty"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Bundesland"
+              },
+              {
+                "language": "EN",
+                "text": "state/county"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/email"
+      },
+      "idShort": "Email",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Emailadresse"
+              },
+              {
+                "language": "EN",
+                "text": "Email address"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Email"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Emailadresse"
+              },
+              {
+                "language": "EN",
+                "text": "Email address"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/ContactInfo/TelephoneContact"
+      },
+      "idShort": "TelephoneContact",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Telephone Contact"
+              },
+              {
+                "language": "DE",
+                "text": "Telefonkontakt"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "TelephoneContact"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Sammlung für Kontaktdaten über Telefon"
+              },
+              {
+                "language": "EN",
+                "text": "Collection for contact data via telephone"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO136#002"
+      },
+      "idShort": "PhoneNumber",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Telefonnummer"
+              },
+              {
+                "language": "EN",
+                "text": "telephone number"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Phone"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "vollständige Telefonnummer unter der ein Geschäftspartner erreichbar ist"
+              },
+              {
+                "language": "EN",
+                "text": "complete telephone number to be called to reach a business partner"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/companylogo"
+      },
+      "idShort": "CompanyLogo",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Firmenlogo"
+              },
+              {
+                "language": "EN",
+                "text": "CompanyLogo"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "CompanyLogo"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Firmenlogo"
+              },
+              {
+                "language": "EN",
+                "text": "CompanyLogo"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO694#001"
+      },
+      "idShort": "URL",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Internetadresse"
+              },
+              {
+                "language": "EN",
+                "text": "Internet address"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "URL"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "EN",
+                "text": "stated as link to a home page. The home page is the starting page or table of contents of a web site with offerings. It usually has the name index.htm or index.html"
+              },
+              {
+                "language": "DE",
+                "text": "Angabe als Link, um in eine Homepage zu gelangen. die Homepage ist die Start- beziehungsweise die Inhaltsseite eines Web-Angebots. Meistens trägt sie den Namen index.htm oder index.html"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAO841#001"
+      },
+      "idShort": "ProductCountryOfOrigin",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Produkt Ursprungsland"
+              },
+              {
+                "language": "EN",
+                "text": "Product country of origin"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "CountryOfOrigin"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Land in dem das Produkt hergestellt wurde (Hersteller Land)"
+              },
+              {
+                "language": "EN",
+                "text": "Country in which the product is manufactured (manufacturer country)"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAP906#001"
+      },
+      "idShort": "YearOfConstruction",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "Year of construction"
+              },
+              {
+                "language": "DE",
+                "text": "Baujahr"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "YearOfConstruction"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Jahreszahl als Datumsangabe für die Fertigstellung des Objektes"
+              },
+              {
+                "language": "EN",
+                "text": "Year as completion date of object"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAD005#008"
+      },
+      "idShort": "File",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Enthaltene Doku. Datei"
+              },
+              {
+                "language": "EN",
+                "text": "Embedded Doc. file"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "File"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Verweis/ BLOB auf enthaltene Dokumentations-Datei."
+              },
+              {
+                "language": "EN",
+                "text": "Reference/ BLOB to embedded documentation file."
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/productmarking"
+      },
+      "idShort": "ProductMarking",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Produktkennzeichnung"
+              },
+              {
+                "language": "EN",
+                "text": "Product Marking"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "ProductMarking"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Sammlungsdatei für Produktkennzeichnung"
+              },
+              {
+                "language": "EN",
+                "text": "Collection file for product marking"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-BAF053#008"
+      },
+      "idShort": "CEQualificationPresent",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "CE-Kennzeichnung vorhanden"
+              },
+              {
+                "language": "EN",
+                "text": "CE- qualification present"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "CEMarkingPresent"
+              }
+            ],
+            "unit": "",
+            "dataType": "BOOLEAN",
+            "definition": [
+              {
+                "language": "EN",
+                "text": "whether CE- qualification is present"
+              },
+              {
+                "language": "DE",
+                "text": "Angabe, ob CE-Kennzeichnung vorhanden ist"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAR528#005"
+      },
+      "idShort": "CRUUSLabelingPresent",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Kennzeichnung (RCM) vorhanden"
+              },
+              {
+                "language": "EN",
+                "text": "RCM labeling present"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "CRUUSLabelingPresent"
+              }
+            ],
+            "unit": "",
+            "dataType": "BOOLEAN",
+            "definition": [
+              {
+                "language": "EN",
+                "text": "indication whether the product is equipped with a specified RCM labeling"
+              },
+              {
+                "language": "DE",
+                "text": "Angabe, ob das Produkt mit einer spezifizierten RCM-Kennzeichnung ausgestattet ist"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId"
+      },
+      "idShort": "DocumentClassification_ClassId",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Dokumentkategorie"
+              },
+              {
+                "language": "EN",
+                "text": "Document category"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Dokumentkategorie nach VDI 2770:2018/10"
+              },
+              {
+                "language": "EN",
+                "text": "Document category after VDI 2770:2018/10"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId"
+      },
+      "idShort": "DocumentId",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "EN",
+                "text": "DocumentId"
+              },
+              {
+                "language": "DE",
+                "text": "Dokumenten-Nummer"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocumentId"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Die Dokument ID stellt eine eindeutige Identifizierung des Dokuments innerhalb einer Domäne sicher."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId"
+      },
+      "idShort": "VDI2770_DomainId",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Domain-Nummer"
+              },
+              {
+                "language": "EN",
+                "text": "DomainId"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DomainId"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Kennung oder Kennzeichen einer Domäne, in der eine DocumentId eineindeutig ist."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType"
+      },
+      "idShort": "VDI2770_IdType",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Nummerntyp"
+              },
+              {
+                "language": "EN",
+                "text": "IdType"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "IdType"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Besitzt ein Dokument mehrere Identifikationsnummern, muss mithilfe dieser Eigenschaft die führende ID angegeben werden. Der Wert „Primary“ ist für diese ID zu setzen."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/4490_8182_7091_6124"
+      },
+      "idShort": "ValString",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Wert"
+              },
+              {
+                "language": "EN",
+                "text": "Value String"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "ValString"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Ausdruck für den Wert der übergeordneten Collection."
+              },
+              {
+                "language": "EN",
+                "text": "Value string for the collection value on the next superordinate level"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRDI",
+        "id": "0173-1#02-AAD001#001"
+      },
+      "idShort": "DocumentationItem",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Dokumentationsgruppe"
+              },
+              {
+                "language": "EN",
+                "text": "Documentation item"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocumentationItem"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Gruppe von Merkmalen, die Zugriff gibt auf eine Dokumentation für ein Asset, beispielhaft struktuiert nach VDI 2770."
+              },
+              {
+                "language": "EN",
+                "text": "Collection of properties, which gives access to documentation of an asset, structured exemplary-wise according to VDI 2770."
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/6003_8182_7091_9350"
+      },
+      "idShort": "DocumentIdDomain",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "DocumentIdDomain"
+              },
+              {
+                "language": "EN",
+                "text": "DocumentIdDomain"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocumentIdDomain"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Angabe einer Liste von Domänen, in de-nen die DocumentIds des Dokuments eindeutig sind"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId"
+      },
+      "idShort": "DocumentDomainId",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "DocumentDomainId"
+              },
+              {
+                "language": "EN",
+                "text": "DocumentDomainId"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocumentDomainId"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Kennung oder Kennzeichen einer Domäne"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/3153_8182_7091_4327"
+      },
+      "idShort": "VDI2770_Party",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Party"
+              },
+              {
+                "language": "EN",
+                "text": "Party"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Party"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Verweis auf eine Party (siehe VDI 2770 Anhang C1.17), die für diese Domäne verantwortlich ist"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role"
+      },
+      "idShort": "VDI2770_Role",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Rolle"
+              },
+              {
+                "language": "EN",
+                "text": "Role"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Role"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Festlegung einer Rolle für die Organisation gemäß der folgenden Auswahlliste: Author (Autor), Customer (Kunde), Supplier (Zulieferer, Anbieter), Manufacturer (Hersteller), Responsible (Verantwortlicher)"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/9214_8182_7091_6391"
+      },
+      "idShort": "VDI2770_Organisation",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Organisation"
+              },
+              {
+                "language": "EN",
+                "text": "Organisation"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Organisation"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Angabe einer Organisation"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId"
+      },
+      "idShort": "VDI2770_OrganisationId",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Organisation ID"
+              },
+              {
+                "language": "EN",
+                "text": "Organisation ID"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "OrganisationId"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "eindeutige ID für die Organisation"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName"
+      },
+      "idShort": "VDI2770_OrganisationName",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "OrganisationName"
+              },
+              {
+                "language": "EN",
+                "text": "OrganisationName"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "OrganisationName"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "gebräuchliche Bezeichnung für die Organisation"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName"
+      },
+      "idShort": "VDI2770_OrganisationOfficialName",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Offizieller Name der Organisation"
+              },
+              {
+                "language": "EN",
+                "text": "Organisation Official Name"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "OrganisationOfficialName"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "offizieller Name der Organisation"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId"
+      },
+      "idShort": "DocumentPartId",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Dokumenten-Teilnummer"
+              },
+              {
+                "language": "EN",
+                "text": "DocumentPartId"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocumentPartId"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Ist das Dokument ein zusammengesetztes Dokument, können mithilfe dieser Eigenschaft eindeutige Dokumententeile IDs eingetragen werden, um das Dokument von den anderen Dokumenten zu unterscheiden."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/Description"
+      },
+      "idShort": "VDI2770_Description",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Beschreibung"
+              },
+              {
+                "language": "EN",
+                "text": "Description"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Description"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Beschreibung für die nächste übergeordnete Collection"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName"
+      },
+      "idShort": "VDI2770_ClassName",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Klassenname"
+              },
+              {
+                "language": "EN",
+                "text": "Class Name"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "ClassName"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Liste von sprachabhängigen Namen zur ClassId. Für die Klassennamen nach VDI 2770 müssen die Werte aus Tabelle 1 in Abschnitt 8.5 angewendet werden."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode"
+      },
+      "idShort": "DocumentVersion_LanguageCode",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Sprachenschlüssel"
+              },
+              {
+                "language": "EN",
+                "text": "LanguageCode"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "LanguageCode"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Angabe eines Sprachcodes gemäss ISO 639-1 oder -2"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem"
+      },
+      "idShort": "VDI2770_ClassificationSystem",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Klassifizierungssystem"
+              },
+              {
+                "language": "EN",
+                "text": "classification system"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "ClassificationSystem"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Eindeutige Kennung für ein Klassifikationssystem. Für Klassifikationen nach VDI 2770 muss „VDI2770:2018“ verwenden werden."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/2580_0282_7091_6213"
+      },
+      "idShort": "DocumentVersion",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Dokumenten-Version"
+              },
+              {
+                "language": "EN",
+                "text": "DocumentVersion"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocumentVersion"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Zu jedem Dokument muss eine Menge von mindestens einer Dokumentenversion existieren. Es können auch mehrere Dokumentenversionen ausgeliefert werden."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId"
+      },
+      "idShort": "DocumentVersionId",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Dokumenten-Versionsnummer"
+              },
+              {
+                "language": "EN",
+                "text": "DocumentVersionId"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocumentVersionId"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Identifikationsnummer zur Dokumenten-version. Verweist ein Document (siehe Anhang C1.1, Eigenschaft DocumentVersion) auf diese Dokumentenversion, muss die Kombination aus DocumentId und DocumentVersionId eindeutig sein."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/0231_0282_7091_5062"
+      },
+      "idShort": "VDI2770_Language",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Sprache"
+              },
+              {
+                "language": "EN",
+                "text": "Language"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Language"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Liste der im Dokument verwendeten Sprachen"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/9151_0282_7091_8032"
+      },
+      "idShort": "DocumentVersion_Description",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Beschreibung zur DocumentVersion"
+              },
+              {
+                "language": "EN",
+                "text": "DocumentVersion Description"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocumentVersion_Description"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Zusammenfassende Beschreibungen zur Dokumentenversion in ggf. unterschiedlichen Sprachen."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title"
+      },
+      "idShort": "VDI2770_Title",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Titel"
+              },
+              {
+                "language": "EN",
+                "text": "Title"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "VDI2770_Title"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "sprachabhängiger Titel des Dokuments"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary"
+      },
+      "idShort": "VDI2770_Summary",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Zusammenfassung"
+              },
+              {
+                "language": "EN",
+                "text": "Summary"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Summary"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "sprachabhängige, aussagekräftige Zusammenfassung des Dokumenteninhalts"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords"
+      },
+      "idShort": "VDI2770_Keywords",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Schlagwörter"
+              },
+              {
+                "language": "EN",
+                "text": "Keywords"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Keywords"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "sprachabhängige, durch Komma getrennte Liste von Schlagwörtern"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/0282_0282_7091_7878"
+      },
+      "idShort": "VDI2770_LifeCycleStatus",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Lebenszyklus Status"
+              },
+              {
+                "language": "EN",
+                "text": "LifeCycleStatus"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "LifeCycleStatus"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Liste von Statusdefinitionen mit Bezug zum Dokumentenlebenszyklus inklusive der Angabe der Beteiligten und einem zugehörigen Zeitstempel"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue"
+      },
+      "idShort": "VDI2770_StatusValue",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Statuswert"
+              },
+              {
+                "language": "EN",
+                "text": "StatusValue"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "StatusValue"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Jede Dokumentenversion stellt einen Zeitpunkt im Dokumentenlebenszyklus dar. Dieser Statuswert bezieht sich auf die Meilensteine im Dokumentenlebenszyklus. Für die Anwendung dieser Richtlinie sind die beiden folgenden Status zu verwenden. InReview (in Prüfung), Released (freigegeben)"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate"
+      },
+      "idShort": "VDI2770_SetDate",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Erstellungsdatum"
+              },
+              {
+                "language": "EN",
+                "text": "Set Date"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "SetDate"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Datum und Uhrzeit, an dem der Status festgelegt wurde Es muss das Datumsformat „YYYY-MM-dd“ verwendet werden (Y = Jahr, M = Monat, d = Tag, siehe DIN ISO 8601)."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose"
+      },
+      "idShort": "VDI2770_Purpose",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Zweck"
+              },
+              {
+                "language": "EN",
+                "text": "Purpose"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Purpose"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Hier kann ein Zweck zum Meilenstein angegeben werden, z. B. „zur Weiterleitung an den Kunden“."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure"
+      },
+      "idShort": "VDI2770_BasedOnProcedure",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Prozedur"
+              },
+              {
+                "language": "EN",
+                "text": "Procedure"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "BasedOnProcedure"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "textueller Bezug auf ein Verfahren, das der Festlegung dieses Status zugrunde liegt"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments"
+      },
+      "idShort": "VDI2770_Comments",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Kommentar"
+              },
+              {
+                "language": "EN",
+                "text": "Comments"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Comments"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "textuelle Bemerkungen und Anmerkungen zum Status"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/1204_0282_7091_7896"
+      },
+      "idShort": "DocumentRelationship",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Dokumenten-Beziehung"
+              },
+              {
+                "language": "EN",
+                "text": "Document Relationship"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocumentRelationship"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Liste von Beziehungen zu anderen Dokumenten. Es ist möglich, auf einen Dokument, ein Dokument in einer spezifischen Dokumentenversion oder auch ein Teildokument zu verweisen."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/5044_0282_7091_6924"
+      },
+      "idShort": "DocumentRelationship_Type",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Typ der Dokumenten-Beziehung"
+              },
+              {
+                "language": "EN",
+                "text": "DocumentRelationship_Type"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocumentRelationship_Type"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Typisierung der Beziehung zwischen den beiden DocumentVersions. Folgende Beziehungsarten können verwendet werden: Affecting (hat Auswirkungen auf), ReferesTo (bezieht sich auf), BasedOn (basiert auf)"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/3094_0282_7091_2090"
+      },
+      "idShort": "StoredDocumentRepresentation",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "StoredDocumentRepresentation"
+              },
+              {
+                "language": "EN",
+                "text": "StoredDocumentRepresentation"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "StoredDocumentRepresentation"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Liste von digitalen Repräsentationen zur DocumentVersion"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/2305_0282_7091_2077"
+      },
+      "idShort": "VDI2770_DigitalFile",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Digitaler-File"
+              },
+              {
+                "language": "EN",
+                "text": "DigitalFile"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DigitalFile"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Datei, die die DocumentVersion (siehe VDI 2770:2018 Anhang C1.5) repräsentiert Neben der obligatorischen PDF/A-Datei können weitere Dateien angegeben werden."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId"
+      },
+      "idShort": "VDI2770_FileId",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "ID der Datei"
+              },
+              {
+                "language": "EN",
+                "text": "File ID"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "FileId"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "eindeutige ID für die Datei"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName"
+      },
+      "idShort": "VDI2770_FileName",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Dateiname"
+              },
+              {
+                "language": "EN",
+                "text": "File name"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "FileName"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Name der Datei inkl. einer Dateiendung (sofern vorhanden) Es ist nicht notwendig, einen Pfad für die Datei anzugeben."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat"
+      },
+      "idShort": "VDI2770_FileFormat",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Datei Format"
+              },
+              {
+                "language": "EN",
+                "text": "File format"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "FileFormat"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Angabe eines Media Typs gemäß der Liste der IANA"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType"
+      },
+      "idShort": "DocumentType",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Dokumententyp"
+              },
+              {
+                "language": "EN",
+                "text": "Document Type"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocumentType"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Festlegung des Typs des Dokuments im Sinne der DIN EN 82045-1: a) Single (Einzeldokument) b) Aggregate (Sammeldokument) c) DocumentSet (Dokumentensatz) d) CompoundDoc (Mischdokument)"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/2570_2282_7091_0055"
+      },
+      "idShort": "VDI2770_ReferencedObject",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "ReferencedObject"
+              },
+              {
+                "language": "EN",
+                "text": "ReferencedObject"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "ReferencedObject"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Liste von IDs für ein Objekt, auf das sich das Dokument bezieht"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType"
+      },
+      "idShort": "VDI2770_ReferencedObject_Type",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Typ"
+              },
+              {
+                "language": "EN",
+                "text": "Type"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Type"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Für Type des Objekts muss immer Product angegeben werden."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType"
+      },
+      "idShort": "VDI2770_ReferencedObject_RefType",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "RefType"
+              },
+              {
+                "language": "EN",
+                "text": "RefType"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "RefType"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Angabe einer Typisierung zur Kennung des technischen Objekts. Folgende Werte sind möglich, ProductId (Produktnummer), SerialId (Seriennummer)"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId"
+      },
+      "idShort": "VDI2770_ReferencedObject_ObjectId",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "ObjectId"
+              },
+              {
+                "language": "EN",
+                "text": "ObjectId"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "ObjectId"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Angabe der Identifikationsnummer zum Objekt"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/role"
+      },
+      "idShort": "ContactInfo_Role",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Rolle"
+              },
+              {
+                "language": "EN",
+                "text": "Role"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Role"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Angabe zur Spezifizierung der Rolle, die die Organisation aus ContactInfo einnimmt"
+              },
+              {
+                "language": "EN",
+                "text": "Information to specify the role which the organisation of ContactInfo plays"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "https://www.hsu-hh.de/aut/aas/fax"
+      },
+      "idShort": "Fax",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "Fax"
+              },
+              {
+                "language": "EN",
+                "text": "Fax"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "Fax"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Faxnummer"
+              },
+              {
+                "language": "EN",
+                "text": "Fax number"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "0173-1#02-AAO136#002",
+              "index": 0,
+              "idType": "IRDI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "0173-1#02-AAO136#002",
+            "index": 0,
+            "idType": "IRDI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "0173-1#02-AAO136#002",
+            "index": 0,
+            "idType": "IRDI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/1420_0113_7091_0891"
+      },
+      "idShort": "DocGroup_01",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "01 Identifikation"
+              },
+              {
+                "language": "EN",
+                "text": "01 Identification"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocGroup_01"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Gruppe „Identifikation“ werden alle Dokumente zugeordnet, die der Identifikation des Objekts dienen, zu dem die Herstellerdokumentation gehört. Sie enthält insbesondere Informationen, die die elektronische Datenverarbeitung unterstützen und die es dem Hersteller und dem Nutzer erlauben, das Objekt in ihren jeweiligen elektronischen Datenverarbeitungssystemen zu identifizieren."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/4323_0113_7091_2591"
+      },
+      "idShort": "DocGroup_02",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "02 Technische Beschaffenheit"
+              },
+              {
+                "language": "EN",
+                "text": "02 Technical characteristics"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocGroup_02"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Die Gruppe „Technische Beschaffenheit“ beinhaltet alle Dokumente, die die technischen Anforderungen, deren Erfüllung und die Bescheinigung der Eigenschaften eines Objekts betreffen."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/5053_0113_7091_5741"
+      },
+      "idShort": "DocGroup_03",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "03 Tätigkeitsbezogene Dokumente"
+              },
+              {
+                "language": "EN",
+                "text": "03 Work-related documents"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocGroup_03"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Die Gruppe „Tätigkeitsbezogene Dokumente“ beinhaltet alle Dokumente, die Anforderungen, Hinweise und Hilfestellungen für Tätigkeiten an und mit dem Objekt nach der Übergabe an den Nutzer betreffen."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/5473_0113_7091_1588"
+      },
+      "idShort": "DocGroup_04",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "04 Vertragsunterlagen"
+              },
+              {
+                "language": "EN",
+                "text": "04 Contract documents"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocGroup_04"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Gruppe „Vertragsunterlagen“ werden alle Dokumente zugeordnet, die im Zusammenhang mit der kaufmännischen Abwicklung eines Vertrages stehen, aber nicht selbst Gegenstand des Vertrags sind und lediglich zur Erfüllung des Vertrags dienen."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/9593_0113_7091_2401"
+      },
+      "idShort": "DocCategory_01-01",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "01-01 Identifikation"
+              },
+              {
+                "language": "EN",
+                "text": "01-01 Identification"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_01-01"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Identifikation“ werden alle Dokumente zugeordnet, die der Identifikation des Objekts dienen, zu dem die Herstellerdokumentation gehört. Sie enthält insbesondere Informationen, die die elektronische Datenverarbeitung unterstützen und die es dem Hersteller und dem Nutzer erlauben, das Objekt in ihren jeweiligen elektronischen Datenverarbeitungssystemen zu identifizieren."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/5314_0113_7091_8640"
+      },
+      "idShort": "DocCategory_02-01",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "02-01 Techn. Spezifikation"
+              },
+              {
+                "language": "EN",
+                "text": "02-01 Technical specification"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_02-01"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Technische Spezifikation“ werden alle Dokumente zugeordnet, die die Anforderungen an ein Objekt sowie dessen Eigenschaften beschreiben. Dazu gehören die Auslegungsdaten, Berechnungen (Verfahrenstechnik, Festigkeit usw.) sowie alle relevanten Eigenschaften des übergebenen Objekts."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/5515_0113_7091_8581"
+      },
+      "idShort": "DocCategory_02-02",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "02-02 Zeichnungen, Pläne"
+              },
+              {
+                "language": "EN",
+                "text": "02-02 Drawings and diagrams"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_02-02"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Zeichnungen, Pläne“ werden alle Dokumente zugeordnet, die Zeichnungscharakter haben, das heißt eine grafische Darstellung zur Übermittlung von Information nutzen."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/0335_0113_7091_0312"
+      },
+      "idShort": "DocCategory_02-03",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "02-03 Bauteile"
+              },
+              {
+                "language": "EN",
+                "text": "02-03 Components"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_02-03"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Bauteile“ werden alle Dokumente zugeordnet, die eine strukturierte Auflistung der Teile eines Objekts beinhalten."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/2155_0113_7091_3955"
+      },
+      "idShort": "DocCategory_02-04",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "02-04 Zeugnisse, Zertifikate, Bescheinigungen"
+              },
+              {
+                "language": "EN",
+                "text": "02-04 Reports, Certificates, declarations"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_02-04"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Zeugnisse, Zertifikate, Bescheinigungen“ werden alle Dokumente zugeordnet, die Urkundencharakter haben."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/3565_0113_7091_2704"
+      },
+      "idShort": "DocCategory_03-01",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "03-01 Montage, Inbetriebnahme, Demontage"
+              },
+              {
+                "language": "EN",
+                "text": "03-01 Assembly, commissioning, disassembly"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_03-01"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Montage, Demontage“ werden alle Dokumente zugeordnet, die Tätigkeiten und Maßnahmen beschreiben, die erforderlich sind, um ein Objekt: zu transportieren oder zu lagern, als Ganzes in ein übergeordnetes Objekt einzubauen, auszubauen oder an dieses anzuschließen, so weit vorzubereiten, dass es zur Inbetriebnahme bereitsteht, nach Abschluss der Nutzungsphase zu demontieren und zu entsorgen"
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/4290_1113_7091_7266"
+      },
+      "idShort": "DocCategory_03-02",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "03-02 Bedienung"
+              },
+              {
+                "language": "EN",
+                "text": "03-02 Operation"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_03-02"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Bedienung“ werden Dokumente zur bestimmungsgemäßen Verwendung und sicheren Bedienung eines Objekts zugeordnet."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/2211_1113_7091_3911"
+      },
+      "idShort": "DocCategory_03-03",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "03-03 Allgemeine Sicherheit"
+              },
+              {
+                "language": "EN",
+                "text": "03-03 Safety in general"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_03-03"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Allgemeine Sicherheit“ werden Dokumente zugeordnet, die Sicherheitshinweise auf mögliche Gefährdungen bei der Verwendung des Objekts geben."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/7521_1113_7091_4471"
+      },
+      "idShort": "DocCategory_03-04",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "03-04 Inspektion, Wartung, Prüfung"
+              },
+              {
+                "language": "EN",
+                "text": "03-04 Inspection, maintenance, test"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_03-04"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Inspektion, Wartung, Prüfung“ werden alle Dokumente zugeordnet, die vom Hersteller vorgeschlagene wiederkehrende Maßnahmen zur Feststellung oder zum Erhalt des funktionsfähigen Zustands beschreiben."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/5161_1113_7091_0458"
+      },
+      "idShort": "DocCategory_03-05",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "03-05 Instandsetzung"
+              },
+              {
+                "language": "EN",
+                "text": "03-05 Repair"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_03-05"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Instandsetzung“ werden alle Dokumente zugeordnet, die Maßnahmen zur Wiederherstellung der Funktion eines Objekts betreffen."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/2181_1113_7091_5948"
+      },
+      "idShort": "DocCategory_03-06",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "03-06 Ersatzteile"
+              },
+              {
+                "language": "EN",
+                "text": "03-06 Spare parts"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_03-06"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Ersatzteile“ werden Dokumente zugeordnet, die Informationen zu Ersatzteilen und Hilfs- und Betriebsstoffen enthalten."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    },
+    {
+      "identification": {
+        "idType": "IRI",
+        "id": "www.company.com/ids/cd/5391_1113_7091_8996"
+      },
+      "idShort": "DocCategory_04-01",
+      "modelType": {
+        "name": "ConceptDescription"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecification": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "local": false,
+                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+                "index": 0,
+                "idType": "IRI"
+              }
+            ],
+            "First": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            },
+            "Last": {
+              "type": "GlobalReference",
+              "local": false,
+              "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0",
+              "index": 0,
+              "idType": "IRI"
+            }
+          },
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "DE",
+                "text": "04-01 Vertragsunterlagen"
+              },
+              {
+                "language": "EN",
+                "text": "04-01 Contract documents"
+              }
+            ],
+            "shortName": [
+              {
+                "language": "EN?",
+                "text": "DocCategory_04-01"
+              }
+            ],
+            "unit": "",
+            "dataType": "STRING",
+            "definition": [
+              {
+                "language": "DE",
+                "text": "Der Kategorie „Vertragsunterlagen“ werden alle Dokumente zugeordnet, die im Zusammenhang mit der kaufmännischen Abwicklung eines Vertrages stehen, aber nicht selbst Gegenstand des Vertrags sind und lediglich zur Erfüllung des Vertrags dienen."
+              },
+              {
+                "language": "EN",
+                "text": "TBD"
+              }
+            ]
+          }
+        }
+      ],
+      "isCaseOf": [
+        {
+          "keys": [
+            {
+              "type": "ConceptDescription",
+              "local": true,
+              "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+              "index": 0,
+              "idType": "IRI"
+            }
+          ],
+          "First": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          },
+          "Last": {
+            "type": "ConceptDescription",
+            "local": true,
+            "value": "http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId",
+            "index": 0,
+            "idType": "IRI"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/AasxToolkit.Tests/TestResources/AasxToolkit.Tests/sample.xml
+++ b/src/AasxToolkit.Tests/TestResources/AasxToolkit.Tests/sample.xml
@@ -1,0 +1,7185 @@
+<?xml version="1.0"?>
+<aas:aasenv xmlns:IEC="http://www.admin-shell.io/IEC61360/2/0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:abac="http://www.admin-shell.io/aas/abac/2/0" xsi:schemaLocation="http://www.admin-shell.io/aas/2/0 AAS.xsd http://www.admin-shell.io/IEC61360/2/0 IEC61360.xsd" xmlns:aas="http://www.admin-shell.io/aas/2/0">
+  <aas:assetAdministrationShells>
+    <aas:assetAdministrationShell>
+      <aas:idShort>000000001</aas:idShort>
+      <aas:identification idType="IRI">https://admin-shell.hitachi-industrial.eu/aas/1/1/000000001</aas:identification>
+      <aas:assetRef>
+        <aas:keys>
+          <aas:key type="Asset" local="true" idType="IRI">https://admin-shell.hitachi-industrial.eu/asset/000000001</aas:key>
+        </aas:keys>
+      </aas:assetRef>
+      <aas:submodelRefs>
+        <aas:submodelRef>
+          <aas:keys>
+            <aas:key type="Submodel" local="true" idType="IRI">www.company.com/ids/sm/4343_5072_7091_3242</aas:key>
+          </aas:keys>
+        </aas:submodelRef>
+        <aas:submodelRef>
+          <aas:keys>
+            <aas:key type="Submodel" local="true" idType="IRI">www.company.com/ids/sm/2543_5072_7091_2660</aas:key>
+          </aas:keys>
+        </aas:submodelRef>
+        <aas:submodelRef>
+          <aas:keys>
+            <aas:key type="Submodel" local="true" idType="IRI">www.company.com/ids/sm/6053_5072_7091_5102</aas:key>
+          </aas:keys>
+        </aas:submodelRef>
+        <aas:submodelRef>
+          <aas:keys>
+            <aas:key type="Submodel" local="true" idType="IRI">www.company.com/ids/sm/6563_5072_7091_4267</aas:key>
+          </aas:keys>
+        </aas:submodelRef>
+        <aas:submodelRef>
+          <aas:keys>
+            <aas:key type="Submodel" local="true" idType="IRI">https://automation.hitachi-industrial.eu/_Resources/Static/Packages/Moon.HitachiEurope/Downloads/automation/[2]%20Software/[5]%20Configuration%20Files/[1]%20Device%20Descriptions/Device%20files.zip</aas:key>
+          </aas:keys>
+        </aas:submodelRef>
+      </aas:submodelRefs>
+      <aas:conceptDictionaries />
+    </aas:assetAdministrationShell>
+  </aas:assetAdministrationShells>
+  <aas:assets>
+    <aas:asset>
+      <aas:idShort>Hitachi_000000001</aas:idShort>
+      <aas:description>
+        <aas:langString lang="EN">Hitachi HX PLC</aas:langString>
+        <aas:langString lang="DE">Hitachi HX SPS</aas:langString>
+      </aas:description>
+      <aas:identification idType="IRI">https://admin-shell.hitachi-industrial.eu/asset/000000001</aas:identification>
+      <aas:kind>Instance</aas:kind>
+    </aas:asset>
+  </aas:assets>
+  <aas:submodels>
+    <aas:submodel>
+      <aas:idShort>Nameplate</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/sm/4343_5072_7091_3242</aas:identification>
+      <aas:kind>Instance</aas:kind>
+      <aas:semanticId>
+        <aas:keys>
+          <aas:key type="GlobalReference" local="false" idType="IRI">https://www.hsu-hh.de/aut/aas/nameplate</aas:key>
+        </aas:keys>
+      </aas:semanticId>
+      <aas:qualifier />
+      <aas:submodelElements>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>ManufacturerName</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO677#002</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>Hitachi Industrial Equipment Systems Co.,Ltd.</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>ManufacturerProductDesignation</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAW338#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>HX-CP1H16</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:submodelElementCollection>
+            <aas:idShort>PhysicalAddress</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/physicaladdress</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:value>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>CountryCode</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO730#001</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>JP</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>Street</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO128#001</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>AKS Bldg, 3 Kanda Neribei-cho</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>Zip</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO129#002</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>101-0022</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>CityTown</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO132#001</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Chiyoda-ku, Tokyo</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>StateCounty</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO133#002</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Tokyo</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+            </aas:value>
+            <aas:ordered>false</aas:ordered>
+            <aas:allowDuplicates>false</aas:allowDuplicates>
+          </aas:submodelElementCollection>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>ManufacturerProductFamily</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAU731#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType />
+            <aas:value>PAC IoT Controller HX Series</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>SerialNumber</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAM556#002</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>HX-CP1H16</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>BatchNumber</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAQ196#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>N/A</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>ProductCountryOfOrigin</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO841#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>JP</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>YearOfConstruction</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAP906#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>integer</aas:valueType>
+            <aas:value>2018</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:submodelElementCollection>
+            <aas:idShort>Marking_CE</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/productmarking</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:value>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>CEQualificationPresent</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-BAF053#008</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>boolean</aas:valueType>
+                  <aas:value>1</aas:value>
+                  <aas:valueId>
+                    <aas:keys>
+                      <aas:key type="GlobalReference" local="false" idType="IRDI">0173-1#07-CAA016#001</aas:key>
+                    </aas:keys>
+                  </aas:valueId>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:file>
+                  <aas:idShort>File</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD005#008</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:mimeType>image/png</aas:mimeType>
+                  <aas:value>/aasx/Nameplate/marking_ce.png</aas:value>
+                </aas:file>
+              </aas:submodelElement>
+            </aas:value>
+            <aas:ordered>false</aas:ordered>
+            <aas:allowDuplicates>false</aas:allowDuplicates>
+          </aas:submodelElementCollection>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:submodelElementCollection>
+            <aas:idShort>Marking_CRUUS</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/productmarking</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:value>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>CRUUSLabelingPresent</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAR528#005</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>boolean</aas:valueType>
+                  <aas:value>1</aas:value>
+                  <aas:valueId>
+                    <aas:keys>
+                      <aas:key type="GlobalReference" local="false" idType="IRDI">0173-1#07-CAA016#001</aas:key>
+                    </aas:keys>
+                  </aas:valueId>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:file>
+                  <aas:idShort>File</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD005#008</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:mimeType>image/png</aas:mimeType>
+                  <aas:value>/aasx/Nameplate/marking_cruus.jpg</aas:value>
+                </aas:file>
+              </aas:submodelElement>
+            </aas:value>
+            <aas:ordered>false</aas:ordered>
+            <aas:allowDuplicates>false</aas:allowDuplicates>
+          </aas:submodelElementCollection>
+        </aas:submodelElement>
+      </aas:submodelElements>
+    </aas:submodel>
+    <aas:submodel>
+      <aas:idShort>Document</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/sm/2543_5072_7091_2660</aas:identification>
+      <aas:kind>Instance</aas:kind>
+      <aas:semanticId>
+        <aas:keys>
+          <aas:key type="GlobalReference" local="false" idType="IRI">https://www.hsu-hh.de/aut/aas/document</aas:key>
+        </aas:keys>
+      </aas:semanticId>
+      <aas:qualifier />
+      <aas:submodelElements>
+        <aas:submodelElement>
+          <aas:submodelElementCollection>
+            <aas:idShort>DeclarationCEMarking</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD001#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:value>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Single</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_DomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_IdType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Primary</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentDomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Role</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Responsible</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationOfficialName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi Industrial Equipment Systems Co.,Ltd.</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Description</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden.</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentPartId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentClassification_ClassId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">eindeutige ID der Klasse in einer Klassifikation</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>02-04</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ClassName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Zeugnisse, Zertifikate, Bescheinigungen</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>ClassificationSystem</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>VDI2770:2018</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersionId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersion_LanguageCode</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>en</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Title</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>HX CE declaration</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Summary</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Keywords</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_StatusValue</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Released</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_SetDate</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Purpose</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_BasedOnProcedure</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Comments</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_Type</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Product</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_RefType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_ObjectId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>CE_DLR_EH-150_REV17.pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileFormat</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>application/pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:file>
+                  <aas:idShort>File</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD005#008</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:mimeType>application/pdf</aas:mimeType>
+                  <aas:value>/aasx/Document/CE_DLR_EH-150_REV17.pdf</aas:value>
+                </aas:file>
+              </aas:submodelElement>
+            </aas:value>
+            <aas:ordered>false</aas:ordered>
+            <aas:allowDuplicates>false</aas:allowDuplicates>
+          </aas:submodelElementCollection>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:submodelElementCollection>
+            <aas:idShort>DeclarationRoHS</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD001#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:value>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Single</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_DomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_IdType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Primary</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentDomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Role</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Responsible</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationOfficialName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi Industrial Equipment Systems Co.,Ltd.</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Description</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden.</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentPartId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentClassification_ClassId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">eindeutige ID der Klasse in einer Klassifikation</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>02-04</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ClassName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Zeugnisse, Zertifikate, Bescheinigungen</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>ClassificationSystem</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>VDI2770:2018</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersionId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersion_LanguageCode</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>en</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Title</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>RoHS 2011/65/EU Declaration of conformity</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Summary</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Keywords</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_StatusValue</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Released</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_SetDate</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Purpose</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_BasedOnProcedure</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Comments</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_Type</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Product</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_RefType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_ObjectId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>CE_DLR_EH-150_REV17.pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileFormat</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>application/pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:file>
+                  <aas:idShort>File</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD005#008</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:mimeType>application/pdf</aas:mimeType>
+                  <aas:value>/aasx/Document/CE_DLR_EH-150_REV17.pdf</aas:value>
+                </aas:file>
+              </aas:submodelElement>
+            </aas:value>
+            <aas:ordered>false</aas:ordered>
+            <aas:allowDuplicates>false</aas:allowDuplicates>
+          </aas:submodelElementCollection>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:submodelElementCollection>
+            <aas:idShort>EN_Manual_Hitachi_HX_Hardware</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD001#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:value>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Single</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_DomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_IdType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Primary</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value>NJI-637(X)</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentDomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Role</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Responsible</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationOfficialName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi Industrial Equipment Systems Co.,Ltd.</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Description</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden.</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentPartId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentClassification_ClassId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">eindeutige ID der Klasse in einer Klassifikation</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>03-02</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ClassName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Bedienung</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>ClassificationSystem</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>VDI2770:2018</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersionId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value>2016.11</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersion_LanguageCode</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>en</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Title</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>HX Series Application Manual (Hardware)</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Summary</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value>This application manual informs about the hardware of HX series which is a high-performance PAC system suitable for IoT. The contents relevant to programming has been separated as an application manual (software) and a command reference manual. </aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Keywords</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_StatusValue</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Released</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_SetDate</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Purpose</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_BasedOnProcedure</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Comments</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_Type</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Product</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_RefType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_ObjectId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>NJI-637A(X)_HX-CPU_Hardware_Rev_01.pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileFormat</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>application/pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:file>
+                  <aas:idShort>File</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD005#008</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:mimeType>application/pdf</aas:mimeType>
+                  <aas:value>/aasx/Document/NJI-637A(X)_HX-CPU_Hardware_Rev_01.pdf</aas:value>
+                </aas:file>
+              </aas:submodelElement>
+            </aas:value>
+            <aas:ordered>false</aas:ordered>
+            <aas:allowDuplicates>false</aas:allowDuplicates>
+          </aas:submodelElementCollection>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:submodelElementCollection>
+            <aas:idShort>EN_Manual_Hitachi_HX_Software</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD001#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:value>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Single</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_DomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_IdType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Primary</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value>NJI-638(X)</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentDomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Role</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Responsible</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationOfficialName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi Industrial Equipment Systems Co.,Ltd.</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Description</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden.</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentPartId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentClassification_ClassId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">eindeutige ID der Klasse in einer Klassifikation</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>03-02</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ClassName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Bedienung</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>ClassificationSystem</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>VDI2770:2018</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersionId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value>2016.12 </aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersion_LanguageCode</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>en</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Title</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>HX Series Application Manual (Software) </aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Summary</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value>This application manual informs about the software of HX series which is a high-performance PAC system suitable for IoT. The contents relevant to installation has been separated as an hardware manual.</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Keywords</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_StatusValue</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Released</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_SetDate</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Purpose</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_BasedOnProcedure</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Comments</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_Type</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Product</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_RefType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_ObjectId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>NJI-638X_HX-CPU_Software.pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileFormat</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>application/pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:file>
+                  <aas:idShort>File</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD005#008</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:mimeType>application/pdf</aas:mimeType>
+                  <aas:value>/aasx/Document/NJI-638X_HX-CPU_Software.pdf</aas:value>
+                </aas:file>
+              </aas:submodelElement>
+            </aas:value>
+            <aas:ordered>false</aas:ordered>
+            <aas:allowDuplicates>false</aas:allowDuplicates>
+          </aas:submodelElementCollection>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:submodelElementCollection>
+            <aas:idShort>DE_CODESYS_V3_Installation_und_Erste_Schritte </aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD001#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:value>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Single</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_DomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_IdType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Primary</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value>0000000</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentDomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Role</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Responsible</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>3S-Smart Software Solutions GmbH </aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationOfficialName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>3S-Smart Software Solutions GmbH </aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Description</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden.</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentPartId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentClassification_ClassId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">eindeutige ID der Klasse in einer Klassifikation</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>03-02</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ClassName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Bedienung</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>ClassificationSystem</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>VDI2770:2018</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersionId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value>20XX</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersion_LanguageCode</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>de</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Title</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>CODESYS V3, Installation und Erste Schritte - Anwenderdokumentation </aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Summary</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Keywords</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_StatusValue</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Released</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_SetDate</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Purpose</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_BasedOnProcedure</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Comments</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_Type</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Product</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_RefType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_ObjectId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>CODESYS_Installation_und_Erste_Schritte_20V11.pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileFormat</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>application/pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:file>
+                  <aas:idShort>File</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD005#008</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:mimeType>application/pdf</aas:mimeType>
+                  <aas:value>/aasx/Document/CODESYS_Installation_und_Erste_Schritte_V11.pdf</aas:value>
+                </aas:file>
+              </aas:submodelElement>
+            </aas:value>
+            <aas:ordered>false</aas:ordered>
+            <aas:allowDuplicates>false</aas:allowDuplicates>
+          </aas:submodelElementCollection>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:submodelElementCollection>
+            <aas:idShort>EN_Datasheet_IoT_PAC_Controller_HX_Series</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD001#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:value>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Single</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_DomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_IdType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Primary</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentDomainId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Role</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Responsible</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_OrganisationOfficialName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi Europe GmbH</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Description</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">Eine Beschreibung zur Dokumententeile ID. Da eine Sprachangabe nicht möglich ist, sollte die Sprache für dieses Metadatum vor der Lieferung abgestimmt werden.</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value>The new Hitachi HX series PAC Controller combines powerful features and efficiency to meet the demands of a global supply chain in manufacturing industries. In addition, HX series is already prepared for the next generation requirements in automation thanks to its IoT capabilities. Manufacturing &amp; service innovations can be achieved with integrated functions and seamless connectivity from field machine level to cloud services. </aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentPartId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentClassification_ClassId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:description>
+                    <aas:langString lang="DE">eindeutige ID der Klasse in einer Klassifikation</aas:langString>
+                  </aas:description>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>03-02</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ClassName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Bedienung</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>ClassificationSystem</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>VDI2770:2018</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersionId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value>1.10</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>DocumentVersion_LanguageCode</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>en</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Title</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Datasheet: IoT PAC Controller HX Series - Next generation industrial controller.</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Summary</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Keywords</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_StatusValue</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Released</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_SetDate</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value>2017.03</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Purpose</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_BasedOnProcedure</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_Comments</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_Type</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Product</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_RefType</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_ReferencedObject_ObjectId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileId</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType />
+                  <aas:value />
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileName</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>HX%20Datasheet.pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>VDI2770_FileFormat</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>application/pdf</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:file>
+                  <aas:idShort>File</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAD005#008</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:mimeType>application/pdf</aas:mimeType>
+                  <aas:value>/aasx/Document/HX_Datasheet.pdf</aas:value>
+                </aas:file>
+              </aas:submodelElement>
+            </aas:value>
+            <aas:ordered>false</aas:ordered>
+            <aas:allowDuplicates>false</aas:allowDuplicates>
+          </aas:submodelElementCollection>
+        </aas:submodelElement>
+      </aas:submodelElements>
+    </aas:submodel>
+    <aas:submodel>
+      <aas:idShort>Service</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/sm/6053_5072_7091_5102</aas:identification>
+      <aas:kind>Instance</aas:kind>
+      <aas:semanticId>
+        <aas:keys>
+          <aas:key type="GlobalReference" local="false" idType="IRI">https://www.hsu-hh.de/aut/aas/service</aas:key>
+        </aas:keys>
+      </aas:semanticId>
+      <aas:qualifier />
+      <aas:submodelElements>
+        <aas:submodelElement>
+          <aas:submodelElementCollection>
+            <aas:idShort>ContactInfo</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/contactinfo</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:value>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>NameOfSupplier</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO735#003</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi Europe GmbH</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>ContactInfo_Role</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/role</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Sales organization</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:submodelElementCollection>
+                  <aas:idShort>PhysicalAddress</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/physicaladdress</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:value>
+                    <aas:submodelElement>
+                      <aas:property>
+                        <aas:idShort>CountryCode</aas:idShort>
+                        <aas:category>PARAMETER</aas:category>
+                        <aas:kind>Instance</aas:kind>
+                        <aas:semanticId>
+                          <aas:keys>
+                            <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO730#001</aas:key>
+                          </aas:keys>
+                        </aas:semanticId>
+                        <aas:qualifier />
+                        <aas:valueType>string</aas:valueType>
+                        <aas:value>DE</aas:value>
+                      </aas:property>
+                    </aas:submodelElement>
+                    <aas:submodelElement>
+                      <aas:property>
+                        <aas:idShort>Street</aas:idShort>
+                        <aas:category>PARAMETER</aas:category>
+                        <aas:kind>Instance</aas:kind>
+                        <aas:semanticId>
+                          <aas:keys>
+                            <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO128#001</aas:key>
+                          </aas:keys>
+                        </aas:semanticId>
+                        <aas:qualifier />
+                        <aas:valueType>string</aas:valueType>
+                        <aas:value>Niederkasseler Lohweg 191</aas:value>
+                      </aas:property>
+                    </aas:submodelElement>
+                    <aas:submodelElement>
+                      <aas:property>
+                        <aas:idShort>Zip</aas:idShort>
+                        <aas:category>PARAMETER</aas:category>
+                        <aas:kind>Instance</aas:kind>
+                        <aas:semanticId>
+                          <aas:keys>
+                            <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO129#002</aas:key>
+                          </aas:keys>
+                        </aas:semanticId>
+                        <aas:qualifier />
+                        <aas:valueType>string</aas:valueType>
+                        <aas:value>40547</aas:value>
+                      </aas:property>
+                    </aas:submodelElement>
+                    <aas:submodelElement>
+                      <aas:property>
+                        <aas:idShort>CityTown</aas:idShort>
+                        <aas:category>PARAMETER</aas:category>
+                        <aas:kind>Instance</aas:kind>
+                        <aas:semanticId>
+                          <aas:keys>
+                            <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO132#001</aas:key>
+                          </aas:keys>
+                        </aas:semanticId>
+                        <aas:qualifier />
+                        <aas:valueType>string</aas:valueType>
+                        <aas:value>Düsseldorf</aas:value>
+                      </aas:property>
+                    </aas:submodelElement>
+                    <aas:submodelElement>
+                      <aas:property>
+                        <aas:idShort>StateCounty</aas:idShort>
+                        <aas:category>PARAMETER</aas:category>
+                        <aas:kind>Instance</aas:kind>
+                        <aas:semanticId>
+                          <aas:keys>
+                            <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO133#002</aas:key>
+                          </aas:keys>
+                        </aas:semanticId>
+                        <aas:qualifier />
+                        <aas:valueType>string</aas:valueType>
+                        <aas:value>North Rhine-Westphalia</aas:value>
+                      </aas:property>
+                    </aas:submodelElement>
+                  </aas:value>
+                  <aas:ordered>false</aas:ordered>
+                  <aas:allowDuplicates>false</aas:allowDuplicates>
+                </aas:submodelElementCollection>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>Email</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/email</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>automation.industrial@hitachi-eu.com</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>URL</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO694#001</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>https://automation.hitachi-industrial.eu/</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>PhoneNumber</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO136#002</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>+49-211-5283-0</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>Fax</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/fax</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>+49-211-2049-049</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+            </aas:value>
+            <aas:ordered>false</aas:ordered>
+            <aas:allowDuplicates>false</aas:allowDuplicates>
+          </aas:submodelElementCollection>
+        </aas:submodelElement>
+      </aas:submodelElements>
+    </aas:submodel>
+    <aas:submodel>
+      <aas:idShort>Identification</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/sm/6563_5072_7091_4267</aas:identification>
+      <aas:kind>Instance</aas:kind>
+      <aas:semanticId>
+        <aas:keys>
+          <aas:key type="GlobalReference" local="false" idType="IRI">https://www.hsu-hh.de/aut/aas/identification</aas:key>
+        </aas:keys>
+      </aas:semanticId>
+      <aas:qualifier />
+      <aas:submodelElements>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>ManufacturerName</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO677#002</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>Hitachi Industrial Equipment Systems Co.,Ltd.</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>GLNOfManufacturer</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAY812#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>N/A</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>SupplierOfTheIdentifier</aas:idShort>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAP796#004</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType />
+            <aas:value>N/A</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>MAN_PROD_NUM</aas:idShort>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO676#003</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType />
+            <aas:value>1696-0702</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>ManufacturerProductDesignation</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAW338#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>HX-CP1H16</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>ManufacturerProductDescription</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAU734#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>langString</aas:valueType>
+            <aas:value>PLC Based PAC System for IoT Applications</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>NameOfSupplier</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO735#003</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>Hitachi Europe GmbH</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>GLNOfSupplier</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAY813#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>N/A</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>SupplierIdProvider</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/supplieridprovider</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType />
+            <aas:value>316033943</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>SUP_PROD_NUM</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO736#004</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType />
+            <aas:value>1696-0702</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>SupplierProductDesignation</aas:idShort>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAM551#002</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>HX-CP1H16</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>SupplierProductDescription</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAU730#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>langString</aas:valueType>
+            <aas:value>Programmable automation controller (PAC) System for IoT Applications</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>ManufacturerProductFamily</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAU731#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>PAC IoT Controller HX Series</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>ClassificationSystem</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO715#002</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>eclass</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>SecondaryKeyTyp</aas:idShort>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/secondarykeytyp</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType />
+            <aas:value />
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:file>
+            <aas:idShort>TypThumbnail</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/thumbnail</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:mimeType>image/png</aas:mimeType>
+            <aas:value>/HX_200432.png</aas:value>
+          </aas:file>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>AssetId</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/assetid</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>anyURI</aas:valueType>
+            <aas:value>https://automation.hitachi-industrial.eu/demo/asset/0000_0000_0000_0000_0000</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>SerialNumber</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAM556#002</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>string</aas:valueType>
+            <aas:value>1696-0702</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>BatchNumber</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAQ196#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType />
+            <aas:value>N/A</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>SecondaryKeyInstance</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/secondarykeyinstance</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType />
+            <aas:value />
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>DateOfManufacture</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAR972#002</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>date</aas:valueType>
+            <aas:value>N/A</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>DeviceRevision</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/devicerevision</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType />
+            <aas:value>N/A</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>SoftwareRevision</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/softwarerevision</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType />
+            <aas:value>3.5.13.40</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>HardwareRevision</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/hardwarerevision</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType />
+            <aas:value>N/A</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:submodelElementCollection>
+            <aas:idShort>ContactInfo</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/contactinfo</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:value>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>NameOfSupplier</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO735#003</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Hitachi Europe GmbH</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>ContactInfo_Role</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/role</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>Manufacturer</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:submodelElementCollection>
+                  <aas:idShort>PhysicalAddress</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/physicaladdress</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:value>
+                    <aas:submodelElement>
+                      <aas:property>
+                        <aas:idShort>CountryCode</aas:idShort>
+                        <aas:category>PARAMETER</aas:category>
+                        <aas:kind>Instance</aas:kind>
+                        <aas:semanticId>
+                          <aas:keys>
+                            <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO730#001</aas:key>
+                          </aas:keys>
+                        </aas:semanticId>
+                        <aas:qualifier />
+                        <aas:valueType>string</aas:valueType>
+                        <aas:value>DE</aas:value>
+                      </aas:property>
+                    </aas:submodelElement>
+                    <aas:submodelElement>
+                      <aas:property>
+                        <aas:idShort>Street</aas:idShort>
+                        <aas:category>PARAMETER</aas:category>
+                        <aas:kind>Instance</aas:kind>
+                        <aas:semanticId>
+                          <aas:keys>
+                            <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO128#001</aas:key>
+                          </aas:keys>
+                        </aas:semanticId>
+                        <aas:qualifier />
+                        <aas:valueType>langString</aas:valueType>
+                        <aas:value>Niederkasseler Lohweg 191</aas:value>
+                      </aas:property>
+                    </aas:submodelElement>
+                    <aas:submodelElement>
+                      <aas:property>
+                        <aas:idShort>Zip</aas:idShort>
+                        <aas:category>PARAMETER</aas:category>
+                        <aas:kind>Instance</aas:kind>
+                        <aas:semanticId>
+                          <aas:keys>
+                            <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO129#002</aas:key>
+                          </aas:keys>
+                        </aas:semanticId>
+                        <aas:qualifier />
+                        <aas:valueType>string</aas:valueType>
+                        <aas:value>40547</aas:value>
+                      </aas:property>
+                    </aas:submodelElement>
+                    <aas:submodelElement>
+                      <aas:property>
+                        <aas:idShort>CityTown</aas:idShort>
+                        <aas:category>PARAMETER</aas:category>
+                        <aas:kind>Instance</aas:kind>
+                        <aas:semanticId>
+                          <aas:keys>
+                            <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO132#001</aas:key>
+                          </aas:keys>
+                        </aas:semanticId>
+                        <aas:qualifier />
+                        <aas:valueType>string</aas:valueType>
+                        <aas:value>Düsseldorf</aas:value>
+                      </aas:property>
+                    </aas:submodelElement>
+                    <aas:submodelElement>
+                      <aas:property>
+                        <aas:idShort>StateCounty</aas:idShort>
+                        <aas:category>PARAMETER</aas:category>
+                        <aas:kind>Instance</aas:kind>
+                        <aas:semanticId>
+                          <aas:keys>
+                            <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO133#002</aas:key>
+                          </aas:keys>
+                        </aas:semanticId>
+                        <aas:qualifier />
+                        <aas:valueType>string</aas:valueType>
+                        <aas:value>North Rhine-Westphalia</aas:value>
+                      </aas:property>
+                    </aas:submodelElement>
+                  </aas:value>
+                  <aas:ordered>false</aas:ordered>
+                  <aas:allowDuplicates>false</aas:allowDuplicates>
+                </aas:submodelElementCollection>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>Email</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/email</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>automation.industrial@hitachi-eu.com</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>URL</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO694#001</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>anyURI</aas:valueType>
+                  <aas:value>https://automation.hitachi-industrial.eu/</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>PhoneNumber</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO136#002</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>+49-211-5283-0</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+              <aas:submodelElement>
+                <aas:property>
+                  <aas:idShort>Fax</aas:idShort>
+                  <aas:category>PARAMETER</aas:category>
+                  <aas:kind>Instance</aas:kind>
+                  <aas:semanticId>
+                    <aas:keys>
+                      <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/fax</aas:key>
+                    </aas:keys>
+                  </aas:semanticId>
+                  <aas:qualifier />
+                  <aas:valueType>string</aas:valueType>
+                  <aas:value>+49-211-2049-049</aas:value>
+                </aas:property>
+              </aas:submodelElement>
+            </aas:value>
+            <aas:ordered>false</aas:ordered>
+            <aas:allowDuplicates>false</aas:allowDuplicates>
+          </aas:submodelElementCollection>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:file>
+            <aas:idShort>CompanyLogo</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRI">https://www.hsu-hh.de/aut/aas/companylogo</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:mimeType>image/png</aas:mimeType>
+            <aas:value>/aasx/assetIdentification/Hitachi_logo.png</aas:value>
+          </aas:file>
+        </aas:submodelElement>
+        <aas:submodelElement>
+          <aas:property>
+            <aas:idShort>URL</aas:idShort>
+            <aas:category>PARAMETER</aas:category>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO694#001</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:valueType>anyURI</aas:valueType>
+            <aas:value>https://automation.hitachi-industrial.eu/demo/0000_0000_0000_0000_0000</aas:value>
+          </aas:property>
+        </aas:submodelElement>
+      </aas:submodelElements>
+    </aas:submodel>
+    <aas:submodel>
+      <aas:idShort>DeviceDescriptionFiles</aas:idShort>
+      <aas:identification idType="IRI">https://automation.hitachi-industrial.eu/_Resources/Static/Packages/Moon.HitachiEurope/Downloads/automation/[2]%20Software/[5]%20Configuration%20Files/[1]%20Device%20Descriptions/Device%20files.zip</aas:identification>
+      <aas:kind>Instance</aas:kind>
+      <aas:semanticId>
+        <aas:keys>
+          <aas:key type="Submodel" local="false" idType="IRI">https://automation.hitachi-industrial.eu/en/products/software/configuration-files/device-descriptions</aas:key>
+        </aas:keys>
+      </aas:semanticId>
+      <aas:qualifier />
+      <aas:submodelElements>
+        <aas:submodelElement>
+          <aas:file>
+            <aas:idShort>CodeSysDD</aas:idShort>
+            <aas:kind>Instance</aas:kind>
+            <aas:semanticId>
+              <aas:keys>
+                <aas:key type="ConceptDescription" local="false" idType="IRI">http://admin-shell.io/sample/conceptdescriptions/437857438753457473</aas:key>
+              </aas:keys>
+            </aas:semanticId>
+            <aas:qualifier />
+            <aas:mimeType>application/general</aas:mimeType>
+            <aas:value>/aasx/Document/Device_files.zip</aas:value>
+          </aas:file>
+        </aas:submodelElement>
+      </aas:submodelElements>
+    </aas:submodel>
+  </aas:submodels>
+  <aas:conceptDescriptions>
+    <aas:conceptDescription>
+      <aas:idShort>ManufacturerName</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO677#002</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Herstellername</IEC:langString>
+              <IEC:langString lang="EN">Manufacturer Name</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Manufacturer Name</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</IEC:langString>
+              <IEC:langString lang="EN">legally valid designation of the natural or judicial person which is directly responsible for the design, production, packaging and labeling of a product in respect to its being brought into circulation</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>GLNOfManufacturer</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAY812#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">GLN of manufacturer</IEC:langString>
+              <IEC:langString lang="DE">GLN des Herstellers</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">GLN of manufacturer</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">international eindeutige Nummer für den Geräte- oder Produkthersteller sowie für den Standort</IEC:langString>
+              <IEC:langString lang="EN">internationally unique identification number for the manufacturer of the device or the product and for the physical location</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>SupplierOfTheIdentifier</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAP796#004</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Supplier of the identifier</IEC:langString>
+              <IEC:langString lang="DE">Anbieter der Identifikationsnummer für Hersteller</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Supplier of the identifier</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING_TRANSLATABLE</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="EN">DUNS-no., supplier number, or other number as identifier of an offeror or supplier of the identification</IEC:langString>
+              <IEC:langString lang="DE">DUNS-Nr., Lieferantennummer oder andere Nummer zur Identifikation eines Anbieters bzw. Lieferanten der Identifikationsnummer</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>MAN_PROD_NUM</aas:idShort>
+      <aas:description>
+        <aas:langString lang="EN">product article number of manufacturer</aas:langString>
+      </aas:description>
+      <aas:identification idType="IRDI">0173-1#02-AAO676#003</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">product article number of manufacturer</IEC:langString>
+              <IEC:langString lang="DE">Herstellerartikelnummer</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">MAN_PROD_NUM</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING_TRANSLATABLE</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">eindeutiger Bestellschlüssel des Herstellers</IEC:langString>
+              <IEC:langString lang="EN">unique product identifier of the manufacturer</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>ManufacturerProductDesignation</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAW338#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Manufacturer product designation</IEC:langString>
+              <IEC:langString lang="DE">Herstellerproduktbezeichnung</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">ManufacturerTypName</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING_TRANSLATABLE</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Kurze Beschreibung des Produktes (Kurztext)</IEC:langString>
+              <IEC:langString lang="EN">Short description of the product (short text)</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>ManufacturerProductDescription</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAU734#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Manufacturer product description</IEC:langString>
+              <IEC:langString lang="DE">Herstellerproduktbeschreibung</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Manufacturer product description</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Beschreibung des Produktes, seiner technischen Eigenschaften und ggf. seiner Anwendung (Langtext)</IEC:langString>
+              <IEC:langString lang="EN">Description of the product, it's technical features and implementation if needed (long text)</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>NameOfSupplier</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO735#003</aas:identification>
+      <aas:administration>
+        <aas:version />
+        <aas:revision />
+      </aas:administration>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">name of supplier</IEC:langString>
+              <IEC:langString lang="DE">Lieferantenname</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">name of supplier</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Name des Lieferanten, welcher dem Kunden ein Produkt oder eine Dienstleistung bereitstellt</IEC:langString>
+              <IEC:langString lang="EN">name of supplier which provides the customer with a product or a service</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>GLNOfSupplier</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAY813#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">GLN of supplier</IEC:langString>
+              <IEC:langString lang="DE">GLN des Lieferanten</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">GLN of supplier</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">international eindeutige Nummer für den Geräte- oder Produktlieferanten sowie für den Standort</IEC:langString>
+              <IEC:langString lang="EN">internationally unique identification number for the supplier of the device or the product and for the physical location</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>SupplierIdProvider</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/supplieridprovider</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">SupplierIdProvider</IEC:langString>
+              <IEC:langString lang="DE">Anbieter der Identifikationsnummer</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">SupplierIdProvider</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING_TRANSLATABLE</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">DUNS-Nr., Lieferantennummer oder andere Nummer zur Identifikation eines Anbieters bzw. Lieferanten der Identifikationsnummer</IEC:langString>
+              <IEC:langString lang="EN">DUNS-no., supplier number, or other number as identifier of an offeror or supplier of the identification</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>SUP_PROD_NUM</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO736#004</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">product article number of supplier</IEC:langString>
+              <IEC:langString lang="DE">Lieferantenartikelnummer</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">product article number of supplier</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">eindeutiger Bestellschlüssel des Lieferanten</IEC:langString>
+              <IEC:langString lang="EN">unique product order identifier of the supplier</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>SupplierProductDesignation</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAM551#002</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Supplier product designation</IEC:langString>
+              <IEC:langString lang="DE">Lieferantenproduktbezeichnung</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">SupplierTypName</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING_TRANSLATABLE</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Kurze Beschreibung des Produktes (Kurztext)</IEC:langString>
+              <IEC:langString lang="EN">Short description of the product (short text)</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>SupplierProductDescription</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAU730#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Supplier product description</IEC:langString>
+              <IEC:langString lang="DE">Lieferantenproduktbeschreibung</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Supplier product description</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Beschreibung des Produktes, seiner technischen Eigenschaften und ggf. seiner Anwendung (Langtext)</IEC:langString>
+              <IEC:langString lang="EN">Description of the product, it's technical features and implementation if needed (long text)</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>ManufacturerProductFamily</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAU731#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Manufacturer product family</IEC:langString>
+              <IEC:langString lang="DE">Herstellerproduktfamilie</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">TypClass</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">2. Ebene einer 3 stufigen herstellerspezifischen Produkthierarchie</IEC:langString>
+              <IEC:langString lang="EN">2nd level of a 3 level manufacturer specific product hierarchy</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>ClassificationSystem</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO715#002</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">classification system</IEC:langString>
+              <IEC:langString lang="DE">Klassifizierungssystem</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">ClassificationSystem</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Klassifizierungssystem</IEC:langString>
+              <IEC:langString lang="EN">Classification System</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>SecondaryKeyTyp</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/secondarykeytyp</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">SecondaryKeyTyp</IEC:langString>
+              <IEC:langString lang="DE">Typnummer des IT Systems</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">SecondaryKeyTyp</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Führende technische ID im IT System des Typs</IEC:langString>
+              <IEC:langString lang="EN">SecondaryKeyTyp</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>TypThumbnail</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/thumbnail</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">TypThumbnail</IEC:langString>
+              <IEC:langString lang="DE">Vorschaubild</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">TypThumbnail</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Darstellung des Produkttyps in kleinem Format</IEC:langString>
+              <IEC:langString lang="EN">Small picture of the product type</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>AssetId</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/assetid</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">AssetId</IEC:langString>
+              <IEC:langString lang="DE">Asset ID</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">AssetId</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Global eindeutige ID eines Asset, die machienenlesbar oder durch Menschen lesbar ist.</IEC:langString>
+              <IEC:langString lang="EN">Global unique ID of an asset, which can be read by both human and machine.</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>SerialNumber</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAM556#002</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Serial number</IEC:langString>
+              <IEC:langString lang="DE">Seriennummer</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">InstanceId</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">eindeutige Zahlen- und Buchstabenkombination mit der das Gerät nach seiner Herstellung identifiziert ist</IEC:langString>
+              <IEC:langString lang="EN">unique combination of numbers and letters used to identify the device once it has been manufactured</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>BatchNumber</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAQ196#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Batch number</IEC:langString>
+              <IEC:langString lang="DE">Chargen-Nummer</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">ChargeId</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Eine vom Hersteller eines Stoffes vergebene Nummer zur Identifikation einer Charge</IEC:langString>
+              <IEC:langString lang="EN">Number assigned by the manufacturer of a material to identify the manufacturer's batch</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>SecondaryKeyInstance</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/secondarykeyinstance</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">SecondaryKeyInstance</IEC:langString>
+              <IEC:langString lang="DE">Instanznummer des IT Systems</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">SecondaryKeyInstance</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Führende technische ID im IT System der Instanz</IEC:langString>
+              <IEC:langString lang="EN">SecondaryKeyInstance</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DateOfManufacture</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAR972#002</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Date of manufacture</IEC:langString>
+              <IEC:langString lang="DE">Herstellungsdatum</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Date of manufacture</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>DATE</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Datum, ab der der Herstellungs- und/oder Entstehungsprozess abgeschlossen ist bzw. ab dem eine Dienstleistung vollständig erbracht ist</IEC:langString>
+              <IEC:langString lang="EN">Date from which the production and / or development process is completed or from which a service is provided completely</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DeviceRevision</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/devicerevision</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">DeviceRevision</IEC:langString>
+              <IEC:langString lang="DE">DeviceRevision</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DeviceRevision</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">DeviceRevision</IEC:langString>
+              <IEC:langString lang="EN">DeviceRevision</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>SoftwareRevision</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/softwarerevision</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">SoftwareRevision</IEC:langString>
+              <IEC:langString lang="EN">SoftwareRevision</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">SoftwareRevision</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">SoftwareRevision</IEC:langString>
+              <IEC:langString lang="EN">SoftwareRevision</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>HardwareRevision</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/hardwarerevision</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">HardwareRevision</IEC:langString>
+              <IEC:langString lang="EN">HardwareRevision</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">HardwareRevision</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">HardwareRevision</IEC:langString>
+              <IEC:langString lang="EN">HardwareRevision</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>QrCode</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/qrcode</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">QrCode</IEC:langString>
+              <IEC:langString lang="EN">QrCode</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">QrCode</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">In dem QRCode ist die URL, die die Instanz des Assets genau beschreibt, hinterlegt.</IEC:langString>
+              <IEC:langString lang="EN">QrCode</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>OrganisationContactInfo</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/contactinfo</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Contact Info</IEC:langString>
+              <IEC:langString lang="DE">Kontakt Info</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">OrganisationContactInfo</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Sammlung für die allgemeinen Kontaktdaten</IEC:langString>
+              <IEC:langString lang="EN">Collection for general contact data</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>PhysicalAddress</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/physicaladdress</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">PhysicalAddress</IEC:langString>
+              <IEC:langString lang="DE">Physische Adresse</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">PhysicalAddress</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Sammlung für reale physische Adresse</IEC:langString>
+              <IEC:langString lang="EN">Collection for real physical address</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>CountryCode</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO730#001</aas:identification>
+      <aas:administration>
+        <aas:version />
+        <aas:revision />
+      </aas:administration>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Landeskennung</IEC:langString>
+              <IEC:langString lang="EN">Country code</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Country code</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Vereinbartes Merkmal zur eindeutigen Identifizierung eines Landes</IEC:langString>
+              <IEC:langString lang="EN">agreed upon symbol for unambiguous identification of a country</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>Street</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO128#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Strasse</IEC:langString>
+              <IEC:langString lang="EN">Street</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Street</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Name der Strasse und Hausnummer</IEC:langString>
+              <IEC:langString lang="EN">Street name and house number</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>Zip</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO129#002</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Zip</IEC:langString>
+              <IEC:langString lang="DE">Postleitzahl</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">PostalCode</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="EN">ZIP code of address</IEC:langString>
+              <IEC:langString lang="DE">Postleitzahl der Anschrift</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>CityTown</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO132#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Ort</IEC:langString>
+              <IEC:langString lang="EN">City/town</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">City/town</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="EN">Town or city of the company</IEC:langString>
+              <IEC:langString lang="DE">Ortsangabe</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>StateCounty</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO133#002</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">state/county</IEC:langString>
+              <IEC:langString lang="DE">Bundesland</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">StateCounty</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Bundesland</IEC:langString>
+              <IEC:langString lang="EN">state/county</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>Email</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/email</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Emailadresse</IEC:langString>
+              <IEC:langString lang="EN">Email address</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Email</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Emailadresse</IEC:langString>
+              <IEC:langString lang="EN">Email address</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>TelephoneContact</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/ContactInfo/TelephoneContact</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Telephone Contact</IEC:langString>
+              <IEC:langString lang="DE">Telefonkontakt</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">TelephoneContact</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Sammlung für Kontaktdaten über Telefon</IEC:langString>
+              <IEC:langString lang="EN">Collection for contact data via telephone</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>PhoneNumber</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO136#002</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Telefonnummer</IEC:langString>
+              <IEC:langString lang="EN">telephone number</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Phone</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">vollständige Telefonnummer unter der ein Geschäftspartner erreichbar ist</IEC:langString>
+              <IEC:langString lang="EN">complete telephone number to be called to reach a business partner</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>CompanyLogo</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/companylogo</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Firmenlogo</IEC:langString>
+              <IEC:langString lang="EN">CompanyLogo</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">CompanyLogo</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Firmenlogo</IEC:langString>
+              <IEC:langString lang="EN">CompanyLogo</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>URL</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO694#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Internetadresse</IEC:langString>
+              <IEC:langString lang="EN">Internet address</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">URL</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="EN">stated as link to a home page. The home page is the starting page or table of contents of a web site with offerings. It usually has the name index.htm or index.html</IEC:langString>
+              <IEC:langString lang="DE">Angabe als Link, um in eine Homepage zu gelangen. die Homepage ist die Start- beziehungsweise die Inhaltsseite eines Web-Angebots. Meistens trägt sie den Namen index.htm oder index.html</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>ProductCountryOfOrigin</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAO841#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Produkt Ursprungsland</IEC:langString>
+              <IEC:langString lang="EN">Product country of origin</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">CountryOfOrigin</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Land in dem das Produkt hergestellt wurde (Hersteller Land)</IEC:langString>
+              <IEC:langString lang="EN">Country in which the product is manufactured (manufacturer country)</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>YearOfConstruction</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAP906#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">Year of construction</IEC:langString>
+              <IEC:langString lang="DE">Baujahr</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">YearOfConstruction</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Jahreszahl als Datumsangabe für die Fertigstellung des Objektes</IEC:langString>
+              <IEC:langString lang="EN">Year as completion date of object</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>File</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAD005#008</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Enthaltene Doku. Datei</IEC:langString>
+              <IEC:langString lang="EN">Embedded Doc. file</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">File</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Verweis/ BLOB auf enthaltene Dokumentations-Datei.</IEC:langString>
+              <IEC:langString lang="EN">Reference/ BLOB to embedded documentation file.</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>ProductMarking</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/productmarking</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Produktkennzeichnung</IEC:langString>
+              <IEC:langString lang="EN">Product Marking</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">ProductMarking</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Sammlungsdatei für Produktkennzeichnung</IEC:langString>
+              <IEC:langString lang="EN">Collection file for product marking</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>CEQualificationPresent</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-BAF053#008</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">CE-Kennzeichnung vorhanden</IEC:langString>
+              <IEC:langString lang="EN">CE- qualification present</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">CEMarkingPresent</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>BOOLEAN</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="EN">whether CE- qualification is present</IEC:langString>
+              <IEC:langString lang="DE">Angabe, ob CE-Kennzeichnung vorhanden ist</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>CRUUSLabelingPresent</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAR528#005</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Kennzeichnung (RCM) vorhanden</IEC:langString>
+              <IEC:langString lang="EN">RCM labeling present</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">CRUUSLabelingPresent</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>BOOLEAN</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="EN">indication whether the product is equipped with a specified RCM labeling</IEC:langString>
+              <IEC:langString lang="DE">Angabe, ob das Produkt mit einer spezifizierten RCM-Kennzeichnung ausgestattet ist</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentClassification_ClassId</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Dokumentkategorie</IEC:langString>
+              <IEC:langString lang="EN">Document category</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Dokumentkategorie nach VDI 2770:2018/10</IEC:langString>
+              <IEC:langString lang="EN">Document category after VDI 2770:2018/10</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentId</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="EN">DocumentId</IEC:langString>
+              <IEC:langString lang="DE">Dokumenten-Nummer</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocumentId</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Die Dokument ID stellt eine eindeutige Identifizierung des Dokuments innerhalb einer Domäne sicher.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_DomainId</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/DomainId</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Domain-Nummer</IEC:langString>
+              <IEC:langString lang="EN">DomainId</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DomainId</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Kennung oder Kennzeichen einer Domäne, in der eine DocumentId eineindeutig ist.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_IdType</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentId/IdType</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Nummerntyp</IEC:langString>
+              <IEC:langString lang="EN">IdType</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">IdType</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Besitzt ein Dokument mehrere Identifikationsnummern, muss mithilfe dieser Eigenschaft die führende ID angegeben werden. Der Wert „Primary“ ist für diese ID zu setzen.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>ValString</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/4490_8182_7091_6124</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Wert</IEC:langString>
+              <IEC:langString lang="EN">Value String</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">ValString</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Ausdruck für den Wert der übergeordneten Collection.</IEC:langString>
+              <IEC:langString lang="EN">Value string for the collection value on the next superordinate level</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentationItem</aas:idShort>
+      <aas:identification idType="IRDI">0173-1#02-AAD001#001</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Dokumentationsgruppe</IEC:langString>
+              <IEC:langString lang="EN">Documentation item</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocumentationItem</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Gruppe von Merkmalen, die Zugriff gibt auf eine Dokumentation für ein Asset, beispielhaft struktuiert nach VDI 2770.</IEC:langString>
+              <IEC:langString lang="EN">Collection of properties, which gives access to documentation of an asset, structured exemplary-wise according to VDI 2770.</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentIdDomain</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/6003_8182_7091_9350</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">DocumentIdDomain</IEC:langString>
+              <IEC:langString lang="EN">DocumentIdDomain</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocumentIdDomain</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Angabe einer Liste von Domänen, in de-nen die DocumentIds des Dokuments eindeutig sind</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentDomainId</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentIdDomain/DocumentDomainId</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">DocumentDomainId</IEC:langString>
+              <IEC:langString lang="EN">DocumentDomainId</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocumentDomainId</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Kennung oder Kennzeichen einer Domäne</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_Party</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/3153_8182_7091_4327</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Party</IEC:langString>
+              <IEC:langString lang="EN">Party</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Party</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Verweis auf eine Party (siehe VDI 2770 Anhang C1.17), die für diese Domäne verantwortlich ist</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_Role</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Role</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Rolle</IEC:langString>
+              <IEC:langString lang="EN">Role</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Role</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Festlegung einer Rolle für die Organisation gemäß der folgenden Auswahlliste: Author (Autor), Customer (Kunde), Supplier (Zulieferer, Anbieter), Manufacturer (Hersteller), Responsible (Verantwortlicher)</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_Organisation</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/9214_8182_7091_6391</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Organisation</IEC:langString>
+              <IEC:langString lang="EN">Organisation</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Organisation</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Angabe einer Organisation</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_OrganisationId</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationId</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Organisation ID</IEC:langString>
+              <IEC:langString lang="EN">Organisation ID</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">OrganisationId</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">eindeutige ID für die Organisation</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_OrganisationName</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationName</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">OrganisationName</IEC:langString>
+              <IEC:langString lang="EN">OrganisationName</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">OrganisationName</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">gebräuchliche Bezeichnung für die Organisation</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_OrganisationOfficialName</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Party/Organisation/OrganisationOfficialName</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Offizieller Name der Organisation</IEC:langString>
+              <IEC:langString lang="EN">Organisation Official Name</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">OrganisationOfficialName</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">offizieller Name der Organisation</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentPartId</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentPartId</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Dokumenten-Teilnummer</IEC:langString>
+              <IEC:langString lang="EN">DocumentPartId</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocumentPartId</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Ist das Dokument ein zusammengesetztes Dokument, können mithilfe dieser Eigenschaft eindeutige Dokumententeile IDs eingetragen werden, um das Dokument von den anderen Dokumenten zu unterscheiden.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_Description</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Beschreibung</IEC:langString>
+              <IEC:langString lang="EN">Description</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Description</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Beschreibung für die nächste übergeordnete Collection</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_ClassName</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassName</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Klassenname</IEC:langString>
+              <IEC:langString lang="EN">Class Name</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">ClassName</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Liste von sprachabhängigen Namen zur ClassId. Für die Klassennamen nach VDI 2770 müssen die Werte aus Tabelle 1 in Abschnitt 8.5 angewendet werden.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentVersion_LanguageCode</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/LanguageCode</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Sprachenschlüssel</IEC:langString>
+              <IEC:langString lang="EN">LanguageCode</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">LanguageCode</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Angabe eines Sprachcodes gemäss ISO 639-1 oder -2</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_ClassificationSystem</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassificationSystem</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Klassifizierungssystem</IEC:langString>
+              <IEC:langString lang="EN">classification system</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">ClassificationSystem</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Eindeutige Kennung für ein Klassifikationssystem. Für Klassifikationen nach VDI 2770 muss „VDI2770:2018“ verwenden werden.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentVersion</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/2580_0282_7091_6213</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Dokumenten-Version</IEC:langString>
+              <IEC:langString lang="EN">DocumentVersion</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocumentVersion</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Zu jedem Dokument muss eine Menge von mindestens einer Dokumentenversion existieren. Es können auch mehrere Dokumentenversionen ausgeliefert werden.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentVersionId</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersionId</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Dokumenten-Versionsnummer</IEC:langString>
+              <IEC:langString lang="EN">DocumentVersionId</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocumentVersionId</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Identifikationsnummer zur Dokumenten-version. Verweist ein Document (siehe Anhang C1.1, Eigenschaft DocumentVersion) auf diese Dokumentenversion, muss die Kombination aus DocumentId und DocumentVersionId eindeutig sein.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_Language</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/0231_0282_7091_5062</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Sprache</IEC:langString>
+              <IEC:langString lang="EN">Language</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Language</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Liste der im Dokument verwendeten Sprachen</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentVersion_Description</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/9151_0282_7091_8032</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Beschreibung zur DocumentVersion</IEC:langString>
+              <IEC:langString lang="EN">DocumentVersion Description</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocumentVersion_Description</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Zusammenfassende Beschreibungen zur Dokumentenversion in ggf. unterschiedlichen Sprachen.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_Title</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Title</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Titel</IEC:langString>
+              <IEC:langString lang="EN">Title</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">VDI2770_Title</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">sprachabhängiger Titel des Dokuments</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_Summary</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Summary</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Zusammenfassung</IEC:langString>
+              <IEC:langString lang="EN">Summary</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Summary</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">sprachabhängige, aussagekräftige Zusammenfassung des Dokumenteninhalts</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_Keywords</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/Description/Keywords</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Schlagwörter</IEC:langString>
+              <IEC:langString lang="EN">Keywords</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Keywords</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">sprachabhängige, durch Komma getrennte Liste von Schlagwörtern</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_LifeCycleStatus</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/0282_0282_7091_7878</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Lebenszyklus Status</IEC:langString>
+              <IEC:langString lang="EN">LifeCycleStatus</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">LifeCycleStatus</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Liste von Statusdefinitionen mit Bezug zum Dokumentenlebenszyklus inklusive der Angabe der Beteiligten und einem zugehörigen Zeitstempel</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_StatusValue</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/StatusValue</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Statuswert</IEC:langString>
+              <IEC:langString lang="EN">StatusValue</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">StatusValue</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Jede Dokumentenversion stellt einen Zeitpunkt im Dokumentenlebenszyklus dar. Dieser Statuswert bezieht sich auf die Meilensteine im Dokumentenlebenszyklus. Für die Anwendung dieser Richtlinie sind die beiden folgenden Status zu verwenden. InReview (in Prüfung), Released (freigegeben)</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_SetDate</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/SetDate</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Erstellungsdatum</IEC:langString>
+              <IEC:langString lang="EN">Set Date</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">SetDate</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Datum und Uhrzeit, an dem der Status festgelegt wurde Es muss das Datumsformat „YYYY-MM-dd“ verwendet werden (Y = Jahr, M = Monat, d = Tag, siehe DIN ISO 8601).</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_Purpose</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Purpose</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Zweck</IEC:langString>
+              <IEC:langString lang="EN">Purpose</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Purpose</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Hier kann ein Zweck zum Meilenstein angegeben werden, z. B. „zur Weiterleitung an den Kunden“.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_BasedOnProcedure</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/BasedOnProcedure</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Prozedur</IEC:langString>
+              <IEC:langString lang="EN">Procedure</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">BasedOnProcedure</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">textueller Bezug auf ein Verfahren, das der Festlegung dieses Status zugrunde liegt</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_Comments</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/LifeCycleStatus/Comments</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Kommentar</IEC:langString>
+              <IEC:langString lang="EN">Comments</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Comments</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">textuelle Bemerkungen und Anmerkungen zum Status</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentRelationship</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/1204_0282_7091_7896</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Dokumenten-Beziehung</IEC:langString>
+              <IEC:langString lang="EN">Document Relationship</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocumentRelationship</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Liste von Beziehungen zu anderen Dokumenten. Es ist möglich, auf einen Dokument, ein Dokument in einer spezifischen Dokumentenversion oder auch ein Teildokument zu verweisen.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentRelationship_Type</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/5044_0282_7091_6924</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Typ der Dokumenten-Beziehung</IEC:langString>
+              <IEC:langString lang="EN">DocumentRelationship_Type</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocumentRelationship_Type</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Typisierung der Beziehung zwischen den beiden DocumentVersions. Folgende Beziehungsarten können verwendet werden: Affecting (hat Auswirkungen auf), ReferesTo (bezieht sich auf), BasedOn (basiert auf)</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>StoredDocumentRepresentation</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/3094_0282_7091_2090</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">StoredDocumentRepresentation</IEC:langString>
+              <IEC:langString lang="EN">StoredDocumentRepresentation</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">StoredDocumentRepresentation</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Liste von digitalen Repräsentationen zur DocumentVersion</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_DigitalFile</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/2305_0282_7091_2077</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Digitaler-File</IEC:langString>
+              <IEC:langString lang="EN">DigitalFile</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DigitalFile</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Datei, die die DocumentVersion (siehe VDI 2770:2018 Anhang C1.5) repräsentiert Neben der obligatorischen PDF/A-Datei können weitere Dateien angegeben werden.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_FileId</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileId</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">ID der Datei</IEC:langString>
+              <IEC:langString lang="EN">File ID</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">FileId</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">eindeutige ID für die Datei</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_FileName</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileName</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Dateiname</IEC:langString>
+              <IEC:langString lang="EN">File name</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">FileName</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Name der Datei inkl. einer Dateiendung (sofern vorhanden) Es ist nicht notwendig, einen Pfad für die Datei anzugeben.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_FileFormat</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentVersion/StoredDocumentRepresentation/DigitalFile/FileFormat</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Datei Format</IEC:langString>
+              <IEC:langString lang="EN">File format</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">FileFormat</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Angabe eines Media Typs gemäß der Liste der IANA</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocumentType</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentType</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Dokumententyp</IEC:langString>
+              <IEC:langString lang="EN">Document Type</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocumentType</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Festlegung des Typs des Dokuments im Sinne der DIN EN 82045-1: a) Single (Einzeldokument) b) Aggregate (Sammeldokument) c) DocumentSet (Dokumentensatz) d) CompoundDoc (Mischdokument)</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_ReferencedObject</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/2570_2282_7091_0055</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">ReferencedObject</IEC:langString>
+              <IEC:langString lang="EN">ReferencedObject</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">ReferencedObject</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Liste von IDs für ein Objekt, auf das sich das Dokument bezieht</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_ReferencedObject_Type</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ReferencedObjectType</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Typ</IEC:langString>
+              <IEC:langString lang="EN">Type</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Type</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Für Type des Objekts muss immer Product angegeben werden.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_ReferencedObject_RefType</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/RefType</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">RefType</IEC:langString>
+              <IEC:langString lang="EN">RefType</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">RefType</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Angabe einer Typisierung zur Kennung des technischen Objekts. Folgende Werte sind möglich, ProductId (Produktnummer), SerialId (Seriennummer)</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>VDI2770_ReferencedObject_ObjectId</aas:idShort>
+      <aas:identification idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/ReferencedObject/ObjectId</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">ObjectId</IEC:langString>
+              <IEC:langString lang="EN">ObjectId</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">ObjectId</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Angabe der Identifikationsnummer zum Objekt</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>ContactInfo_Role</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/role</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Rolle</IEC:langString>
+              <IEC:langString lang="EN">Role</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Role</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Angabe zur Spezifizierung der Rolle, die die Organisation aus ContactInfo einnimmt</IEC:langString>
+              <IEC:langString lang="EN">Information to specify the role which the organisation of ContactInfo plays</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>Fax</aas:idShort>
+      <aas:identification idType="IRI">https://www.hsu-hh.de/aut/aas/fax</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">Fax</IEC:langString>
+              <IEC:langString lang="EN">Fax</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">Fax</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Faxnummer</IEC:langString>
+              <IEC:langString lang="EN">Fax number</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRDI">0173-1#02-AAO136#002</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocGroup_01</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/1420_0113_7091_0891</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">01 Identifikation</IEC:langString>
+              <IEC:langString lang="EN">01 Identification</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocGroup_01</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Gruppe „Identifikation“ werden alle Dokumente zugeordnet, die der Identifikation des Objekts dienen, zu dem die Herstellerdokumentation gehört. Sie enthält insbesondere Informationen, die die elektronische Datenverarbeitung unterstützen und die es dem Hersteller und dem Nutzer erlauben, das Objekt in ihren jeweiligen elektronischen Datenverarbeitungssystemen zu identifizieren.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocGroup_02</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/4323_0113_7091_2591</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">02 Technische Beschaffenheit</IEC:langString>
+              <IEC:langString lang="EN">02 Technical characteristics</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocGroup_02</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Die Gruppe „Technische Beschaffenheit“ beinhaltet alle Dokumente, die die technischen Anforderungen, deren Erfüllung und die Bescheinigung der Eigenschaften eines Objekts betreffen.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocGroup_03</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/5053_0113_7091_5741</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">03 Tätigkeitsbezogene Dokumente</IEC:langString>
+              <IEC:langString lang="EN">03 Work-related documents</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocGroup_03</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Die Gruppe „Tätigkeitsbezogene Dokumente“ beinhaltet alle Dokumente, die Anforderungen, Hinweise und Hilfestellungen für Tätigkeiten an und mit dem Objekt nach der Übergabe an den Nutzer betreffen.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocGroup_04</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/5473_0113_7091_1588</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">04 Vertragsunterlagen</IEC:langString>
+              <IEC:langString lang="EN">04 Contract documents</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocGroup_04</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Gruppe „Vertragsunterlagen“ werden alle Dokumente zugeordnet, die im Zusammenhang mit der kaufmännischen Abwicklung eines Vertrages stehen, aber nicht selbst Gegenstand des Vertrags sind und lediglich zur Erfüllung des Vertrags dienen.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_01-01</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/9593_0113_7091_2401</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">01-01 Identifikation</IEC:langString>
+              <IEC:langString lang="EN">01-01 Identification</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_01-01</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Identifikation“ werden alle Dokumente zugeordnet, die der Identifikation des Objekts dienen, zu dem die Herstellerdokumentation gehört. Sie enthält insbesondere Informationen, die die elektronische Datenverarbeitung unterstützen und die es dem Hersteller und dem Nutzer erlauben, das Objekt in ihren jeweiligen elektronischen Datenverarbeitungssystemen zu identifizieren.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_02-01</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/5314_0113_7091_8640</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">02-01 Techn. Spezifikation</IEC:langString>
+              <IEC:langString lang="EN">02-01 Technical specification</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_02-01</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Technische Spezifikation“ werden alle Dokumente zugeordnet, die die Anforderungen an ein Objekt sowie dessen Eigenschaften beschreiben. Dazu gehören die Auslegungsdaten, Berechnungen (Verfahrenstechnik, Festigkeit usw.) sowie alle relevanten Eigenschaften des übergebenen Objekts.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_02-02</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/5515_0113_7091_8581</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">02-02 Zeichnungen, Pläne</IEC:langString>
+              <IEC:langString lang="EN">02-02 Drawings and diagrams</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_02-02</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Zeichnungen, Pläne“ werden alle Dokumente zugeordnet, die Zeichnungscharakter haben, das heißt eine grafische Darstellung zur Übermittlung von Information nutzen.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_02-03</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/0335_0113_7091_0312</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">02-03 Bauteile</IEC:langString>
+              <IEC:langString lang="EN">02-03 Components</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_02-03</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Bauteile“ werden alle Dokumente zugeordnet, die eine strukturierte Auflistung der Teile eines Objekts beinhalten.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_02-04</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/2155_0113_7091_3955</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">02-04 Zeugnisse, Zertifikate, Bescheinigungen</IEC:langString>
+              <IEC:langString lang="EN">02-04 Reports, Certificates, declarations</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_02-04</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Zeugnisse, Zertifikate, Bescheinigungen“ werden alle Dokumente zugeordnet, die Urkundencharakter haben.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_03-01</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/3565_0113_7091_2704</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">03-01 Montage, Inbetriebnahme, Demontage</IEC:langString>
+              <IEC:langString lang="EN">03-01 Assembly, commissioning, disassembly</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_03-01</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Montage, Demontage“ werden alle Dokumente zugeordnet, die Tätigkeiten und Maßnahmen beschreiben, die erforderlich sind, um ein Objekt: zu transportieren oder zu lagern, als Ganzes in ein übergeordnetes Objekt einzubauen, auszubauen oder an dieses anzuschließen, so weit vorzubereiten, dass es zur Inbetriebnahme bereitsteht, nach Abschluss der Nutzungsphase zu demontieren und zu entsorgen</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_03-02</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/4290_1113_7091_7266</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">03-02 Bedienung</IEC:langString>
+              <IEC:langString lang="EN">03-02 Operation</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_03-02</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Bedienung“ werden Dokumente zur bestimmungsgemäßen Verwendung und sicheren Bedienung eines Objekts zugeordnet.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_03-03</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/2211_1113_7091_3911</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">03-03 Allgemeine Sicherheit</IEC:langString>
+              <IEC:langString lang="EN">03-03 Safety in general</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_03-03</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Allgemeine Sicherheit“ werden Dokumente zugeordnet, die Sicherheitshinweise auf mögliche Gefährdungen bei der Verwendung des Objekts geben.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_03-04</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/7521_1113_7091_4471</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">03-04 Inspektion, Wartung, Prüfung</IEC:langString>
+              <IEC:langString lang="EN">03-04 Inspection, maintenance, test</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_03-04</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Inspektion, Wartung, Prüfung“ werden alle Dokumente zugeordnet, die vom Hersteller vorgeschlagene wiederkehrende Maßnahmen zur Feststellung oder zum Erhalt des funktionsfähigen Zustands beschreiben.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_03-05</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/5161_1113_7091_0458</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">03-05 Instandsetzung</IEC:langString>
+              <IEC:langString lang="EN">03-05 Repair</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_03-05</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Instandsetzung“ werden alle Dokumente zugeordnet, die Maßnahmen zur Wiederherstellung der Funktion eines Objekts betreffen.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_03-06</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/2181_1113_7091_5948</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">03-06 Ersatzteile</IEC:langString>
+              <IEC:langString lang="EN">03-06 Spare parts</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_03-06</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Ersatzteile“ werden Dokumente zugeordnet, die Informationen zu Ersatzteilen und Hilfs- und Betriebsstoffen enthalten.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+    <aas:conceptDescription>
+      <aas:idShort>DocCategory_04-01</aas:idShort>
+      <aas:identification idType="IRI">www.company.com/ids/cd/5391_1113_7091_8996</aas:identification>
+      <aas:embeddedDataSpecification>
+        <aas:dataSpecificationContent>
+          <aas:dataSpecificationIEC61360>
+            <IEC:preferredName>
+              <IEC:langString lang="DE">04-01 Vertragsunterlagen</IEC:langString>
+              <IEC:langString lang="EN">04-01 Contract documents</IEC:langString>
+            </IEC:preferredName>
+            <IEC:shortName>
+              <IEC:langString lang="EN?">DocCategory_04-01</IEC:langString>
+            </IEC:shortName>
+            <IEC:unit />
+            <IEC:dataType>STRING</IEC:dataType>
+            <IEC:definition>
+              <IEC:langString lang="DE">Der Kategorie „Vertragsunterlagen“ werden alle Dokumente zugeordnet, die im Zusammenhang mit der kaufmännischen Abwicklung eines Vertrages stehen, aber nicht selbst Gegenstand des Vertrags sind und lediglich zur Erfüllung des Vertrags dienen.</IEC:langString>
+              <IEC:langString lang="EN">TBD</IEC:langString>
+            </IEC:definition>
+          </aas:dataSpecificationIEC61360>
+        </aas:dataSpecificationContent>
+        <aas:dataSpecification>
+          <aas:keys>
+            <aas:key type="GlobalReference" local="false" idType="IRI">http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0</aas:key>
+          </aas:keys>
+        </aas:dataSpecification>
+      </aas:embeddedDataSpecification>
+      <aas:isCaseOf>
+        <aas:keys>
+          <aas:key type="ConceptDescription" local="true" idType="IRI">http://www.vdi.de/2770/AssetDocumentation/Document/DocumentClassification/ClassId</aas:key>
+        </aas:keys>
+      </aas:isCaseOf>
+    </aas:conceptDescription>
+  </aas:conceptDescriptions>
+</aas:aasenv>

--- a/src/AasxToolkit/Execution.cs
+++ b/src/AasxToolkit/Execution.cs
@@ -133,18 +133,22 @@ namespace AasxToolkit
                                 var recs = new AasValidationRecordList();
 
                                 string extension = Path.GetExtension(validate.Path).ToLower();
-                                if (extension == @".xml")
+                                if (extension == ".xml")
                                 {
                                     Console.Out.WriteLine($"Validating file {validate.Path} against XSD ..");
 
-                                    var stream = File.Open(validate.Path, FileMode.Open, FileAccess.Read);
-                                    AasSchemaValidation.ValidateXML(recs, stream);
+                                    using (var stream = File.Open(validate.Path, FileMode.Open, FileAccess.Read))
+                                    {
+                                        AasSchemaValidation.ValidateXML(recs, stream);
+                                    }
                                 }
                                 else if (extension == ".json")
                                 {
                                     Console.Out.WriteLine($"Validating file {validate.Path} against JSON ..");
-                                    var stream = File.Open(validate.Path, FileMode.Open, FileAccess.Read);
-                                    AasSchemaValidation.ValidateJSONAlternative(recs, stream);
+                                    using (var stream = File.Open(validate.Path, FileMode.Open, FileAccess.Read))
+                                    {
+                                        AasSchemaValidation.ValidateJSONAlternative(recs, stream);
+                                    }
                                 }
                                 else
                                 {


### PR DESCRIPTION
This patch introduces a test case that tests the command chain against
sample XML and JSON data (analogous to ValidateAAS.ps1 debug script).

Additionally, a couple of streams and files were not properly closed
(due to omitted `using` or `finally` blocks), so this patch fixes them
as well so that the tests pass.