### PR TITLE
Simplify OptionsInformation in Package Explorer

### DIFF
--- a/src/AasxPackageExplorer.GuiTests/Test.cs
+++ b/src/AasxPackageExplorer.GuiTests/Test.cs
@@ -95,7 +95,7 @@ namespace AasxPackageExplorer.GuiTests
                     assetPic.BoundingRectangle.Width <= 1)
                 {
                     throw new AssertionException(
-                        "The assert picture has unexpected dimensions: " +
+                        "The asset picture has unexpected dimensions: " +
                         $"width is {assetPic.BoundingRectangle.Width} and " +
                         $"height is {assetPic.BoundingRectangle.Height}");
                 }

--- a/src/AasxPackageExplorer.Tests/TestOptionsAndPlugins.cs
+++ b/src/AasxPackageExplorer.Tests/TestOptionsAndPlugins.cs
@@ -129,6 +129,18 @@ namespace AasxPackageExplorer.Tests
         }
 
         [Test]
+        public void TestPluginsArePassedArguments()
+        {
+            var optionsInformation = App.InferOptions(
+                "NonExistingAasxPackageExplorer.exe",
+                new[] { "-p", "-something", "-dll", "ACME-plugins\\AasxSomeACMEPlugin.dll" });
+
+            Assert.AreEqual(1, optionsInformation.PluginDll.Count);
+            Assert.AreEqual("ACME-plugins\\AasxSomeACMEPlugin.dll", optionsInformation.PluginDll[0].Path);
+            Assert.That(optionsInformation.PluginDll[0].Args, Is.EquivalentTo(new[] { "-something" }));
+        }
+
+        [Test]
         public void TestPluginsAreSearchedInPluginsDirectory()
         {
             using (var tmpDir = new TemporaryDirectory())
@@ -148,6 +160,15 @@ namespace AasxPackageExplorer.Tests
                 Assert.AreEqual(null, pluginDllInfos[0].DefaultOptions);
                 Assert.AreEqual(pluginPath, pluginDllInfos[0].Path);
             }
+        }
+
+        [Test]
+        public void TestThatSplashTimeIsSet()
+        {
+            var optionsInformation = App.InferOptions(
+                "NonExistingAasxPackageExplorer.exe", new[] { "-splash", "1984" });
+
+            Assert.AreEqual(1984, optionsInformation.SplashTime);
         }
     }
 

--- a/src/AasxPackageExplorer/AboutBox.xaml.cs
+++ b/src/AasxPackageExplorer/AboutBox.xaml.cs
@@ -27,8 +27,11 @@ namespace AasxPackageExplorer
 {
     public partial class AboutBox : Window
     {
-        public AboutBox()
+        private readonly Pref _pref;
+
+        public AboutBox(Pref pref)
         {
+            _pref = pref;
             InitializeComponent();
         }
 
@@ -37,12 +40,12 @@ namespace AasxPackageExplorer
             // HEADER
             this.HeaderText.Text = "AASX Package Explorer\n" +
                 "Copyright (c) 2018-2020 Festo AG & Co. KG and further (see below)\n" +
-                "Authors: " + Options.Curr.PrefAuthors + " (see below)\n" +
+                "Authors: " + _pref.Authors + " (see below)\n" +
                 "This software is licensed under the Apache License 2.0 (see below)" + "\n" +
-                "Version: " + Options.Curr.PrefVersion + "\n" +
-                "Build date: " + Options.Curr.PrefBuildDate;
+                "Version: " + _pref.Version + "\n" +
+                "Build date: " + _pref.BuildDate;
 
-            this.InfoBox.Text = "[AasxPackageExplorer]" + Environment.NewLine + Options.Curr.PrefLicenseLong;
+            this.InfoBox.Text = "[AasxPackageExplorer]" + Environment.NewLine + _pref.LicenseLong;
 
             // try to include plug-ins as well
             var lic = Plugins.CompileAllLicenses();

--- a/src/AasxPackageExplorer/App.xaml.cs
+++ b/src/AasxPackageExplorer/App.xaml.cs
@@ -125,7 +125,6 @@ namespace AasxPackageExplorer
                 Options.Curr.PluginDll.AddRange(pluginDllInfos);
             }
 
-
             Log.Info($"Loading and activating {Options.Curr.PluginDll.Count} plugin(s)...");
             Plugins.LoadedPlugins = LoadAndActivatePlugins(Options.Curr.PluginDll);
 
@@ -163,15 +162,17 @@ namespace AasxPackageExplorer
                 }
             }
 
+            Pref pref = Pref.Read();
+
             // show splash (required for licenses of open source)
             if (Options.Curr.SplashTime != 0)
             {
-                var splash = new CustomSplashScreenNew();
+                var splash = new CustomSplashScreenNew(pref);
                 splash.Show();
             }
 
             // show main window
-            MainWindow wnd = new MainWindow();
+            MainWindow wnd = new MainWindow(pref);
             wnd.Show();
         }
     }

--- a/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
+++ b/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
@@ -5,7 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
-        Title="AASX Package Explorer Splash Screen" Width="650" Height="350" Background="White" WindowStyle="None" WindowStartupLocation="CenterScreen" Topmost="True" MouseDown="Image_MouseDown">
+        Title="AASX Package Explorer Splash Screen" Width="650" Height="350" Background="White" WindowStyle="None"
+        WindowStartupLocation="CenterScreen" Topmost="True" MouseDown="Window_MouseDown">
     <!--
     Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
     Author: Michael Hoffmeister
@@ -27,7 +28,7 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-        
+
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
@@ -59,7 +60,7 @@
                     <TextBlock x:Name="TextBlockVersion">Unknown version</TextBlock>
                     <TextBlock x:Name="TextBlockBuildDate">Unknown build date!</TextBlock>
                 </StackPanel>
-                
+
             </Grid>
 
         </Border>

--- a/src/AasxPackageExplorer/CustomSplashScreenNew.xaml.cs
+++ b/src/AasxPackageExplorer/CustomSplashScreenNew.xaml.cs
@@ -28,14 +28,14 @@ namespace AasxPackageExplorer
 {
     public partial class CustomSplashScreenNew : Window
     {
-        public CustomSplashScreenNew()
+        public CustomSplashScreenNew(Pref pref)
         {
             InitializeComponent();
 
             // set new values here
-            this.TextBlockAuthors.Text = Options.Curr.PrefAuthors;
-            this.TextBlockLicenses.Text = Options.Curr.PrefLicenseShort;
-            this.TextBlockVersion.Text = Options.Curr.PrefVersion;
+            this.TextBlockAuthors.Text = pref.Authors;
+            this.TextBlockLicenses.Text = pref.LicenseShort;
+            this.TextBlockVersion.Text = pref.Version;
             this.TextBlockBuildDate.Text = "";
 
             // try to include plug-ins as well
@@ -53,7 +53,7 @@ namespace AasxPackageExplorer
             };
         }
 
-        private void Image_MouseDown(object sender, MouseButtonEventArgs e)
+        private void Window_MouseDown(object sender, MouseButtonEventArgs e)
         {
             this.Close();
         }

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -39,24 +39,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-/*
-Copyright (c) 2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-Copyright (c) 2019 Phoenix Contact GmbH & Co. KG <>
-Author: Andreas Orzelski
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
-
 namespace AasxPackageExplorer
 {
     /// <summary>
@@ -109,6 +91,7 @@ namespace AasxPackageExplorer
             {
                 throw new ArgumentNullException($"Unexpected null {nameof(cmd)}");
             }
+
             if (cmd == "new")
             {
                 if (MessageBoxResult.Yes == MessageBoxFlyoutShow(
@@ -139,6 +122,7 @@ namespace AasxPackageExplorer
                 dlg.Filter =
                     "AASX package files (*.aasx)|*.aasx|AAS XML file (*.xml)|*.xml|" +
                     "AAS JSON file (*.json)|*.json|All files (*.*)|*.*";
+
                 if (Options.Curr.UseFlyovers) this.StartFlyover(new EmptyFlyout());
                 var res = dlg.ShowDialog();
                 if (Options.Curr.UseFlyovers) this.CloseFlyover();
@@ -399,7 +383,7 @@ namespace AasxPackageExplorer
 
             if (cmd == "about")
             {
-                var ab = new AboutBox();
+                var ab = new AboutBox(_pref);
                 ab.ShowDialog();
             }
 

--- a/src/AasxPackageExplorer/MainWindow.xaml
+++ b/src/AasxPackageExplorer/MainWindow.xaml
@@ -7,8 +7,8 @@
         xmlns:local="clr-namespace:AasxPackageExplorer;assembly=AasxWpfControlLibrary"
         mc:Ignorable="d"
         x:Name="mainWindow"
-        Title="AASX Package Explorer" Height="350" Width="700" Loaded="Window_Loaded" AllowDrop="True" 
-        DragEnter="Window_DragEnter" Drop="Window_Drop" Closing="Window_Closing" SizeChanged="Window_SizeChanged" 
+        Title="AASX Package Explorer" Height="350" Width="700" Loaded="Window_Loaded" AllowDrop="True"
+        DragEnter="Window_DragEnter" Drop="Window_Drop" Closing="Window_Closing" SizeChanged="Window_SizeChanged"
         PreviewKeyDown="mainWindow_PreviewKeyDown" >
     <!--
     Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
@@ -19,9 +19,9 @@
     This source code may use other Open Source software components (see LICENSE.txt).
     -->
 
-        <!-- TODO: fix again -->
+    <!-- TODO: fix again -->
     <!-- ReSharper disable Xaml.MissingGridIndex -->
-    
+
     <Window.Resources>
         <RoutedUICommand x:Key="New" Text="New" />
         <RoutedUICommand x:Key="Open" Text="Open" />
@@ -333,7 +333,7 @@
                             <MenuItem Header="Import CSV-file into SubModel .." Command="{StaticResource CSVImport}"/>
                             <MenuItem Header="Import AAS from i4aas-nodeset .." Command="{StaticResource OPCUAi4aasImport}"/>
                             <MenuItem Header="Import OPC UA nodeset.xml as Submodel .." Command="{StaticResource OpcUaImportNodeSet}"/>
-                            <MenuItem Header="Read OPC values into SubModel .." Command="{StaticResource OPCRead}"/>                            
+                            <MenuItem Header="Read OPC values into SubModel .." Command="{StaticResource OPCRead}"/>
                         </MenuItem>
                         <MenuItem Header="Export ..">
                             <MenuItem Header="Export AutomationML .." Command="{StaticResource ExportAML}"/>
@@ -378,7 +378,7 @@
                     </MenuItem>
                 </Menu>
 
-                <local:VisualElementHistoryControl Grid.Column="2" x:Name="ButtonHistory" Margin="2" Width="50" 
+                <local:VisualElementHistoryControl Grid.Column="2" x:Name="ButtonHistory" Margin="2" Width="50"
                         VisualElementRequested="ButtonHistory_ObjectRequested"
                         HomeRequested="ButtonHistory_HomeRequested"/>
 
@@ -443,14 +443,14 @@
                     <ColumnDefinition Width="250" />
                 </Grid.ColumnDefinitions>
 
-                <GridSplitter HorizontalAlignment="Right" 
-                      VerticalAlignment="Stretch" 
+                <GridSplitter HorizontalAlignment="Right"
+                      VerticalAlignment="Stretch"
                       Grid.Column="1" ResizeBehavior="PreviousAndNext"
                       Grid.Row="0"
                       Width="5" Background="#FFBCBCBC"/>
 
-                <GridSplitter HorizontalAlignment="Right" 
-                      VerticalAlignment="Stretch" 
+                <GridSplitter HorizontalAlignment="Right"
+                      VerticalAlignment="Stretch"
                       Grid.Column="3" ResizeBehavior="PreviousAndNext"
                       Grid.Row="0"
                       Width="5" Background="#FFBCBCBC"/>
@@ -468,8 +468,8 @@
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
-                    <GridSplitter HorizontalAlignment="Stretch" 
-                      VerticalAlignment="Top" 
+                    <GridSplitter HorizontalAlignment="Stretch"
+                      VerticalAlignment="Top"
                       Grid.Row="1" Grid.Column="0"
                       ResizeBehavior="PreviousAndNext"
                       Height="5" Background="#FFBCBCBC"/>
@@ -491,7 +491,7 @@
                     </Viewbox>
 
                     <local:AasxFileRepoControl x:Name="RepoControl" Grid.Row="2" Grid.Column="0" AllowDrop="True" Drop="RepoControl_Drop">
-                        
+
                     </local:AasxFileRepoControl>
 
                 </Grid>
@@ -575,7 +575,12 @@
             <DockPanel Grid.Row="3" Margin="0,2,0,0">
                 <Button x:Name="ButtonReport" DockPanel.Dock="Right" Margin="6,3,2,2" Padding="2,0,2,0" Click="ButtonReport_Click">Report ..</Button>
                 <Button x:Name="ButtonClear" DockPanel.Dock="Right" Margin="6,3,2,2" Padding="2,0,2,0" Click="ButtonReport_Click">Clear</Button>
-                <Label x:Name="LabelNumberErrors" DockPanel.Dock="Right" MinWidth="60" Margin="6,3,2,2" Padding="2,0,2,0" VerticalContentAlignment="Center" BorderBrush="LightGray" BorderThickness="1" Content="No errors"/>
+
+                <Label x:Name="LabelNumberErrors"
+                       DockPanel.Dock="Right" MinWidth="60" Margin="6,3,2,2" Padding="2,0,2,0"
+                       VerticalContentAlignment="Center" BorderBrush="LightGray" BorderThickness="1"
+                       Content="No errors"/>
+
                 <Label x:Name="Message" VerticalContentAlignment="Center"></Label>
             </DockPanel>
 
@@ -583,7 +588,7 @@
 
         <!--
         <local:SelectFromRepository Grid.Row="0" Grid.Column="0" Width="Auto" Height="Auto" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch">
-            
+
         </local:SelectFromRepository>
         -->
 

--- a/src/AasxPackageExplorer/MainWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MainWindow.xaml.cs
@@ -31,6 +31,12 @@ namespace AasxPackageExplorer
 {
     public partial class MainWindow : Window, IFlyoutProvider
     {
+        #region Dependencies
+        // (mristin, 2020-11-18): consider injecting OptionsInformation, Package environment *etc.* to the main window
+        // to make it traceable and testable.
+        private readonly Pref _pref;
+        #endregion
+
         #region Members
         // ============
 
@@ -48,8 +54,9 @@ namespace AasxPackageExplorer
         #region Init Component
         //====================
 
-        public MainWindow()
+        public MainWindow(Pref pref)
         {
+            _pref = pref;
             InitializeComponent();
         }
 
@@ -241,7 +248,7 @@ namespace AasxPackageExplorer
         }
 
         /// <summary>
-        /// Using the currently loaded AASX, will check if a CD_AasxLoadedNavigateTo elements can be 
+        /// Using the currently loaded AASX, will check if a CD_AasxLoadedNavigateTo elements can be
         /// found to be activated
         /// </summary>
         public bool UiCheckIfActivateLoadedNavTo()
@@ -1203,7 +1210,16 @@ namespace AasxPackageExplorer
             var cmd = ruic.Text?.Trim().ToLower();
 
             // see: MainWindow.CommandBindings.cs
-            this.CommandBinding_GeneralDispatch(cmd);
+            try
+            {
+                this.CommandBinding_GeneralDispatch(cmd);
+            }
+            catch (Exception err)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to execute the command {cmd}: {err}");
+            }
+
         }
 
 

--- a/src/AasxWpfControlLibrary/Options.cs
+++ b/src/AasxWpfControlLibrary/Options.cs
@@ -79,105 +79,6 @@ namespace AasxPackageExplorer
     public class OptionsInformation
     {
         /// <summary>
-        /// The authors of the application. Use of Options as singleton.
-        /// </summary>
-        [JsonIgnore]
-        public string PrefAuthors = "Michael Hoffmeister, Andreas Orzelski and further";
-
-        /// <summary>
-        /// The current (used) licenses of the application. Use of Options as singleton.
-        /// </summary>
-        [JsonIgnore]
-        public string PrefLicenseShort =
-            "This software is licensed under the Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
-            "The Newtonsoft.JSON serialization is licensed under the MIT License (MIT)." + Environment.NewLine +
-            "The QR code generation is licensed under the MIT license (MIT)." + Environment.NewLine +
-            "The Zxing.Net Dot Matrix Code (DMC) generation is licensed " +
-            "under the Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
-            "The Grapevine REST server framework is licensed " +
-            "under the Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
-            "The AutomationML.Engine is licensed under the MIT license (MIT)." +
-            "The MQTT server and client is licensed " +
-            "under the MIT license (MIT)." + Environment.NewLine +
-            "The IdentityModel OpenID client is licensed " +
-            "under the Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
-            "The jose-jwt object signing and encryption is licensed " +
-            "under the MIT license (MIT).";
-
-        /// <summary>
-        /// The last build date of the application. Based on a resource file. Use of Options as singleton.
-        /// </summary>
-        [JsonIgnore]
-        public string PrefBuildDate
-        {
-            get
-            {
-                using (var stream =
-                    Assembly
-                        .GetExecutingAssembly()
-                        .GetManifestResourceStream("AasxWpfControlLibrary.Resources.BuildDate.txt"))
-                {
-                    if (stream != null)
-                    {
-                        TextReader tr = new StreamReader(stream);
-                        string fileContents = tr.ReadToEnd();
-                        if (fileContents.Length > 20)
-                            fileContents = fileContents.Substring(0, 20) + "..";
-                        return (fileContents.Trim());
-                    }
-                }
-                return "";
-            }
-        }
-
-        /// <summary>
-        /// The license texts of the application. Based on a resource file. Use of Options as singleton.
-        /// </summary>
-        [JsonIgnore]
-        public string PrefLicenseLong
-        {
-            get
-            {
-                return AasxPluginHelper.LoadLicenseTxtFromAssemblyDir("LICENSE.txt", Assembly.GetEntryAssembly());
-            }
-        }
-
-        /// <summary>
-        /// The current version string of the application. Use of Options as singleton.
-        /// Note: in the past, there was a semantic version such as "1.9.8.3", but
-        /// this was not maintained properly. Now, a version is derived from the
-        /// build data with the intention, that the according tag in Github-Releases
-        /// will be identical.
-        /// </summary>
-        [JsonIgnore]
-        public string PrefVersion
-        {
-            get
-            {
-                var bdate = "" + PrefBuildDate;
-                var version = "(not available)";
-
-                // %date% in European format (e.g. during development)
-                var m = Regex.Match(bdate, @"(\d+)\.(\d+)\.(\d+)");
-                if (m.Success && m.Groups.Count >= 4)
-                    version = "v" + ((m.Groups[3].Value.Length == 2) ? "20" : "")
-                        + m.Groups[3].Value + "-"
-                        + m.Groups[2].Value + "-"
-                        + m.Groups[1].Value;
-
-                // %date% in US local (e.g. from continous integration from Github)
-                m = Regex.Match(bdate, @"(\d+)\/(\d+)\/(\d+)");
-                if (m.Success && m.Groups.Count >= 4)
-                    version = "v" + ((m.Groups[3].Value.Length == 2) ? "20" : "")
-                        + m.Groups[3].Value + "-"
-                        + m.Groups[1].Value + "-"
-                        + m.Groups[2].Value;
-
-                return version;
-            }
-        }
-
-        /// <summary>
         /// This file shall be loaded at start of application
         /// </summary>
         [SettableOption]
@@ -341,22 +242,15 @@ namespace AasxPackageExplorer
 
         /// <summary>
         /// For such operations as query repository, do load a new AASX file without
-        /// prmpting the user.
+        /// prompting the user.
         /// </summary>
         public bool LoadWithoutPrompt = false;
 
         /// <summary>
-        /// Point to a list of SecureConnectPresets for the respective dialogie
+        /// Point to a list of SecureConnectPresets for the respective dialogue
         /// </summary>
         [JetBrains.Annotations.UsedImplicitly]
         public Newtonsoft.Json.Linq.JToken SecureConnectPresets;
-
-        /// <summary>
-        /// Contains a list of strings which shall be handled over to plugins.
-        /// New: only for internal use, will be found in the DllInfos
-        /// </summary>
-        [JsonIgnore]
-        private List<string> PluginArgs = new List<string>();
 
         public class PluginDllInfo
         {
@@ -384,6 +278,8 @@ namespace AasxPackageExplorer
         /// </summary>
         [SettableOption]
         public List<PluginDllInfo> PluginDll = new List<PluginDllInfo>();
+
+
 
         /// <summary>
         /// Will save options to a file. Catches exceptions.
@@ -420,6 +316,9 @@ namespace AasxPackageExplorer
 
         public static void ParseArgs(string[] args, OptionsInformation optionsInformation)
         {
+            // This is a sweep line for plugin arguments.
+            var pluginArgs = new List<string>();
+
             for (int index = 0; index < args.Length; index++)
             {
                 var arg = args[index].Trim().ToLower();
@@ -625,19 +524,20 @@ namespace AasxPackageExplorer
                     continue;
                 }
 
-                // (temporary) options for plugins and DLL path
+                // Sweep-line options for plugins and DLL path
                 if (arg == "-p" && morearg > 0)
                 {
-                    // Add exactly one following argument to the plugin list
-                    optionsInformation.PluginArgs.Add(args[index + 1]);
+                    // Add exactly one following argument to the sweep line of plugin arguments
+                    pluginArgs.Add(args[index + 1]);
                     index += 1;
                     continue;
                 }
                 if (arg == "-dll" && morearg > 0)
                 {
+                    // Process and reset the sweep line
                     optionsInformation.PluginDll.Add(
-                        new PluginDllInfo(args[index + 1], optionsInformation.PluginArgs.ToArray()));
-                    optionsInformation.PluginArgs.Clear();
+                        new PluginDllInfo(args[index + 1], pluginArgs.ToArray()));
+                    pluginArgs.Clear();
                     index++;
                     continue;
                 }

--- a/src/AasxWpfControlLibrary/Pref.cs
+++ b/src/AasxWpfControlLibrary/Pref.cs
@@ -1,0 +1,129 @@
+﻿/*
+Copyright (c) 2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using AasxPluginHelper = AasxIntegrationBase.AasxPluginHelper;
+using Assembly = System.Reflection.Assembly;
+using Environment = System.Environment;
+using Regex = System.Text.RegularExpressions.Regex;
+using StreamReader = System.IO.StreamReader;
+using TextReader = System.IO.TextReader;
+
+namespace AasxPackageExplorer
+{
+    /// <summary>
+    /// Information about the application.
+    /// </summary>
+    public class Pref
+    {
+        public readonly string Authors;
+
+        /// <summary>
+        /// The current (used) licenses of the application.
+        /// </summary>
+        public readonly string LicenseShort;
+
+        /// <summary>
+        /// The last build date of the application.
+        /// </summary>
+        public readonly string BuildDate;
+
+        /// <summary>
+        /// The full license texts of the application.
+        /// </summary>
+        public readonly string LicenseLong;
+
+        /// <summary>
+        /// The current version string of the application.
+        /// Note: in the past, there was a semantic version such as "1.9.8.3", but
+        /// this was not maintained properly. Now, a version is derived from the
+        /// build data with the intention, that the according tag in Github-Releases
+        /// will be identical.
+        /// </summary>
+        public readonly string Version;
+
+        public Pref(string authors, string licenseShort, string buildDate, string licenseLong, string version)
+        {
+            Authors = authors;
+            LicenseShort = licenseShort;
+            BuildDate = buildDate;
+            LicenseLong = licenseLong;
+            Version = version;
+        }
+
+        /// <summary>
+        /// Reads the necessary resources from the system and produces the author, license, build and version
+        /// information about the application.
+        /// </summary>
+        /// <returns>relevant information about the application</returns>
+        public static Pref Read()
+        {
+            string authors = "Michael Hoffmeister, Andreas Orzelski et al.";
+
+            string licenseShort =
+                "This software is licensed under the Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
+                "The Newtonsoft.JSON serialization is licensed under the MIT License (MIT)." + Environment.NewLine +
+                "The QR code generation is licensed under the MIT license (MIT)." + Environment.NewLine +
+                "The Zxing.Net Dot Matrix Code (DMC) generation is licensed " +
+                "under the Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
+                "The Grapevine REST server framework is licensed " +
+                "under the Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
+                "The AutomationML.Engine is licensed under the MIT license (MIT)." +
+                "The MQTT server and client is licensed " +
+                "under the MIT license (MIT)." + Environment.NewLine +
+                "The IdentityModel OpenID client is licensed " +
+                "under the Apache License 2.0 (Apache-2.0)." + Environment.NewLine +
+                "The jose-jwt object signing and encryption is licensed " +
+                "under the MIT license (MIT).";
+
+            string buildDate = "";
+            using (var stream =
+                Assembly
+                    .GetExecutingAssembly()
+                    .GetManifestResourceStream("AasxWpfControlLibrary.Resources.BuildDate.txt"))
+            {
+                if (stream != null)
+                {
+                    TextReader tr = new StreamReader(stream);
+                    string fileContents = tr.ReadToEnd();
+                    if (fileContents.Length > 20)
+                        fileContents = fileContents.Substring(0, 20) + "..";
+                    buildDate = fileContents.Trim();
+                }
+            }
+
+            string licenseLong = AasxPluginHelper.LoadLicenseTxtFromAssemblyDir(
+                "LICENSE.txt", Assembly.GetEntryAssembly());
+
+            string version = "(not available)";
+            {
+                // %date% in European format (e.g. during development)
+                var m = Regex.Match(buildDate, @"(\d+)\.(\d+)\.(\d+)");
+                if (m.Success && m.Groups.Count >= 4)
+                {
+                    version = "v" + ((m.Groups[3].Value.Length == 2) ? "20" : "")
+                                  + m.Groups[3].Value + "-"
+                                  + m.Groups[2].Value + "-"
+                                  + m.Groups[1].Value;
+                }
+                else
+                {
+                    // %date% in US local (e.g. from continuous integration from Github)
+                    m = Regex.Match(buildDate, @"(\d+)\/(\d+)\/(\d+)");
+                    if (m.Success && m.Groups.Count >= 4)
+                        version = "v" + ((m.Groups[3].Value.Length == 2) ? "20" : "")
+                                      + m.Groups[3].Value + "-"
+                                      + m.Groups[1].Value + "-"
+                                      + m.Groups[2].Value;
+                }
+            }
+
+            return new Pref(authors, licenseShort, buildDate, licenseLong, version);
+        }
+    }
+}


### PR DESCRIPTION
There were multiple legacy options that were actually not inferred in
Package Explorer.

This patch moves them out of `OptionsInformation` class. The internal
parsing data is moved to the corresponding function, while author,
version and license information is moved to a separate class `Pref`.

Finally, two GUI tests check that the change in the logic does not break
the application.