### PR TITLE
Test Explorer's splash screen and About dialogue

### DIFF
--- a/src/AasxPackageExplorer.GuiTests/AasxPackageExplorer.GuiTests.csproj
+++ b/src/AasxPackageExplorer.GuiTests/AasxPackageExplorer.GuiTests.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net461</TargetFramework>
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FlaUI.UIA3" Version="3.2.0" />

--- a/src/AasxPackageExplorer/App.xaml.cs
+++ b/src/AasxPackageExplorer/App.xaml.cs
@@ -170,8 +170,11 @@ namespace AasxPackageExplorer
             }
 
             // show splash (required for licenses of open source)
-            var splash = new CustomSplashScreenNew();
-            splash.Show();
+            if (Options.Curr.SplashTime != 0)
+            {
+                var splash = new CustomSplashScreenNew();
+                splash.Show();
+            }
 
             // show main window
             MainWindow wnd = new MainWindow();

--- a/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
+++ b/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
-        Title="CustomSplashScreenNew" Width="650" Height="350" Background="White" WindowStyle="None" WindowStartupLocation="CenterScreen" Topmost="True" MouseDown="Image_MouseDown">
+        Title="AASX Package Explorer Splash Screen" Width="650" Height="350" Background="White" WindowStyle="None" WindowStartupLocation="CenterScreen" Topmost="True" MouseDown="Image_MouseDown">
 
     <!-- -->    
     


### PR DESCRIPTION
This patch allows the splash screen to be completely ignored in the GUI
tests except for the one test where it is explicitly tested.
This speeds up the tests substantially.

Additionally, to test for the similar logic (authors, version *etc.*),
this patch tests "About" dialogue.