### PR TITLE
Test asset picture in Package Explorer

### DIFF
--- a/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
+++ b/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
@@ -875,6 +875,10 @@ namespace AdminShellNS
             return res;
         }
 
+        /// <remarks>
+        /// Ensures:
+        /// <ul><li><c>result == null || result.CanRead</c></li></ul>
+        /// </remarks>
         public Stream GetLocalThumbnailStream(ref Uri thumbUri)
         {
             // access
@@ -893,13 +897,34 @@ namespace AdminShellNS
                 }
             if (thumbPart == null)
                 throw (new Exception("Unable to find AASX thumbnail. Aborting!"));
-            return thumbPart.GetStream(FileMode.Open);
+
+            var result = thumbPart.GetStream(FileMode.Open);
+
+            // Post-condition
+            if (!(result == null || result.CanRead))
+            {
+                throw new InvalidOperationException("Unexpected unreadable result stream");
+            }
+
+            return result;
         }
 
+        /// <remarks>
+        /// Ensures:
+        /// <ul><li><c>result == null || result.CanRead</c></li></ul>
+        /// </remarks>
         public Stream GetLocalThumbnailStream()
         {
             Uri dummy = null;
-            return GetLocalThumbnailStream(ref dummy);
+            var result = GetLocalThumbnailStream(ref dummy);
+
+            // Post-condition
+            if (!(result == null || result.CanRead))
+            {
+                throw new InvalidOperationException("Unexpected unreadable result stream");
+            }
+
+            return result;
         }
 
         public List<AdminShellPackageSupplementaryFile> GetListOfSupplementaryFiles()

--- a/src/AasxPackageExplorer.GuiTests/AasxPackageExplorer.GuiTests.csproj
+++ b/src/AasxPackageExplorer.GuiTests/AasxPackageExplorer.GuiTests.csproj
@@ -10,5 +10,10 @@
     <PackageReference Include="FlaUI.UIA3" Version="3.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+
+    <!-- see https://stackoverflow.com/a/38383064/1600678 -->
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup>
   </ItemGroup>
 </Project>

--- a/src/AasxPackageExplorer.GuiTests/Common.cs
+++ b/src/AasxPackageExplorer.GuiTests/Common.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using FlaUI.Core.AutomationElements;  // necessary extension for AsLabel() and other methods
+﻿using System.Linq;
+using FlaUI.Core.AutomationElements; // necessary extension for AsLabel() and other methods
 using Application = FlaUI.Core.Application;
 using Assert = NUnit.Framework.Assert;
 using AssertionException = NUnit.Framework.AssertionException;
@@ -18,7 +17,7 @@ namespace AasxPackageExplorer.GuiTests
 {
     static class Common
     {
-        public static List<string> ListAasxPaths()
+        public static string PathTo01FestoAasx()
         {
             var variable = "SAMPLE_AASX_DIR";
 
@@ -38,13 +37,14 @@ namespace AasxPackageExplorer.GuiTests
                     $"{sampleAasxDir}; did you download the samples with DownloadSamples.ps1?");
             }
 
-            var result = Directory.GetFiles(sampleAasxDir)
-                .Where(p => Path.GetExtension(p) == ".aasx")
-                .ToList();
+            var pth = Path.Combine(sampleAasxDir, "01_Festo.aasx");
 
-            result.Sort();
+            if (!File.Exists(pth))
+            {
+                throw new FileNotFoundException($"The Article-ovel sample AASX could not be found: {pth}");
+            }
 
-            return result;
+            return pth;
         }
 
 
@@ -110,7 +110,9 @@ namespace AasxPackageExplorer.GuiTests
             const string automationId = "LabelNumberErrors";
 
             var numberErrors = Retry.Find(
-                () => (application.HasExited) ? null : mainWindow.FindFirstChild(cf => cf.ByAutomationId(automationId)),
+                () => (application.HasExited)
+                    ? null
+                    : mainWindow.FindFirstChild(cf => cf.ByAutomationId(automationId)),
                 new RetrySettings { ThrowOnTimeout = true, Timeout = TimeSpan.FromSeconds(5) });
 
             Assert.IsFalse(application.HasExited,
@@ -122,7 +124,7 @@ namespace AasxPackageExplorer.GuiTests
             Assert.AreEqual("No errors", numberErrors.AsLabel().Text, "Expected no errors on startup");
         }
 
-        public static void AssertLoad(Application application, Window mainWindow, string path)
+        public static void AssertLoadAasx(Application application, Window mainWindow, string path)
         {
             if (!File.Exists(path))
             {

--- a/src/AasxPackageExplorer.sln.DotSettings
+++ b/src/AasxPackageExplorer.sln.DotSettings
@@ -166,6 +166,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dsiec/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Festo/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hoffmeister/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ovel/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Referables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=smref/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Submodel/@EntryIndexedValue">True</s:Boolean>

--- a/src/AasxPackageExplorer/MainWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MainWindow.xaml.cs
@@ -461,7 +461,7 @@ namespace AasxPackageExplorer
                         this.AssetId.Text = WpfStringAddWrapChars(
                             AdminShellUtil.EvalToNonNullString("{0}", asset.identification.id));
 
-                    // asset thumbail
+                    // asset thumbnail
                     // ReSharper disable EmptyGeneralCatchClause
                     try
                     {
@@ -469,20 +469,22 @@ namespace AasxPackageExplorer
                         if (thePackageEnv != null)
                             try
                             {
-                                var thumbStream = thePackageEnv.GetLocalThumbnailStream();
-
-                                // load image
-                                if (thumbStream != null)
+                                using (var thumbStream = thePackageEnv.GetLocalThumbnailStream())
                                 {
-                                    var bi = new BitmapImage();
-                                    bi.BeginInit();
-                                    bi.CacheOption = BitmapCacheOption.OnLoad;
-                                    bi.StreamSource = thumbStream;
-                                    bi.EndInit();
-                                    this.AssetPic.Source = bi;
-                                    // note: no closing required!
-                                }
+                                    // load image
+                                    if (thumbStream != null)
+                                    {
+                                        var bi = new BitmapImage();
+                                        bi.BeginInit();
 
+                                        // See https://stackoverflow.com/a/5346766/1600678
+                                        bi.CacheOption = BitmapCacheOption.OnLoad;
+
+                                        bi.StreamSource = thumbStream;
+                                        bi.EndInit();
+                                        this.AssetPic.Source = bi;
+                                    }
+                                }
                             }
                             catch { }
 
@@ -490,20 +492,20 @@ namespace AasxPackageExplorer
                             this.theOnlineConnection.IsConnected())
                             try
                             {
-                                var thumbStream = this.theOnlineConnection.GetThumbnailStream();
-
-                                if (thumbStream != null)
+                                using (var thumbStream = this.theOnlineConnection.GetThumbnailStream())
                                 {
-                                    var ms = new MemoryStream();
-                                    thumbStream.CopyTo(ms);
-                                    ms.Flush();
-                                    var bitmapdata = ms.ToArray();
+                                    if (thumbStream != null)
+                                    {
+                                        using (var ms = new MemoryStream())
+                                        {
+                                            thumbStream.CopyTo(ms);
+                                            ms.Flush();
+                                            var bitmapdata = ms.ToArray();
 
-                                    ms.Close();
-                                    thumbStream.Close();
-
-                                    var bi = (BitmapSource)new ImageSourceConverter().ConvertFrom(bitmapdata);
-                                    this.AssetPic.Source = bi;
+                                            var bi = (BitmapSource)new ImageSourceConverter().ConvertFrom(bitmapdata);
+                                            this.AssetPic.Source = bi;
+                                        }
+                                    }
                                 }
                             }
                             catch { }


### PR DESCRIPTION
This patch introduces a GUI test for Package Explorer which checks that
the picture of an asset is correctly loaded and shown on the main
window.

We introduced a couple of missing `using`'s and post-conditions while
the code was revisited.