### PR TITLE
Add RemoveBinAndObj.ps1

### DIFF
--- a/docdev/docfx_project/getting-started/continuous-integration.md
+++ b/docdev/docfx_project/getting-started/continuous-integration.md
@@ -19,6 +19,16 @@ To clean the build, call:
 .\src\BuildForDebug.ps1 -clean
 ```
 
+In cases of substantial changes to the solution (*e.g.*, conversion of the
+projects from legacy to SDK style), you need to delete `bin` and `obj` 
+subdirectories beneath `src` as dotnet (and consequently MSBuild) will not do 
+that for you. We provide a shallow script to save you a couple of 
+keystrokes:
+
+```powershell
+.\src\RemoveBinAndObj.ps1
+```
+
 ## Reformatting Code
 
 We use `dontet-format` to automatically fix the formatting of

--- a/docdev/docfx_project/getting-started/releasing.md
+++ b/docdev/docfx_project/getting-started/releasing.md
@@ -36,6 +36,16 @@ If you want to clean a previous build, call:
 
 This will produce the solution build in `artefacts/` directory.
 
+In cases of substantial changes to the solution (*e.g.*, conversion of the
+projects from legacy to SDK style), you need to delete `bin` and `obj` 
+subdirectories beneath `src` as dotnet (and consequently MSBuild) will not do 
+that for you. We provide a shallow script to save you a couple of 
+keystrokes:
+
+```powershell
+.\src\RemoveBinAndObj.ps1
+```
+
 ## Package the Release
 
 The release is now ready to be packaged. Call `PackageRelease.ps` with the

--- a/src/RemoveBinAndObj.ps1
+++ b/src/RemoveBinAndObj.ps1
@@ -1,0 +1,76 @@
+#!/usr/bin/env pwsh
+
+param(
+    [Parameter(
+            HelpMessage = "If set, deletes the directories without any prompt")]
+    [switch]
+    $Force = $false
+)
+
+<#
+.DESCRIPTION
+This script removes recursively all `bin` and `obj` directories beneath `src`
+directory.
+
+You often need to remove these directories manually in case of clean builds
+or substantial changes to the C# solution (*e.g.*, converting csproj from
+legacy to SDK style).
+#>
+
+function Main
+{
+    Set-Location $PSScriptRoot
+
+    $binDirs = Get-ChildItem `
+            -Path $PSScriptRoot `
+            -Filter "bin" `
+            -Directory `
+            -Recurse `
+            -ErrorAction SilentlyContinue `
+            -Force | ForEach-Object{ $_.FullName } |Sort-Object
+
+    $objDirs = Get-ChildItem `
+            -Path $PSScriptRoot `
+            -Filter "obj" `
+            -Directory `
+            -Recurse `
+            -ErrorAction SilentlyContinue `
+            -Force | ForEach-Object{ $_.FullName } |Sort-Object
+
+    $morituri = $binDirs + $objDirs
+
+    if (!$Force)
+    {
+        Write-Host "The following directories will be deleted:"
+        foreach ($path in $morituri)
+        {
+            Write-Host $path
+        }
+
+        Write-Host
+        Write-Host (
+        "All the temporary data (such as files temporarily copied " +
+                "for debugging etc.) will be also lost!")
+        Write-Host
+        $confirmation = Read-Host "Are you sure you want to proceed (y/n)"
+        if ($confirmation -ne 'y')
+        {
+            return
+        }
+    }
+
+    foreach($path in $morituri)
+    {
+        Write-Host "Deleting: $path"
+        Remove-Item -Path $path -Recurse -Force
+    }
+}
+
+$previousLocation = Get-Location; try
+{
+    Main
+}
+finally
+{
+    Set-Location $previousLocation
+}


### PR DESCRIPTION
This patch introduces a script to delete all `bin` and `obj` directories
in the `src` directory. This is sometimes necessary in case of
substantial solution changes (such as converting projects from legacy to
SDK style).

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.