### PR TITLE
Add "export" to additional commit verbs

### DIFF
--- a/src/AdditionalVerbsInImperativeMood.txt
+++ b/src/AdditionalVerbsInImperativeMood.txt
@@ -16,3 +16,4 @@ enhance
 untrack
 refine
 dispatch
+export


### PR DESCRIPTION
The current version (2.2.0) of the commit message checker lacked
"export" in its whitelist of verbs in imperative mood. This patch adds
the verb to the additional whitelist specific to this project.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.