### PR TITLE
Remove setup-msbuild and nuget from workflows

### DIFF
--- a/.github/workflows/build-and-package-release.yml
+++ b/.github/workflows/build-and-package-release.yml
@@ -38,14 +38,6 @@ jobs:
 
           Write-Output "::set-output name=version::$version"
 
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.0.0
-        with:
-          vs-version: 15
-
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1.0.2
-
       - name: Install .NET core
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -17,14 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.0.0
-        with:
-          vs-version: 15
-
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1.0.2
-
       - name: Install .NET core
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -23,14 +23,6 @@ jobs:
           $timestamp = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH-mm-ssZ")
           Write-Output "::set-output name=timestamp::$timestamp"
 
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.0.0
-        with:
-          vs-version: 15
-
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1.0.2
-
       - name: Install .NET core
         uses: actions/setup-dotnet@v1
         with:


### PR DESCRIPTION
Since we migrated the projects to SDK-style, we do not need to
separately install MSBuild and NuGet in GitHub workflows as
dotnet will automatically locate and use them.