### PR TITLE
Specify path for GUI test results

### DIFF
--- a/src/TestGui.ps1
+++ b/src/TestGui.ps1
@@ -123,6 +123,8 @@ function Main
     $env:SAMPLE_AASX_DIR = $samplesDir
     $env:AASX_PACKAGE_EXPLORER_RELEASE_DIR = $TargetDir
 
+    $testResultsPath = Join-Path $artefactsDir "GuiTestResults.xml"
+
     Push-Location
     try
     {
@@ -133,12 +135,14 @@ function Main
         {
             & $nunit3Console `
                 --stoponerror `
+                --result=$testResultsPath `
                 $absTestDlls
         }
         else
         {
             & $nunit3Console `
                 --test=$Test `
+                --result=$testResultsPath `
                 --stoponerror `
                 $absTestDlls
         }


### PR DESCRIPTION
We specify explicitly a path to a file in `artefacts` directory so that
the developer can inspect (or send by e-mail *etc.*) the test results in
XML.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.