### PR TITLE
Extend GenericForms for ZVEI Simulation Models

### DIFF
--- a/src/AasxIntegrationBase/AasxPluginInterface.cs
+++ b/src/AasxIntegrationBase/AasxPluginInterface.cs
@@ -43,6 +43,12 @@ namespace AasxIntegrationBase
         }
     }
 
+    public class AasxPluginResultGenerateSubmodel : AasxPluginResultBase
+    {
+        public AdminShell.Submodel sm;
+        public AdminShell.ListOfConceptDescriptions cds;
+    }
+
     public class AasxPluginResultEventBase : AasxPluginResultBase
     {
         public string info = null;

--- a/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -91,6 +92,14 @@ namespace AasxIntegrationBase.AasForms
                         q = qs?.FindType("PresetMimeType");
                         if (q != null && tsme is FormDescFile)
                             (tsme as FormDescFile).presetMimeType = "" + q.value;
+
+                        q = qs?.FindType("FormChoices");
+                        if (q != null && q.value.HasContent() && tsme is FormDescProperty fdprop)
+                        {
+                            var choices = q.value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                            if (choices != null && choices.Length > 0)
+                                fdprop.comboBoxChoices = choices;
+                        }
 
                         // adopt presetIdShort
                         if (tsme.Multiplicity == FormMultiplicity.ZeroToMany ||

--- a/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
@@ -24,30 +24,32 @@ namespace AasxIntegrationBase.AasForms
                 if (smw != null && smw.submodelElement != null)
                 {
                     FormDescSubmodelElement tsme = null;
-                    if (smw.submodelElement is AdminShell.Property)
+                    if (smw.submodelElement is AdminShell.Property p)
                     {
-                        var p = (smw.submodelElement as AdminShell.Property);
                         tsme = new FormDescProperty(
                             "" + p.idShort, FormMultiplicity.One, p.semanticId?.GetAsExactlyOneKey(),
                             "" + p.idShort, valueType: p.valueType);
                     }
-                    if (smw.submodelElement is AdminShell.MultiLanguageProperty)
+                    if (smw.submodelElement is AdminShell.MultiLanguageProperty mlp)
                     {
-                        var mlp = (smw.submodelElement as AdminShell.MultiLanguageProperty);
                         tsme = new FormDescMultiLangProp(
                             "" + mlp.idShort, FormMultiplicity.One, mlp.semanticId?.GetAsExactlyOneKey(),
                             "" + mlp.idShort);
                     }
-                    if (smw.submodelElement is AdminShell.File)
+                    if (smw.submodelElement is AdminShell.File fl)
                     {
-                        var mlp = (smw.submodelElement as AdminShell.File);
                         tsme = new FormDescFile(
-                            "" + mlp.idShort, FormMultiplicity.One, mlp.semanticId?.GetAsExactlyOneKey(),
-                            "" + mlp.idShort);
+                            "" + fl.idShort, FormMultiplicity.One, fl.semanticId?.GetAsExactlyOneKey(),
+                            "" + fl.idShort);
                     }
-                    if (smw.submodelElement is AdminShell.SubmodelElementCollection)
+                    if (smw.submodelElement is AdminShell.ReferenceElement rf)
                     {
-                        var smec = (smw.submodelElement as AdminShell.SubmodelElementCollection);
+                        tsme = new FormDescReferenceElement(
+                            "" + rf.idShort, FormMultiplicity.One, rf.semanticId?.GetAsExactlyOneKey(),
+                            "" + rf.idShort);
+                    }
+                    if (smw.submodelElement is AdminShell.SubmodelElementCollection smec)
+                    {
                         tsme = new FormDescSubmodelElementCollection(
                             "" + smec.idShort, FormMultiplicity.One, smec.semanticId?.GetAsExactlyOneKey(),
                             "" + smec.idShort);
@@ -158,7 +160,7 @@ namespace AasxIntegrationBase.AasForms
                     // make submodel template
                     var tsm = new FormDescSubmodel(
                         "Submodel",
-                        sm.semanticId?.GetAsExactlyOneKey(),
+                        sm.GetSemanticKey(),
                         sm.idShort,
                         "");
                     tsm.SubmodelElements = new FormDescListOfElement();

--- a/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
@@ -540,7 +540,7 @@ namespace AasxIntegrationBase.AasForms
         /// If not, the display functionality will finally care about creating them.
         /// </summary>
         public void PresetInstancesBasedOnSource(AdminShell.SubmodelElementWrapperCollection sourceElements = null)
-        {            
+        {
             if (this.PairInstances != null)
                 foreach (var pair in this.PairInstances)
                 {
@@ -552,7 +552,7 @@ namespace AasxIntegrationBase.AasForms
         /// Render the list of form elements into a list of SubmodelElements.
         /// </summary>
         public AdminShell.SubmodelElementWrapperCollection AddOrUpdateDifferentElementsToCollection(
-            AdminShell.SubmodelElementWrapperCollection elements, 
+            AdminShell.SubmodelElementWrapperCollection elements,
             AdminShellPackageEnv packageEnv = null,
             bool addFilesToPackage = false,
             bool editSource = false)
@@ -568,8 +568,8 @@ namespace AasxIntegrationBase.AasForms
 
             // SM as a set of elements
             if (this.PairInstances != null)
-            return this.PairInstances.AddOrUpdateDifferentElementsToCollection(
-                    elements, packageEnv, addFilesToPackage);
+                return this.PairInstances.AddOrUpdateDifferentElementsToCollection(
+                        elements, packageEnv, addFilesToPackage);
             return null;
         }
     }
@@ -728,7 +728,7 @@ namespace AasxIntegrationBase.AasForms
             if (this.PairInstances != null)
                 return this.PairInstances.AddOrUpdateDifferentElementsToCollection(
                     elements, packageEnv, addFilesToPackage);
-            
+
             return null;
         }
 

--- a/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
@@ -477,6 +477,16 @@ namespace AasxIntegrationBase.AasForms
 
     public class FormInstanceSubmodel : FormInstanceBase, IFormListOfDifferent
     {
+        /// <summary>
+        /// The Submodel is maintained by the instance
+        /// </summary>
+        public AdminShell.Submodel sm = null;
+
+        /// <summary>
+        /// This links to a Submodel, from which the instance was read/ edited.
+        /// </summary>
+        public AdminShell.Submodel sourceSM = null;
+
         public FormInstanceListOfDifferent PairInstances = new FormInstanceListOfDifferent();
 
         public FormInstanceSubmodel() { }
@@ -497,6 +507,28 @@ namespace AasxIntegrationBase.AasForms
             }
         }
 
+        public void InitReferable(FormDescSubmodel desc, AdminShell.Submodel source)
+        {
+            if (desc == null)
+                return;
+
+            // create sm here! (different than handling of SME!!)
+            this.sm = new AdminShell.Submodel();
+            this.sourceSM = source;
+
+            sm.idShort = desc.PresetIdShort;
+            if (source?.idShort != null)
+                sm.idShort = source.idShort;
+            sm.category = desc.PresetCategory;
+            if (desc.PresetDescription != null)
+                sm.description = new AdminShell.Description(desc.PresetDescription);
+            if (source?.description != null)
+                sm.description = new AdminShell.Description(source.description);
+
+            if (desc.KeySemanticId != null)
+                sm.semanticId = AdminShell.SemanticId.CreateFromKey(desc.KeySemanticId);
+        }
+
         public FormInstanceListOfDifferent GetListOfDifferent()
         {
             return PairInstances;
@@ -508,7 +540,7 @@ namespace AasxIntegrationBase.AasForms
         /// If not, the display functionality will finally care about creating them.
         /// </summary>
         public void PresetInstancesBasedOnSource(AdminShell.SubmodelElementWrapperCollection sourceElements = null)
-        {
+        {            
             if (this.PairInstances != null)
                 foreach (var pair in this.PairInstances)
                 {
@@ -520,11 +552,23 @@ namespace AasxIntegrationBase.AasForms
         /// Render the list of form elements into a list of SubmodelElements.
         /// </summary>
         public AdminShell.SubmodelElementWrapperCollection AddOrUpdateDifferentElementsToCollection(
-            AdminShell.SubmodelElementWrapperCollection elements, AdminShellPackageEnv packageEnv = null,
-            bool addFilesToPackage = false)
+            AdminShell.SubmodelElementWrapperCollection elements, 
+            AdminShellPackageEnv packageEnv = null,
+            bool addFilesToPackage = false,
+            bool editSource = false)
         {
+            // SM itself?
+            if (this.sm != null && Touched && this.sourceSM != null && editSource)
+            {
+                if (this.sm.idShort != null)
+                    this.sourceSM.idShort = "" + this.sm.idShort;
+                if (this.sm.description != null)
+                    this.sourceSM.description = new AdminShell.Description(this.sm.description);
+            }
+
+            // SM as a set of elements
             if (this.PairInstances != null)
-                return this.PairInstances.AddOrUpdateDifferentElementsToCollection(
+            return this.PairInstances.AddOrUpdateDifferentElementsToCollection(
                     elements, packageEnv, addFilesToPackage);
             return null;
         }
@@ -544,7 +588,7 @@ namespace AasxIntegrationBase.AasForms
 
         protected void InitReferable(FormDescSubmodelElement desc, AdminShell.SubmodelElement source)
         {
-            if (desc == null)
+            if (desc == null || sme == null)
                 return;
 
             sme.idShort = desc.PresetIdShort;
@@ -677,9 +721,14 @@ namespace AasxIntegrationBase.AasForms
             AdminShell.SubmodelElementWrapperCollection elements, AdminShellPackageEnv packageEnv = null,
             bool addFilesToPackage = false)
         {
+            // SMEC as Refrable
+            this.ProcessSmeForRender(packageEnv: null, addFilesToPackage: false, editSource: true);
+
+            // SMEC as list of items
             if (this.PairInstances != null)
                 return this.PairInstances.AddOrUpdateDifferentElementsToCollection(
                     elements, packageEnv, addFilesToPackage);
+            
             return null;
         }
 
@@ -968,7 +1017,6 @@ namespace AasxIntegrationBase.AasForms
 
     public class FormInstanceReferenceElement : FormInstanceSubmodelElement
     {
-
         public FormInstanceReferenceElement(
             FormInstanceListOfSame parentInstance, FormDescReferenceElement parentDesc,
             AdminShell.SubmodelElement source = null, bool deepCopy = false)

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml
@@ -68,26 +68,9 @@
             <TextBlock x:Name="TextBlockHeaderFormInfo" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" FontSize="10" FontWeight="Light" Margin="2,0,2,2" Text="Quite a long informative text" TextWrapping="Wrap" Foreground="DarkBlue"/>
         </Grid>
 
-        <Grid x:Name="GridIdShortDesc" Margin="4" Background="LightBlue">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="70"/>
-                <ColumnDefinition Width="48"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="24"/>
-            </Grid.ColumnDefinitions>
-
-            <TextBlock x:Name="LabelIdShort" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="idShort:"/>
-            <TextBox x:Name="TextBoxIdShort" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="2" />
-
-            <TextBlock x:Name="LabelDescription" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Description:"/>
-            <TextBlock x:Name="TextBlockInfo"  Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Text="Click '+' to add language set" Margin="2" Visibility="Visible" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-            <Button x:Name="ButtonLangPlus" Grid.Row="1" Grid.Column="3" Content="+" Margin="2" Click="Button_Click"/>
-        </Grid>
+        <local:FormSubControlReferableAttributes x:Name="TheRefAttributes" Margin="4"
+                DataContext="{Binding DataContext, RelativeSource={RelativeSource AncestorType=UserControl}}">
+        </local:FormSubControlReferableAttributes>
 
         <!-- LIST OF ELEMENTS -->
         <StackPanel x:Name="StackPanelElements" Orientation="Vertical" Visibility="Visible">

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml
@@ -68,28 +68,26 @@
             <TextBlock x:Name="TextBlockHeaderFormInfo" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" FontSize="10" FontWeight="Light" Margin="2,0,2,2" Text="Quite a long informative text" TextWrapping="Wrap" Foreground="DarkBlue"/>
         </Grid>
 
-        <!-- SMEC
-        <Grid x:Name="GridSMEC" Margin="2" Background="White" Visibility="Visible">
-
+        <Grid x:Name="GridIdShortDesc" Margin="4" Background="LightBlue">
             <Grid.RowDefinitions>
-                <RowDefinition Height="2"/>
-                <RowDefinition Height="24"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="6"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2"/>
-                <ColumnDefinition Width="24"/>
+                <ColumnDefinition Width="70"/>
+                <ColumnDefinition Width="48"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="24"/>
-                <ColumnDefinition Width="24"/>
-                <ColumnDefinition Width="2"/>
             </Grid.ColumnDefinitions>
 
-            <TextBlock x:Name="TextBlockSmecFormTitle" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Text="SubmodelElementCollection" VerticalAlignment="Center" FontSize="14" FontWeight="Bold" Foreground="DarkBlue"/>
-            <TextBlock x:Name="TextBlockSmecFormInfo" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" FontSize="10" FontWeight="Light" Margin="2,0,2,2" Text="Quite a long informative text" TextWrapping="Wrap" Foreground="DarkBlue"/>
+            <TextBlock x:Name="LabelIdShort" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="idShort:"/>
+            <TextBox x:Name="TextBoxIdShort" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="2" />
+
+            <TextBlock x:Name="LabelDescription" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Description:"/>
+            <TextBlock x:Name="TextBlockInfo"  Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Text="Click '+' to add language set" Margin="2" Visibility="Visible" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+            <Button x:Name="ButtonLangPlus" Grid.Row="1" Grid.Column="3" Content="+" Margin="2" Click="Button_Click"/>
         </Grid>
-         -->
 
         <!-- LIST OF ELEMENTS -->
         <StackPanel x:Name="StackPanelElements" Orientation="Vertical" Visibility="Visible">

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml.cs
@@ -156,41 +156,6 @@ namespace AasxIntegrationBase.AasForms
 
         // Display functionality
 
-        private void UpdateDisplayForidShortDesc(
-            FormDescReferable desc, AdminShell.Referable rf, FormInstanceBase instance)
-        {
-            // access
-            if (desc == null || rf == null || instance == null)
-            {
-                // invisible
-                GridIdShortDesc.Visibility = Visibility.Collapsed;
-                return;
-            }
-
-            // eval visibilities
-            var visiIdShort = desc.FormEditIdShort;
-            var visiDescription = desc.FormEditDescription;
-            var visiAtAll = visiIdShort || visiDescription;
-
-            // set plain fields
-            LabelIdShort.Visibility = (visiIdShort) ? Visibility.Visible : Visibility.Collapsed;
-            TextBoxIdShort.Visibility = LabelIdShort.Visibility;
-
-            TextBoxIdShort.Text = "" + rf.idShort;
-            TextBoxIdShort.TextChanged += (object sender3, TextChangedEventArgs e3) =>
-            {
-                // if (!UpdateDisplayInCharge)
-                    instance.Touch();
-                rf.idShort = TextBoxIdShort.Text;
-            };
-
-            LabelDescription.Visibility = (visiDescription) ? Visibility.Visible : Visibility.Collapsed;
-            TextBlockInfo.Visibility = LabelDescription.Visibility;
-            ButtonLangPlus.Visibility = LabelDescription.Visibility;
-
-            GridIdShortDesc.Visibility = (visiAtAll) ? Visibility.Visible : Visibility.Collapsed;
-        }
-
         private void UpdateDisplay()
         {
             // need data context of the UC coming from Submodel, SMEC or at least listOfElements
@@ -222,9 +187,6 @@ namespace AasxIntegrationBase.AasForms
                     TextBlockHeaderFormInfo.Text = dc.smDesc.FormInfo;
                 }
 
-                // IdShort / Description
-                UpdateDisplayForidShortDesc(dc.smDesc, dc.smInst.sm, dc.smInst);
-
                 // populate elements
                 foreach (var pair in dc.smInst.PairInstances)
                 {
@@ -253,9 +215,6 @@ namespace AasxIntegrationBase.AasForms
                         : dc.smecDesc.FormTitle;
                     TextBlockHeaderFormInfo.Text = dc.smecDesc.FormInfo;
                 }
-
-                // IdShort / Description
-                UpdateDisplayForidShortDesc(dc.smecDesc, dc.smecInst.sme, dc.smecInst);
 
                 // populate elements
                 foreach (var pair in dc.smecInst.PairInstances)
@@ -307,32 +266,6 @@ namespace AasxIntegrationBase.AasForms
             {
                 this.FormSmaller = !this.FormSmaller;
                 this.SetProperty(IFormListControlPropertyType.FormSmaller, this.FormSmaller);
-            }
-
-            // Plus?
-            if (sender == ButtonLangPlus)
-            {
-                // add
-                if (dc.smInst != null && dc.smInst.sm != null)
-                {
-                    if (dc.smInst.sm.description == null)
-                        dc.smInst.sm.description = new AdminShell.Description();
-
-                    dc.smInst.Touch();
-                    dc.smInst.sm.description.langString.Add(new AdminShell.LangStr("", ""));
-                }
-
-                if (dc.smecInst != null && dc.smecInst.sme != null)
-                {
-                    if (dc.smecInst.sme.description == null)
-                        dc.smecInst.sme.description = new AdminShell.Description();
-
-                    dc.smecInst.Touch();
-                    dc.smecInst.sme.description.langString.Add(new AdminShell.LangStr("", ""));
-                }
-
-                // show
-                UpdateDisplay();
             }
         }
     }

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml.cs
@@ -156,6 +156,41 @@ namespace AasxIntegrationBase.AasForms
 
         // Display functionality
 
+        private void UpdateDisplayForidShortDesc(
+            FormDescReferable desc, AdminShell.Referable rf, FormInstanceBase instance)
+        {
+            // access
+            if (desc == null || rf == null || instance == null)
+            {
+                // invisible
+                GridIdShortDesc.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            // eval visibilities
+            var visiIdShort = desc.FormEditIdShort;
+            var visiDescription = desc.FormEditDescription;
+            var visiAtAll = visiIdShort || visiDescription;
+
+            // set plain fields
+            LabelIdShort.Visibility = (visiIdShort) ? Visibility.Visible : Visibility.Collapsed;
+            TextBoxIdShort.Visibility = LabelIdShort.Visibility;
+
+            TextBoxIdShort.Text = "" + rf.idShort;
+            TextBoxIdShort.TextChanged += (object sender3, TextChangedEventArgs e3) =>
+            {
+                // if (!UpdateDisplayInCharge)
+                    instance.Touch();
+                rf.idShort = TextBoxIdShort.Text;
+            };
+
+            LabelDescription.Visibility = (visiDescription) ? Visibility.Visible : Visibility.Collapsed;
+            TextBlockInfo.Visibility = LabelDescription.Visibility;
+            ButtonLangPlus.Visibility = LabelDescription.Visibility;
+
+            GridIdShortDesc.Visibility = (visiAtAll) ? Visibility.Visible : Visibility.Collapsed;
+        }
+
         private void UpdateDisplay()
         {
             // need data context of the UC coming from Submodel, SMEC or at least listOfElements
@@ -187,6 +222,9 @@ namespace AasxIntegrationBase.AasForms
                     TextBlockHeaderFormInfo.Text = dc.smDesc.FormInfo;
                 }
 
+                // IdShort / Description
+                UpdateDisplayForidShortDesc(dc.smDesc, dc.smInst.sm, dc.smInst);
+
                 // populate elements
                 foreach (var pair in dc.smInst.PairInstances)
                 {
@@ -216,6 +254,9 @@ namespace AasxIntegrationBase.AasForms
                     TextBlockHeaderFormInfo.Text = dc.smecDesc.FormInfo;
                 }
 
+                // IdShort / Description
+                UpdateDisplayForidShortDesc(dc.smecDesc, dc.smecInst.sme, dc.smecInst);
+
                 // populate elements
                 foreach (var pair in dc.smecInst.PairInstances)
                 {
@@ -243,6 +284,11 @@ namespace AasxIntegrationBase.AasForms
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
+            // access
+            var dc = IndividualDataContext.CreateDataContext(this.DataContext);
+            if (dc == null)
+                return;
+
             if (sender == ButtonInstanceCollapse)
             {
                 // access
@@ -261,6 +307,32 @@ namespace AasxIntegrationBase.AasForms
             {
                 this.FormSmaller = !this.FormSmaller;
                 this.SetProperty(IFormListControlPropertyType.FormSmaller, this.FormSmaller);
+            }
+
+            // Plus?
+            if (sender == ButtonLangPlus)
+            {
+                // add
+                if (dc.smInst != null && dc.smInst.sm != null)
+                {
+                    if (dc.smInst.sm.description == null)
+                        dc.smInst.sm.description = new AdminShell.Description();
+
+                    dc.smInst.Touch();
+                    dc.smInst.sm.description.langString.Add(new AdminShell.LangStr("", ""));
+                }
+
+                if (dc.smecInst != null && dc.smecInst.sme != null)
+                {
+                    if (dc.smecInst.sme.description == null)
+                        dc.smecInst.sme.description = new AdminShell.Description();
+
+                    dc.smecInst.Touch();
+                    dc.smecInst.sme.description.langString.Add(new AdminShell.LangStr("", ""));
+                }
+
+                // show
+                UpdateDisplay();
             }
         }
     }

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml
@@ -1,0 +1,29 @@
+﻿<UserControl x:Class="AasxIntegrationBase.AasForms.FormSubControlReferableAttributes"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
+             mc:Ignorable="d" 
+             d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <Grid x:Name="GridAttributes" Background="LightBlue">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="70"/>
+            <ColumnDefinition Width="48"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="24"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock x:Name="LabelIdShort" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="idShort:"/>
+        <TextBox x:Name="TextBoxIdShort" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="2" />
+
+        <TextBlock x:Name="LabelDescription" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Description:"/>
+        <TextBlock x:Name="TextBlockInfo"  Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Text="Click '+' to add language set" Margin="2" Visibility="Visible" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+        <Button x:Name="ButtonLangPlus" Grid.Row="1" Grid.Column="3" Content="+" Margin="2" Click="Button_Click"/>
+    </Grid>
+</UserControl>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using AdminShellNS;
+
+namespace AasxIntegrationBase.AasForms
+{
+    /// <summary>
+    /// Interaktionslogik für FormSubControlProperty.xaml
+    /// </summary>
+    public partial class FormSubControlReferableAttributes : UserControl
+    {
+        // Members
+
+        /// <summary>
+        /// Is true while <c>UpdateDisplay</c> takes place, in order to distinguish between user updates and
+        /// program logic
+        /// </summary>
+        protected bool UpdateDisplayInCharge = false;
+
+        // Constructors & access
+
+        public class IndividualDataContext
+        {
+            public FormInstanceBase instance;
+            public FormDescReferable desc;
+            public AdminShell.Referable rf;
+
+            public static IndividualDataContext CreateDataContext(object dataContext)
+            {
+                var dc = new IndividualDataContext();
+
+                if (dataContext is FormInstanceSubmodel fism)
+                {
+                    dc.desc = fism.desc as FormDescReferable;
+                    dc.rf = fism.sm;
+                    dc.instance = fism;
+                }
+
+                if (dataContext is FormInstanceSubmodelElement fisme)
+                {
+                    dc.desc = fisme.desc as FormDescReferable;
+                    dc.rf = fisme.sme;
+                    dc.instance = fisme;
+                }
+
+                if (dc.instance == null || dc.desc == null || dc.rf == null)
+                    return null;
+                return dc;
+            }
+        }
+
+        public FormSubControlReferableAttributes()
+        {
+            InitializeComponent();
+        }
+
+        // own functionality
+
+        public void UpdateDisplay()
+        {
+            // access
+            var dc = IndividualDataContext.CreateDataContext(this.DataContext);
+            if (dc?.desc == null || dc.rf == null)
+                return;
+
+            // eval visibilities
+            var visiIdShort = dc.desc.FormEditIdShort;
+            var visiDescription = dc.desc.FormEditDescription;
+            var visiAtAll = visiIdShort || visiDescription;
+
+            // set plain fields
+            LabelIdShort.Visibility = (visiIdShort) ? Visibility.Visible : Visibility.Collapsed;
+            TextBoxIdShort.Visibility = LabelIdShort.Visibility;
+
+            TextBoxIdShort.Text = "" + dc.rf.idShort;
+            TextBoxIdShort.TextChanged += (object sender3, TextChangedEventArgs e3) =>
+            {
+                if (!UpdateDisplayInCharge)
+                    dc.instance.Touch();
+                dc.rf.idShort = TextBoxIdShort.Text;
+            };
+
+            LabelDescription.Visibility = (visiDescription) ? Visibility.Visible : Visibility.Collapsed;
+            TextBlockInfo.Visibility = LabelDescription.Visibility;
+            ButtonLangPlus.Visibility = LabelDescription.Visibility;
+
+            GridAttributes.Visibility = (visiAtAll) ? Visibility.Visible : Visibility.Collapsed;
+
+            // set flag
+            UpdateDisplayInCharge = true;
+
+            // DELETE all grid childs with ROW > 1
+            var todel = new List<UIElement>();
+            foreach (var c in GridAttributes.Children)
+                if (c is UIElement && Grid.GetRow(c as UIElement) > 1)
+                    todel.Add(c as UIElement);
+            foreach (var td in todel)
+                GridAttributes.Children.Remove(td);
+
+            // renew row definitions
+            GridAttributes.RowDefinitions.Clear();
+
+            var rd = new RowDefinition();
+            rd.Height = GridLength.Auto;
+            GridAttributes.RowDefinitions.Add(rd);
+
+            var rd2 = new RowDefinition();
+            rd2.Height = GridLength.Auto;
+            GridAttributes.RowDefinitions.Add(rd2);
+
+            // build up net grid
+            if (visiDescription)
+            {
+                int row = 2;
+                if (dc.rf.description != null && dc.rf.description.langString != null)
+                    foreach (var ls in dc.rf.description.langString)
+                    {
+                        // another row
+                        rd = new RowDefinition();
+                        rd.Height = GridLength.Auto;
+                        GridAttributes.RowDefinitions.Add(rd);
+
+                        // build lang combo
+                        var cb = new ComboBox();
+                        cb.Margin = new Thickness(2);
+                        if (FormDescMultiLangProp.DefaultLanguages != null)
+                            foreach (var l in FormDescMultiLangProp.DefaultLanguages)
+                                cb.Items.Add(l);
+                        cb.IsEditable = true;
+                        cb.Text = ls.lang;
+                        cb.SelectionChanged += (object sender2, SelectionChangedEventArgs e2) =>
+                        {
+                            if (!UpdateDisplayInCharge)
+                                dc.instance.Touch();
+                            ls.lang = "" + cb.SelectedItem;
+                        };
+                        cb.KeyUp += (object sender3, KeyEventArgs e3) =>
+                        {
+                            if (!UpdateDisplayInCharge)
+                                dc.instance.Touch();
+                            ls.lang = cb.Text;
+                        };
+
+                        Grid.SetRow(cb, row);
+                        Grid.SetColumn(cb, 1);
+                        GridAttributes.Children.Add(cb);
+
+                        // build str text
+                        var tb = new TextBox();
+                        tb.Margin = new Thickness(2);
+                        tb.Text = ls.str;
+                        tb.TextChanged += (object sender2, TextChangedEventArgs e2) =>
+                        {
+                            if (!UpdateDisplayInCharge)
+                                dc.instance.Touch();
+                            ls.str = tb.Text;
+                        };
+
+                        Grid.SetRow(tb, row);
+                        Grid.SetColumn(tb, 2);
+                        GridAttributes.Children.Add(tb);
+
+                        // build minus button
+                        var bt = new Button();
+                        bt.Margin = new Thickness(2);
+                        bt.Content = "-";
+                        var lsToDel = ls;
+                        bt.Click += (object sender3, RoutedEventArgs e3) =>
+                        {
+                            if (dc.rf?.description?.langString != null)
+                                if (dc.rf.description.langString.Contains(lsToDel))
+                                {
+                                    dc.instance.Touch();
+                                    dc.rf.description.langString.Remove(lsToDel);
+                                    UpdateDisplay();
+                                }
+                        };
+
+                        Grid.SetRow(bt, row);
+                        Grid.SetColumn(bt, 3);
+                        GridAttributes.Children.Add(bt);
+
+                        // increase the row
+                        row++;
+                    }
+            }
+
+            // release flag
+            UpdateDisplayInCharge = false;
+        }
+
+        // callbacks
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            // access
+            var dc = IndividualDataContext.CreateDataContext(this.DataContext);
+            if (dc == null)
+                return;
+
+            // Plus?
+            if (sender == ButtonLangPlus)
+            {
+                // add
+                if (dc.rf.description == null)
+                    dc.rf.description = new AdminShell.Description();
+
+                dc.instance.Touch();
+                dc.rf.description.langString.Add(new AdminShell.LangStr("", ""));
+
+                // show
+                UpdateDisplay();
+            }
+        }
+
+        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            // save data context
+            var dc = IndividualDataContext.CreateDataContext(this.DataContext);
+            if (dc == null)
+                return;
+
+            // then update
+            UpdateDisplay();
+        }
+
+    }
+}

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferenceElement.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferenceElement.xaml.cs
@@ -117,7 +117,7 @@ namespace AasxIntegrationBase.AasForms
                 {
                     // give over to event stack
                     var ev = new AasxIntegrationBase.AasxPluginResultEventSelectAasEntity();
-                    ev.filterEntities = "Entity"; //// dc.desc.presetFilter;
+                    ev.filterEntities = AdminShell.Key.AllElements;
                     ev.showAuxPackage = true;
                     ev.showRepoFiles = true;
                     topBase.outerEventStack.PushEvent(ev);

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml
@@ -6,27 +6,11 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
-    <Grid x:Name="GridOuter" Background="LightBlue" Margin="2">
-        <Grid x:Name="TheGrid" Margin="2">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="70"/>
-                <ColumnDefinition Width="48"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="24"/>
-            </Grid.ColumnDefinitions>
 
-            <TextBlock x:Name="LabelIdShort" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="idShort:"/>
-            <TextBox x:Name="TextBoxIdShort" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="2" />
+    <StackPanel>
+        <local:FormSubControlReferableAttributes x:Name="TheRefAttributes" Margin="4"
+                DataContext="{Binding DataContext, RelativeSource={RelativeSource AncestorType=UserControl}}">
+        </local:FormSubControlReferableAttributes>
+    </StackPanel>
 
-            <TextBlock x:Name="LabelDescription" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Description:"/>
-            <TextBlock x:Name="TextBlockInfo"  Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Text="Click '+' to add language set" Margin="2" Visibility="Visible" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-            <Button x:Name="ButtonLangPlus" Grid.Row="1" Grid.Column="3" Content="+" Margin="2" Click="Button_Click"/>
-
-        </Grid>
-    </Grid>
 </UserControl>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml.cs
@@ -86,7 +86,7 @@ namespace AasxIntegrationBase.AasForms
         {
             // access
             var dc = IndividualDataContext.CreateDataContext(this.DataContext);
-            // Resharper disable once
+            // Resharper disable once RedundantJumpStatement
             if (dc == null)
                 return;
         }

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml.cs
@@ -71,128 +71,11 @@ namespace AasxIntegrationBase.AasForms
             if (dc?.desc == null || dc.sme == null)
                 return;
 
-            // eval visibilities
-            var visiIdShort = dc.desc.FormEditIdShort;
-            var visiDescription = dc.desc.FormEditDescription;
-            var visiAtAll = visiIdShort || visiDescription;
-
-            // set plain fields
-            LabelIdShort.Visibility = (visiIdShort) ? Visibility.Visible : Visibility.Collapsed;
-            TextBoxIdShort.Visibility = LabelIdShort.Visibility;
-
-            TextBoxIdShort.Text = "" + dc.sme.idShort;
-            TextBoxIdShort.TextChanged += (object sender3, TextChangedEventArgs e3) =>
-            {
-                if (!UpdateDisplayInCharge)
-                    dc.instance.Touch();
-                dc.sme.idShort = TextBoxIdShort.Text;
-            };
-
-            LabelDescription.Visibility = (visiDescription) ? Visibility.Visible : Visibility.Collapsed;
-            TextBlockInfo.Visibility = LabelDescription.Visibility;
-            ButtonLangPlus.Visibility = LabelDescription.Visibility;
-
-            TheGrid.Visibility = (visiAtAll) ? Visibility.Visible : Visibility.Collapsed;
-            GridOuter.Margin = new Thickness((visiAtAll) ? 2.0 : 0.0);
-
             // set flag
             UpdateDisplayInCharge = true;
 
-            // DELETE all grid childs with ROW > 1
-            var todel = new List<UIElement>();
-            foreach (var c in TheGrid.Children)
-                if (c is UIElement && Grid.GetRow(c as UIElement) > 1)
-                    todel.Add(c as UIElement);
-            foreach (var td in todel)
-                TheGrid.Children.Remove(td);
+            // do something
 
-            // renew row definitions
-            TheGrid.RowDefinitions.Clear();
-
-            var rd = new RowDefinition();
-            rd.Height = GridLength.Auto;
-            TheGrid.RowDefinitions.Add(rd);
-
-            var rd2 = new RowDefinition();
-            rd2.Height = GridLength.Auto;
-            TheGrid.RowDefinitions.Add(rd2);
-
-            // build up net grid
-            if (visiDescription)
-            {
-                int row = 2;
-                if (dc.sme.description != null && dc.sme.description.langString != null)
-                    foreach (var ls in dc.sme.description.langString)
-                    {
-                        // another row
-                        rd = new RowDefinition();
-                        rd.Height = GridLength.Auto;
-                        TheGrid.RowDefinitions.Add(rd);
-
-                        // build lang combo
-                        var cb = new ComboBox();
-                        cb.Margin = new Thickness(2);
-                        if (FormDescMultiLangProp.DefaultLanguages != null)
-                            foreach (var l in FormDescMultiLangProp.DefaultLanguages)
-                                cb.Items.Add(l);
-                        cb.IsEditable = true;
-                        cb.Text = ls.lang;
-                        cb.SelectionChanged += (object sender2, SelectionChangedEventArgs e2) =>
-                        {
-                            if (!UpdateDisplayInCharge)
-                                dc.instance.Touch();
-                            ls.lang = "" + cb.SelectedItem;
-                        };
-                        cb.KeyUp += (object sender3, KeyEventArgs e3) =>
-                        {
-                            if (!UpdateDisplayInCharge)
-                                dc.instance.Touch();
-                            ls.lang = cb.Text;
-                        };
-
-                        Grid.SetRow(cb, row);
-                        Grid.SetColumn(cb, 1);
-                        TheGrid.Children.Add(cb);
-
-                        // build str text
-                        var tb = new TextBox();
-                        tb.Margin = new Thickness(2);
-                        tb.Text = ls.str;
-                        tb.TextChanged += (object sender2, TextChangedEventArgs e2) =>
-                        {
-                            if (!UpdateDisplayInCharge)
-                                dc.instance.Touch();
-                            ls.str = tb.Text;
-                        };
-
-                        Grid.SetRow(tb, row);
-                        Grid.SetColumn(tb, 2);
-                        TheGrid.Children.Add(tb);
-
-                        // build minus button
-                        var bt = new Button();
-                        bt.Margin = new Thickness(2);
-                        bt.Content = "-";
-                        var lsToDel = ls;
-                        bt.Click += (object sender3, RoutedEventArgs e3) =>
-                        {
-                            if (dc.sme?.description?.langString != null)
-                                if (dc.sme.description.langString.Contains(lsToDel))
-                                {
-                                    dc.instance.Touch();
-                                    dc.sme.description.langString.Remove(lsToDel);
-                                    UpdateDisplay();
-                                }
-                        };
-
-                        Grid.SetRow(bt, row);
-                        Grid.SetColumn(bt, 3);
-                        TheGrid.Children.Add(bt);
-
-                        // increase the row
-                        row++;
-                    }
-            }
 
             // release flag
             UpdateDisplayInCharge = false;
@@ -203,22 +86,9 @@ namespace AasxIntegrationBase.AasForms
         {
             // access
             var dc = IndividualDataContext.CreateDataContext(this.DataContext);
+            // Resharper disable once
             if (dc == null)
                 return;
-
-            // Plus?
-            if (sender == ButtonLangPlus)
-            {
-                // add
-                if (dc.sme.description == null)
-                    dc.sme.description = new AdminShell.Description();
-
-                dc.instance.Touch();
-                dc.sme.description.langString.Add(new AdminShell.LangStr("", ""));
-
-                // show
-                UpdateDisplay();
-            }
         }
     }
 }

--- a/src/AasxPackageExplorer/AasxPackageExplorer.csproj
+++ b/src/AasxPackageExplorer/AasxPackageExplorer.csproj
@@ -47,6 +47,9 @@
     <None Update="options.pref">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="backup\README.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="plugins\README.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/AasxPackageExplorer/qualifier-presets.json
+++ b/src/AasxPackageExplorer/qualifier-presets.json
@@ -502,5 +502,14 @@
       "value": "True",
       "valueId": null
     }
+  },
+  {
+    "name": "GenericForms plugin | FormChoices",
+    "qualifier": {
+      "semanticId": null,
+      "type": "FormChoices",
+      "value": "To be filled; multiple choices separated by semicolon ';'.",
+      "valueId": null
+    }
   }
 ]

--- a/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData.add-options.json
+++ b/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData.add-options.json
@@ -4,7 +4,7 @@
     {
       "$type": "Record",
       "FormTag": "TEC",
-      "FormTitle": "Technical data (sheet) model",
+      "FormTitle": "Technical data (sheet) model (v1.0)",
       "FormSubmodel": {
         "$type": "FormSubmodel",
         "FormTitle": "Submodel",

--- a/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData_v11.add-options.json
+++ b/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData_v11.add-options.json
@@ -4,7 +4,7 @@
     {
       "$type": "Record",
       "FormTag": "TEC",
-      "FormTitle": "Technical data (sheet) model",
+      "FormTitle": "Technical data (sheet) model (v1.1)",
       "FormSubmodel": {
         "$type": "FormSubmodel",
         "FormTitle": "Submodel",

--- a/src/AasxPluginGenericForms/GenericFormsControl.xaml.cs
+++ b/src/AasxPluginGenericForms/GenericFormsControl.xaml.cs
@@ -112,6 +112,19 @@ namespace AasxPluginGenericForms
             return shelfCntl;
         }
 
+        public void HandleEventReturn(AasxPluginEventReturnBase evtReturn)
+        {
+            if (this.currentFormInst?.subscribeForNextEventReturn != null)
+            {
+                // delete first
+                var tempLambda = this.currentFormInst.subscribeForNextEventReturn;
+                this.currentFormInst.subscribeForNextEventReturn = null;
+
+                // execute
+                tempLambda(evtReturn);
+            }
+        }
+
         private void Grid_Loaded(object sender, RoutedEventArgs e)
         {
             // user control was loaded, all options shall be set and outer grid is loaded fully ..

--- a/src/AasxPluginGenericForms/GenericFormsControl.xaml.cs
+++ b/src/AasxPluginGenericForms/GenericFormsControl.xaml.cs
@@ -163,6 +163,7 @@ namespace AasxPluginGenericForms
 
             // take over existing data
             this.currentFormInst = new FormInstanceSubmodel(currentFormRecord.FormSubmodel);
+            this.currentFormInst.InitReferable(currentFormRecord.FormSubmodel, theSubmodel);
             this.currentFormInst.PresetInstancesBasedOnSource(updateSourceElements);
             this.currentFormInst.outerEventStack = theEventStack;
 
@@ -197,7 +198,7 @@ namespace AasxPluginGenericForms
                     try
                     {
                         this.currentFormInst.AddOrUpdateDifferentElementsToCollection(
-                            currentElements, thePackage, addFilesToPackage: true);
+                            currentElements, thePackage, addFilesToPackage: true, editSource: true);
                     }
                     catch (Exception ex)
                     {

--- a/src/AasxPluginGenericForms/Plugin.cs
+++ b/src/AasxPluginGenericForms/Plugin.cs
@@ -27,6 +27,7 @@ namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
         public LogInstance Log = new LogInstance();
         private PluginEventStack eventStack = new PluginEventStack();
         private AasxPluginGenericForms.GenericFormOptions options = new AasxPluginGenericForms.GenericFormOptions();
+        private AasxPluginGenericForms.GenericFormsControl formsControl = null;
 
         public string GetPluginName()
         {
@@ -88,6 +89,8 @@ namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
             res.Add(
                 new AasxPluginActionDescriptionBase(
                     "get-events", "Pops and returns the earliest event from the event stack."));
+            res.Add(new AasxPluginActionDescriptionBase(
+                    "event-return", "Called to return a result evaluated by the host for a certain event."));
             res.Add(
                 new AasxPluginActionDescriptionBase(
                     "get-check-visual-extension", "Returns true, if plug-ins checks for visual extension."));
@@ -179,6 +182,13 @@ namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
                     return this.eventStack.PopEvent();
                 }
 
+                if (action == "event-return" && args != null
+                    && args.Length >= 1 && args[0] is AasxPluginEventReturnBase
+                    && this.formsControl != null)
+                {
+                    this.formsControl.HandleEventReturn(args[0] as AasxPluginEventReturnBase);
+                }
+
                 if (action == "get-check-visual-extension")
                 {
                     var cve = new AasxPluginResultBaseObject();
@@ -194,12 +204,12 @@ namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
                         return null;
 
                     // call
-                    var resobj = AasxPluginGenericForms.GenericFormsControl.FillWithWpfControls(
+                    this.formsControl = AasxPluginGenericForms.GenericFormsControl.FillWithWpfControls(
                         Log, args[0], args[1], this.options, this.eventStack, args[2]);
 
                     // give object back
                     var res = new AasxPluginResultBaseObject();
-                    res.obj = resobj;
+                    res.obj = this.formsControl;
                     return res;
                 }
 
@@ -216,6 +226,7 @@ namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 
                     // make result
                     var res = new AasxPluginResultBaseObject();
+                    res.strType = "OK";
                     res.obj = list;
                     return res;
                 }
@@ -240,9 +251,9 @@ namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
                     var sm = foundRec.FormSubmodel.GenerateDefault();
 
                     // make result
-                    var res = new AasxPluginResultBaseObject();
-                    res.strType = "OK";
-                    res.obj = sm;
+                    var res = new AasxPluginResultGenerateSubmodel();
+                    res.sm = sm;
+                    res.cds = foundRec.ConceptDescriptions;
                     return res;
                 }
             }


### PR DESCRIPTION
* for working group ZVEI Simulation Models
* handling of idShort for SM, SMEC implemented
* rendering of Description does still not work
* edit idShort/ Descriptions for SM, SMCs
* when creating Submodels, create
  ConceptDescriptions as well
* export FormChoices and ReferenceElements