### PR TITLE
Make `*.cs` and `*.xaml` headers uniform

### DIFF
--- a/src/AasxAmlImExport/AasAmlMatcher.cs
+++ b/src/AasxAmlImExport/AasAmlMatcher.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxAmlImExport/AmlConst.cs
+++ b/src/AasxAmlImExport/AmlConst.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxAmlImExport/AmlExport.cs
+++ b/src/AasxAmlImExport/AmlExport.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -9,24 +18,6 @@ using AasxIntegrationBase;
 using AdminShellNS;
 using Aml.Engine.AmlObjects;
 using Aml.Engine.CAEX;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-
-The AutomationML.Engine is under the MIT license.
-(see https://raw.githubusercontent.com/AutomationML/AMLEngine2.1/master/license.txt)
-*/
 
 namespace AasxAmlImExport
 {

--- a/src/AasxAmlImExport/AmlImport.cs
+++ b/src/AasxAmlImExport/AmlImport.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,23 +17,6 @@ using AasxIntegrationBase;
 using AdminShellNS;
 using Aml.Engine.CAEX;
 
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-
-The AutomationML.Engine is under the MIT license.
-(see https://raw.githubusercontent.com/AutomationML/AMLEngine2.1/master/license.txt)
-*/
 
 namespace AasxAmlImExport
 {

--- a/src/AasxCsharpLibrary.Tests/DocTestAdminShellUtil.cs
+++ b/src/AasxCsharpLibrary.Tests/DocTestAdminShellUtil.cs
@@ -8,55 +8,55 @@ namespace AdminShellNS.Tests
     public class DocTest_AdminShellUtil_cs
     {
         [Test]
-        public void AtLine31AndColumn12()
+        public void AtLine40AndColumn12()
         {
             Assert.AreEqual("someName", AdminShellUtil.FilterFriendlyName("someName"));
         }
 
         [Test]
-        public void AtLine32AndColumn12()
+        public void AtLine41AndColumn12()
         {
             Assert.AreEqual("some__name", AdminShellUtil.FilterFriendlyName("some!;name"));
         }
 
         [Test]
-        public void AtLine42AndColumn12()
+        public void AtLine51AndColumn12()
         {
             Assert.IsFalse(AdminShellUtil.HasWhitespace(""));
         }
 
         [Test]
-        public void AtLine43AndColumn12()
+        public void AtLine52AndColumn12()
         {
             Assert.IsTrue(AdminShellUtil.HasWhitespace(" "));
         }
 
         [Test]
-        public void AtLine44AndColumn12()
+        public void AtLine53AndColumn12()
         {
             Assert.IsTrue(AdminShellUtil.HasWhitespace("aa bb"));
         }
 
         [Test]
-        public void AtLine45AndColumn12()
+        public void AtLine54AndColumn12()
         {
             Assert.IsTrue(AdminShellUtil.HasWhitespace(" aabb"));
         }
 
         [Test]
-        public void AtLine46AndColumn12()
+        public void AtLine55AndColumn12()
         {
             Assert.IsTrue(AdminShellUtil.HasWhitespace("aabb "));
         }
 
         [Test]
-        public void AtLine47AndColumn12()
+        public void AtLine56AndColumn12()
         {
             Assert.IsFalse(AdminShellUtil.HasWhitespace("aabb"));
         }
 
         [Test]
-        public void AtLine59AndColumn12()
+        public void AtLine68AndColumn12()
         {
             Assert.IsTrue(AdminShellUtil.ComplyIdShort(""));
         }

--- a/src/AasxCsharpLibrary/AasxCompatibilityModels/V10/AdminShellV10.cs
+++ b/src/AasxCsharpLibrary/AasxCompatibilityModels/V10/AdminShellV10.cs
@@ -1,3 +1,12 @@
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -11,21 +20,6 @@ using System.Xml;
 using System.Xml.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 // ReSharper disable All .. as this is legacy code!
 

--- a/src/AasxCsharpLibrary/AdminShell.cs
+++ b/src/AasxCsharpLibrary/AdminShell.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -14,21 +23,6 @@ using System.Xml;
 using System.Xml.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AdminShellNS
 {

--- a/src/AasxCsharpLibrary/AdminShellCollections.cs
+++ b/src/AasxCsharpLibrary/AdminShellCollections.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxCsharpLibrary/AdminShellConverters.cs
+++ b/src/AasxCsharpLibrary/AdminShellConverters.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
+++ b/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Packaging;

--- a/src/AasxCsharpLibrary/AdminShellUtil.cs
+++ b/src/AasxCsharpLibrary/AdminShellUtil.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;

--- a/src/AasxCsharpLibrary/AdminShellValidate.cs
+++ b/src/AasxCsharpLibrary/AdminShellValidate.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.IO;

--- a/src/AasxCsharpLibrary/IAasxOnlineConnection.cs
+++ b/src/AasxCsharpLibrary/IAasxOnlineConnection.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxDictionaryImport/Cdd/Data.cs
+++ b/src/AasxDictionaryImport/Cdd/Data.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Cdd/Importer.cs
+++ b/src/AasxDictionaryImport/Cdd/Importer.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Cdd/Model.cs
+++ b/src/AasxDictionaryImport/Cdd/Model.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Cdd/Parser.cs
+++ b/src/AasxDictionaryImport/Cdd/Parser.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/ElementDetailsDialog.xaml
+++ b/src/AasxDictionaryImport/ElementDetailsDialog.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxDictionaryImport"
              mc:Ignorable="d"
              MinWidth="300" MinHeight="200" SizeToContent="WidthAndHeight">
+    <!--
+    Copyright (c) 2020 SICK AG <info@sick.de>
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <DockPanel Margin="5" LastChildFill="False">
         <Grid x:Name="Grid" DockPanel.Dock="Top" VerticalAlignment="Stretch">
             <Grid.ColumnDefinitions>

--- a/src/AasxDictionaryImport/ElementDetailsDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ElementDetailsDialog.xaml.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Iec61360Utils.cs
+++ b/src/AasxDictionaryImport/Iec61360Utils.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Import.cs
+++ b/src/AasxDictionaryImport/Import.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/ImportDialog.xaml
+++ b/src/AasxDictionaryImport/ImportDialog.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxDictionaryImport"
              mc:Ignorable="d" 
              Title="Dictionary Import" Width="1000" Height="500" MinWidth="550" MinHeight="200">
+    <!--
+    Copyright (c) 2020 SICK AG <info@sick.de>
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Model.cs
+++ b/src/AasxDictionaryImport/Model.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxIntegrationBase/AasxLanguageHelper.cs
+++ b/src/AasxIntegrationBase/AasxLanguageHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBase/AasxPluginHelper.cs
+++ b/src/AasxIntegrationBase/AasxPluginHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxIntegrationBase/AasxPluginInterface.cs
+++ b/src/AasxIntegrationBase/AasxPluginInterface.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBase/AasxPluginOptionsBase.cs
+++ b/src/AasxIntegrationBase/AasxPluginOptionsBase.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxIntegrationBase/Extensions.cs
+++ b/src/AasxIntegrationBase/Extensions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBase/LogInstance.cs
+++ b/src/AasxIntegrationBase/LogInstance.cs
@@ -1,20 +1,18 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
- */
 
 namespace AasxIntegrationBase
 {

--- a/src/AasxIntegrationBase/MinimalLogger.cs
+++ b/src/AasxIntegrationBase/MinimalLogger.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBase/PluginEventStack.cs
+++ b/src/AasxIntegrationBase/PluginEventStack.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="250" d:DesignWidth="500" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <StackPanel x:Name="OutPanel" Orientation="Vertical" Background="#e8e8e8">
 
         <StackPanel.Resources>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfSameControl.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfSameControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="250" d:DesignWidth="500" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid x:Name="GridOuterElement" Background="#e8e8e8">
 
         <!-- Here, the different control controls are being defined -->

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfSameControl.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfSameControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlFile.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlFile.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid>
             <Grid.RowDefinitions>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlFile.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlFile.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlMultiLangProp.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlMultiLangProp.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid x:Name="TheGrid">
             <Grid.RowDefinitions>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlMultiLangProp.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlMultiLangProp.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlProperty.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlProperty.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid>
             <Grid.RowDefinitions>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlProperty.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlProperty.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid x:Name="GridAttributes" Background="LightBlue">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferenceElement.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferenceElement.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid>
             <Grid.RowDefinitions>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferenceElement.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferenceElement.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml
@@ -6,6 +6,14 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <StackPanel>
         <local:FormSubControlReferableAttributes x:Name="TheRefAttributes" Margin="4"

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEC.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEC.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid>
             <Grid.RowDefinitions>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEC.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEC.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/IFormListControl.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/IFormListControl.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasxPluginOptionSerialization.cs
+++ b/src/AasxIntegrationBaseWpf/AasxPluginOptionSerialization.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxIntegrationBaseWpf/AasxWpfBaseUtils.cs
+++ b/src/AasxIntegrationBaseWpf/AasxWpfBaseUtils.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml
+++ b/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml
@@ -6,13 +6,14 @@
              xmlns:local="clr-namespace:AasxIntegrationBase"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,21 +24,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxIntegrationBase
 {

--- a/src/AasxIntegrationBaseWpf/IFlyoutControl.cs
+++ b/src/AasxIntegrationBaseWpf/IFlyoutControl.cs
@@ -1,24 +1,18 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxIntegrationBase
 {

--- a/src/AasxIntegrationBaseWpf/IFlyoutProvider.cs
+++ b/src/AasxIntegrationBaseWpf/IFlyoutProvider.cs
@@ -1,25 +1,19 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxIntegrationBase
 {

--- a/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml
+++ b/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,21 +24,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxIntegrationBase
 {

--- a/src/AasxIntegrationBaseWpf/Resources/Graphics.xaml
+++ b/src/AasxIntegrationBaseWpf/Resources/Graphics.xaml
@@ -1,12 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxIntegrationBase">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Viewbox x:Key="IconDelete" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Stretch="Uniform">
         <Canvas Width="1000" Height="1000">

--- a/src/AasxIntegrationBaseWpf/Themes/Generic.xaml
+++ b/src/AasxIntegrationBaseWpf/Themes/Generic.xaml
@@ -1,9 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxIntegrationBase">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
--->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Style x:Key="TranspRoundCorner" TargetType="{x:Type Button}">
         <Setter Property="HorizontalContentAlignment" Value="Center"/>

--- a/src/AasxIntegrationBaseWpf/WpfViewmodelBase.cs
+++ b/src/AasxIntegrationBaseWpf/WpfViewmodelBase.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/src/AasxIntegrationEmptySample/Plugin.cs
+++ b/src/AasxIntegrationEmptySample/Plugin.cs
@@ -1,15 +1,18 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxMqtt/MqttServer.cs
+++ b/src/AasxMqtt/MqttServer.cs
@@ -1,17 +1,27 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+Copyright (c) 2019 Phoenix Contact GmbH & Co. KG <opensource@phoenixcontact.com>
+Author: Andreas Orzelski
+
+Copyright (c) 2019 Fraunhofer IOSB-INA Lemgo,
+    eine rechtlich nicht selbständige Einrichtung der Fraunhofer-Gesellschaft
+    zur Förderung der angewandten Forschung e.V. <florian.pethig@iosb-ina.fraunhofer.de>
+Author: Florian Pethig
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using MQTTnet;
 using MQTTnet.Server;
-
-/* For Mqtt Content:
-
-MIT License
-
-MQTTnet Copyright (c) 2016-2019 Christian Kratky
-*/
 
 namespace AasxMqttServer
 {

--- a/src/AasxMqtt/Plugin.cs
+++ b/src/AasxMqtt/Plugin.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AasxMqttServer;
-using JetBrains.Annotations;
-
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -18,10 +10,18 @@ Copyright (c) 2019 Fraunhofer IOSB-INA Lemgo,
     zur Förderung der angewandten Forschung e.V. <florian.pethig@iosb-ina.fraunhofer.de>
 Author: Florian Pethig
 
-For Mqtt Content: MIT License
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-MQTTnet Copyright (c) 2016-2019 Christian Kratky
+This source code may use other Open Source software components (see LICENSE.txt).
 */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AasxMqttServer;
+using JetBrains.Annotations;
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxMqttClient/GrapevineLoggerConsumers.cs
+++ b/src/AasxMqttClient/GrapevineLoggerConsumers.cs
@@ -1,26 +1,19 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Grapevine.Interfaces.Shared;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 /*
 Please notice: the API and REST routes implemented in this version of the source code are not specified and

--- a/src/AasxMqttClient/MqttClient.cs
+++ b/src/AasxMqttClient/MqttClient.cs
@@ -1,14 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AdminShellNS;
-using MQTTnet;
-using MQTTnet.Client;
-using MQTTnet.Client.Options;
-
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -20,12 +10,20 @@ Copyright (c) 2019 Fraunhofer IOSB-INA Lemgo,
     zur Förderung der angewandten Forschung e.V. <florian.pethig@iosb-ina.fraunhofer.de>
 Author: Florian Pethig
 
-For Mqtt Content:
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-MIT License
-
-MQTTnet Copyright (c) 2016-2019 Christian Kratky
+This source code may use other Open Source software components (see LICENSE.txt).
 */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AdminShellNS;
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Client.Options;
 
 namespace AasxMqttClient
 {

--- a/src/AasxOpenidClient/ConsoleExtensions.cs
+++ b/src/AasxOpenidClient/ConsoleExtensions.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Diagnostics;
-
-/*
+﻿/*
 Copyright (c) 2020 see https://github.com/IdentityServer/IdentityServer4
 
 We adapted the code marginally and removed the parts that we do not use.
 */
+
+using System;
+using System.Diagnostics;
 
 // ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
 

--- a/src/AasxOpenidClient/Constants.cs
+++ b/src/AasxOpenidClient/Constants.cs
@@ -1,10 +1,10 @@
-﻿// ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
-
-/*
+﻿/*
 Copyright (c) 2020 see https://github.com/IdentityServer/IdentityServer4
 
 We adapted the code marginally and removed the parts that we do not use.
 */
+
+// ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
 
 namespace AasxOpenIdClient
 {

--- a/src/AasxPackageExplorer/AboutBox.xaml
+++ b/src/AasxPackageExplorer/AboutBox.xaml
@@ -6,13 +6,15 @@
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
         Title="About" Height="500" Width="600" Loaded="Window_Loaded" MinWidth="150">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
- <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
-    
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="100"/>

--- a/src/AasxPackageExplorer/AboutBox.xaml.cs
+++ b/src/AasxPackageExplorer/AboutBox.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -13,21 +22,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxPackageExplorer/App.xaml
+++ b/src/AasxPackageExplorer/App.xaml
@@ -3,12 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:AasxPackageExplorer"             
              Startup="Application_Startup">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Application.Resources>
         <!--OZ, UT: external dictionary for theme colors-->

--- a/src/AasxPackageExplorer/App.xaml.cs
+++ b/src/AasxPackageExplorer/App.xaml.cs
@@ -1,22 +1,16 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Windows;
-using AasxGlobalLogging;
-
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
+This source code may use other Open Source software components (see LICENSE.txt).
 */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Windows;
+using AasxGlobalLogging;
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxPackageExplorer/BrowserContainer.cs
+++ b/src/AasxPackageExplorer/BrowserContainer.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;

--- a/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
+++ b/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
@@ -6,15 +6,17 @@
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
         Title="AASX Package Explorer Splash Screen" Width="650" Height="350" Background="White" WindowStyle="None" WindowStartupLocation="CenterScreen" Topmost="True" MouseDown="Image_MouseDown">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- -->    
     
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
-
     <Grid>
 
         <Border Margin="4" BorderBrush="{DynamicResource DarkestAccentColor}" BorderThickness="2" Padding="4">

--- a/src/AasxPackageExplorer/CustomSplashScreenNew.xaml.cs
+++ b/src/AasxPackageExplorer/CustomSplashScreenNew.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,21 +23,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using System.Windows.Threading;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -1,3 +1,15 @@
+/*
+Copyright (c) 2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+Copyright (c) 2019 Phoenix Contact GmbH & Co. KG <>
+Author: Andreas Orzelski
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/AasxPackageExplorer/MainWindow.xaml
+++ b/src/AasxPackageExplorer/MainWindow.xaml
@@ -10,14 +10,16 @@
         Title="AASX Package Explorer" Height="350" Width="700" Loaded="Window_Loaded" AllowDrop="True" 
         DragEnter="Window_DragEnter" Drop="Window_Drop" Closing="Window_Closing" SizeChanged="Window_SizeChanged" 
         PreviewKeyDown="mainWindow_PreviewKeyDown" >
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-    <!-- TODO: fix again -->
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
+        <!-- TODO: fix again -->
     <!-- ReSharper disable Xaml.MissingGridIndex -->
     
     <Window.Resources>

--- a/src/AasxPackageExplorer/MainWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MainWindow.xaml.cs
@@ -1,4 +1,12 @@
-﻿
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -18,21 +26,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AasxWpfControlLibrary;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxPackageExplorer/MessageReportWindow.xaml
+++ b/src/AasxPackageExplorer/MessageReportWindow.xaml
@@ -6,12 +6,14 @@
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
         Title="Message Report" Height="600" Width="800">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Grid>
         <Grid.RowDefinitions>

--- a/src/AasxPackageExplorer/MessageReportWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MessageReportWindow.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,21 +22,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using AasxGlobalLogging;
 using AasxIntegrationBase;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxPackageExplorer/Themes/Brandlabel.xaml
+++ b/src/AasxPackageExplorer/Themes/Brandlabel.xaml
@@ -1,6 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxPackageExplorer" xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- -->
 

--- a/src/AasxPackageExplorer/Themes/Generic.xaml
+++ b/src/AasxPackageExplorer/Themes/Generic.xaml
@@ -2,6 +2,14 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:AasxPackageExplorer;assembly=AasxWpfControlLibrary">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- ReSharper disable Xaml.PathError -->
     

--- a/src/AasxPluginAdvancedTextEditor/AdvancedTextEditOptions.cs
+++ b/src/AasxPluginAdvancedTextEditor/AdvancedTextEditOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginAdvancedTextEditor/Plugin.cs
+++ b/src/AasxPluginAdvancedTextEditor/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -10,15 +19,6 @@ using System.Windows.Controls;
 using AasxPluginAdvancedTextEditor;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The AvalonEdit component, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginAdvancedTextEditor/UserControlAdvancedTextEditor.xaml
+++ b/src/AasxPluginAdvancedTextEditor/UserControlAdvancedTextEditor.xaml
@@ -8,6 +8,15 @@
              xmlns:local="clr-namespace:AasxPluginAdvancedTextEditor"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <DockPanel>
         <ToolBar DockPanel.Dock="Top">
             <ToolBar.Resources>

--- a/src/AasxPluginAdvancedTextEditor/UserControlAdvancedTextEditor.xaml.cs
+++ b/src/AasxPluginAdvancedTextEditor/UserControlAdvancedTextEditor.xaml.cs
@@ -1,3 +1,12 @@
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/AasxPluginBomStructure/AasReferenceStore.cs
+++ b/src/AasxPluginBomStructure/AasReferenceStore.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;

--- a/src/AasxPluginBomStructure/BomStructureOptions.cs
+++ b/src/AasxPluginBomStructure/BomStructureOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginBomStructure/GenericBomControl.cs
+++ b/src/AasxPluginBomStructure/GenericBomControl.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,14 +17,6 @@ using System.Windows.Controls;
 using AasxIntegrationBase;
 using AdminShellNS;
 
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 namespace AasxPluginBomStructure
 {
     public class GenericBomCreator

--- a/src/AasxPluginBomStructure/Plugin.cs
+++ b/src/AasxPluginBomStructure/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,15 +16,6 @@ using System.Text;
 using System.Threading.Tasks;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginDocumentShelf/DocumentEntity.cs
+++ b/src/AasxPluginDocumentShelf/DocumentEntity.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginDocumentShelf/DocumentShelfOptions.cs
+++ b/src/AasxPluginDocumentShelf/DocumentShelfOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxPluginDocumentShelf/EnumBooleanConverter.cs
+++ b/src/AasxPluginDocumentShelf/EnumBooleanConverter.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginDocumentShelf/Plugin.cs
+++ b/src/AasxPluginDocumentShelf/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,15 +16,6 @@ using System.Text;
 using System.Threading.Tasks;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginDocumentShelf/ShelfControl.xaml
+++ b/src/AasxPluginDocumentShelf/ShelfControl.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxPluginDocumentShelf"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="500">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- There seems to be an issue to load the CountryFlag.dll for the Relase version of the binaries in XAML-->
     <!-- Solution: do everything in code behind -->

--- a/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
+++ b/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/AasxPluginDocumentShelf/ShelfItemBar.xaml
+++ b/src/AasxPluginDocumentShelf/ShelfItemBar.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxPluginDocumentShelf"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- There seems to be an issue to load the CountryFlag.dll for the Relase version of the binaries in XAML-->
     <!-- xmlns:cf="clr-namespace:CountryFlag;assembly=CountryFlag" -->

--- a/src/AasxPluginDocumentShelf/ShelfItemBar.xaml.cs
+++ b/src/AasxPluginDocumentShelf/ShelfItemBar.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginDocumentShelf/ShelfItemGrid.xaml
+++ b/src/AasxPluginDocumentShelf/ShelfItemGrid.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxPluginDocumentShelf"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- There seems to be an issue to load the CountryFlag.dll for the Relase version of the binaries in XAML-->
     <!-- xmlns:cf="clr-namespace:CountryFlag;assembly=CountryFlag" -->

--- a/src/AasxPluginDocumentShelf/ShelfItemGrid.xaml.cs
+++ b/src/AasxPluginDocumentShelf/ShelfItemGrid.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginExportTable/ExportTableFlyout.xaml
+++ b/src/AasxPluginExportTable/ExportTableFlyout.xaml
@@ -7,13 +7,14 @@
              x:Class="AasxPluginExportTable.ExportTableFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxPluginExportTable/ExportTableFlyout.xaml.cs
+++ b/src/AasxPluginExportTable/ExportTableFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -19,21 +28,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPluginExportTable
 {

--- a/src/AasxPluginExportTable/ExportTableOptions.cs
+++ b/src/AasxPluginExportTable/ExportTableOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginExportTable/ExportTableRecord.cs
+++ b/src/AasxPluginExportTable/ExportTableRecord.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxPluginExportTable/Plugin.cs
+++ b/src/AasxPluginExportTable/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,15 +18,6 @@ using System.Windows;
 using AasxPluginExportTable;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginExportTable/Themes/Generic.xaml
+++ b/src/AasxPluginExportTable/Themes/Generic.xaml
@@ -1,10 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxPluginExportTable">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The OpenXML SDK is under MIT license. 
--->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Style x:Key="TranspRoundCorner" TargetType="{x:Type Button}">
         <Setter Property="HorizontalContentAlignment" Value="Center"/>

--- a/src/AasxPluginGenericForms/GenericFormsControl.xaml
+++ b/src/AasxPluginGenericForms/GenericFormsControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxPluginGenericForms"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="400">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <TabControl x:Name="OuterTabControl">
         <TabItem x:Name="TabPanelEdit" Visibility="Collapsed">
             <Grid Background="#e8e8e8" Loaded="Grid_Loaded">

--- a/src/AasxPluginGenericForms/GenericFormsControl.xaml.cs
+++ b/src/AasxPluginGenericForms/GenericFormsControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/AasxPluginGenericForms/GenericFormsOptions.cs
+++ b/src/AasxPluginGenericForms/GenericFormsOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxPluginGenericForms/Plugin.cs
+++ b/src/AasxPluginGenericForms/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,15 +17,6 @@ using System.Threading.Tasks;
 using AdminShellNS;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginImageMap/ImageMapControl.xaml
+++ b/src/AasxPluginImageMap/ImageMapControl.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxPluginImageMap"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="400">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- There seems to be an issue to load the CountryFlag.dll for the Relase version of the binaries in XAML-->
     <!-- Solution: do everything in code behind -->

--- a/src/AasxPluginImageMap/ImageMapControl.xaml.cs
+++ b/src/AasxPluginImageMap/ImageMapControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/AasxPluginImageMap/ImageMapOptions.cs
+++ b/src/AasxPluginImageMap/ImageMapOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginImageMap/Plugin.cs
+++ b/src/AasxPluginImageMap/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,10 +16,6 @@ using System.Text;
 using System.Threading.Tasks;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, 
- * author: Michael Hoffmeister
- */
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginMtpViewer/MtpViewerOptions.cs
+++ b/src/AasxPluginMtpViewer/MtpViewerOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginMtpViewer/Plugin.cs
+++ b/src/AasxPluginMtpViewer/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,10 +16,6 @@ using System.Text;
 using System.Threading.Tasks;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, 
- * author: Michael Hoffmeister
- */
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml
+++ b/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:WpfMtpControl;assembly=WpfMtpControl"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml.cs
+++ b/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginTechnicalData/PimpedPaginator.cs
+++ b/src/AasxPluginTechnicalData/PimpedPaginator.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/AasxPluginTechnicalData/Plugin.cs
+++ b/src/AasxPluginTechnicalData/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,15 +17,6 @@ using System.Threading.Tasks;
 using System.Windows.Controls;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginTechnicalData/TechDataFooterControl.xaml
+++ b/src/AasxPluginTechnicalData/TechDataFooterControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxPluginTechnicalData"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="600">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/src/AasxPluginTechnicalData/TechDataFooterControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechDataFooterControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginTechnicalData/TechDataHeaderControl.xaml
+++ b/src/AasxPluginTechnicalData/TechDataHeaderControl.xaml
@@ -6,7 +6,15 @@
              xmlns:local="clr-namespace:AasxPluginTechnicalData"
              mc:Ignorable="d" 
              d:DesignHeight="180" d:DesignWidth="600">
-    
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <!-- Not sure, if binding can be improved -->
     <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
     

--- a/src/AasxPluginTechnicalData/TechDataHeaderControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechDataHeaderControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginTechnicalData/TechDataPropertiesControl.xaml
+++ b/src/AasxPluginTechnicalData/TechDataPropertiesControl.xaml
@@ -7,6 +7,14 @@
              xmlns:doc="clr-namespace:System.Windows.Documents;assembly=PresentationFramework"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="600">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- styles declared for use in code -->
     <!-- ReSharper disable Xaml.RedundantResource -->

--- a/src/AasxPluginTechnicalData/TechDataPropertiesControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechDataPropertiesControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginTechnicalData/TechnicalDataOptions.cs
+++ b/src/AasxPluginTechnicalData/TechnicalDataOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml
+++ b/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxPluginTechnicalData"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="40"/>

--- a/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginUaNetClient/ExitCode.cs
+++ b/src/AasxPluginUaNetClient/ExitCode.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginUaNetClient/Plugin.cs
+++ b/src/AasxPluginUaNetClient/Plugin.cs
@@ -1,17 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>,
+Author: Michael Hoffmeister.
 
-/* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, 
- * author: Michael Hoffmeister.
- * Copyright (c) 2019 Phoenix Contact GmbH & Co. KG <>, author: Andreas Orzelski
-*/
+Copyright (c) 2019 Phoenix Contact GmbH & Co. KG <>
+Author: Andreas Orzelski
 
-/* For OPC Content
+For OPC Content:
 
 Copyright (c) 1996-2016, OPC Foundation. All rights reserved.
 The source code in this file is covered under a dual-license scenario:
@@ -24,6 +18,14 @@ This source code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE
 */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginUaNetServer/Plugin.cs
+++ b/src/AasxPluginUaNetServer/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,10 +21,6 @@ using AdminShellNS;
 using Opc.Ua;
 using Opc.Ua.Configuration;
 using Opc.Ua.Server;
-
-/* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, 
- * author: Michael Hoffmeister.
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginWebBrowser/Plugin.cs
+++ b/src/AasxPluginWebBrowser/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,15 +18,6 @@ using System.Windows;
 using System.Windows.Controls;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginWebBrowser/Themes/Generic.xaml
+++ b/src/AasxPluginWebBrowser/Themes/Generic.xaml
@@ -2,4 +2,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:AasxPluginWebBrowser">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
 </ResourceDictionary>

--- a/src/AasxPluginWebBrowser/WebBrowserOptions.cs
+++ b/src/AasxPluginWebBrowser/WebBrowserOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/AasxDefinitionBase.cs
+++ b/src/AasxPredefinedConcepts/AasxDefinitionBase.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxPredefinedConcepts/ConceptModel/ConceptModelZveiTechnicalData.cs
+++ b/src/AasxPredefinedConcepts/ConceptModel/ConceptModelZveiTechnicalData.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertDocumentationHsuToSg2.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertDocumentationHsuToSg2.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToHsu.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToHsu.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToV11.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToV11.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertPredefinedConcepts.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertPredefinedConcepts.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataToFlat.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataToFlat.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataV10ToV11.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataV10ToV11.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsExperimental.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsExperimental.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsImageMap.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsImageMap.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsLanguages.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsLanguages.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsMTP.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsMTP.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsPool.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsPool.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Authentication.ExtendedProtection;

--- a/src/AasxPredefinedConcepts/DefinitionsV2770v11.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsV2770v11.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/AasxPredefinedConcepts/DefinitionsVDI2770.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsVDI2770.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsZveiDigitalTypeplate.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsZveiDigitalTypeplate.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalData.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalData.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalDataV11.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalDataV11.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/AasxPredefinedConcepts/ExportPredefinedConcepts.cs
+++ b/src/AasxPredefinedConcepts/ExportPredefinedConcepts.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxPredefinedConcepts/PackageExplorer.cs
+++ b/src/AasxPredefinedConcepts/PackageExplorer.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxRestConsoleServer/Program.cs
+++ b/src/AasxRestConsoleServer/Program.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxRestServerLibrary/AasxHttpContextHelper.cs
+++ b/src/AasxRestServerLibrary/AasxHttpContextHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Globalization;
@@ -16,22 +25,6 @@ using Grapevine.Server.Attributes;
 using Grapevine.Shared;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 /*
 Please notice:

--- a/src/AasxRestServerLibrary/AasxHttpHandleStore.cs
+++ b/src/AasxRestServerLibrary/AasxHttpHandleStore.cs
@@ -1,26 +1,19 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 /*
 Please notice:

--- a/src/AasxRestServerLibrary/AasxRestClient.cs
+++ b/src/AasxRestServerLibrary/AasxRestClient.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxRestServerLibrary/AasxRestServer.cs
+++ b/src/AasxRestServerLibrary/AasxRestServer.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -13,22 +22,6 @@ using Grapevine.Server;
 using Grapevine.Server.Attributes;
 using Grapevine.Shared;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 /*
 Please notice:

--- a/src/AasxRestServerLibrary/GrapevineLoggerConsumers.cs
+++ b/src/AasxRestServerLibrary/GrapevineLoggerConsumers.cs
@@ -1,25 +1,18 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Grapevine.Interfaces.Shared;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 /*
 Please notice:

--- a/src/AasxSignature/AasxSignature.cs
+++ b/src/AasxSignature/AasxSignature.cs
@@ -1,9 +1,14 @@
-﻿/* Copyright(c) 2020 Schneider Electric Automation GmbH <marco.mendes@se.com>, author: Marco Mendes */
+﻿/*
+Copyright(c) 2020 Schneider Electric Automation GmbH <marco.mendes@se.com>
+Author: Marco Mendes
 
-/*
 This file has been shortened to include only the features needed by AASX Package Explorer.
 The original file is available at: obsolete/2020-07-20/AasxLibrary/AasxLibrary.cs
- */
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 using System;
 using System.Collections.Generic;

--- a/src/AasxToolkit.Tests/DocTestCli.cs
+++ b/src/AasxToolkit.Tests/DocTestCli.cs
@@ -8,26 +8,26 @@ namespace AasxToolkit.Tests
     public class DocTest_Cli_cs
     {
         [Test]
-        public void AtLine189AndColumn16()
+        public void AtLine198AndColumn16()
         {
             Assert.AreEqual("", Cli.Indentation.Indent("", "  "));
         }
 
         [Test]
-        public void AtLine190AndColumn16()
+        public void AtLine199AndColumn16()
         {
             Assert.AreEqual("  test", Cli.Indentation.Indent("test", "  "));
         }
 
         [Test]
-        public void AtLine191AndColumn16()
+        public void AtLine200AndColumn16()
         {
             var nl = System.Environment.NewLine;
             Assert.AreEqual($"  test{nl}  me", Cli.Indentation.Indent("test\nme", "  "));
         }
 
         [Test]
-        public void AtLine195AndColumn16()
+        public void AtLine204AndColumn16()
         {
             var nl = System.Environment.NewLine;
             Assert.AreEqual($"  test{nl}  me", Cli.Indentation.Indent("test\r\nme", "  "));

--- a/src/AasxToolkit/Cli.cs
+++ b/src/AasxToolkit/Cli.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ArgumentException = System.ArgumentException;

--- a/src/AasxToolkit/Execution.cs
+++ b/src/AasxToolkit/Execution.cs
@@ -1,4 +1,13 @@
-﻿using System.Collections.Generic;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System.Collections.Generic;
 using AasFormUtils = AasxIntegrationBase.AasForms.AasFormUtils;
 using AasSchemaValidation = AdminShellNS.AasSchemaValidation;
 using AasValidationRecordList = AdminShellNS.AasValidationRecordList;

--- a/src/AasxToolkit/Generate.cs
+++ b/src/AasxToolkit/Generate.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;

--- a/src/AasxToolkit/Instruction.cs
+++ b/src/AasxToolkit/Instruction.cs
@@ -1,4 +1,13 @@
-﻿namespace AasxToolkit.Instruction
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+namespace AasxToolkit.Instruction
 {
     /// <summary>
     /// Represents a single instruction to the program.

--- a/src/AasxToolkit/Log.cs
+++ b/src/AasxToolkit/Log.cs
@@ -1,21 +1,15 @@
-using System;
-using System.IO;
-using System.Text;
-
 /*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
+This source code may use other Open Source software components (see LICENSE.txt).
 */
+
+using System;
+using System.IO;
+using System.Text;
 
 namespace AasxToolkit
 {

--- a/src/AasxToolkit/Program.cs
+++ b/src/AasxToolkit/Program.cs
@@ -1,22 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-
 /*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
+This source code may use other Open Source software components (see LICENSE.txt).
 */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 /*
 Many parts of the program became obsolete over time (such as a method <c>CreateSubmodelDocumentation</c>).

--- a/src/AasxToolkit/UriIdentifierRepository.cs
+++ b/src/AasxToolkit/UriIdentifierRepository.cs
@@ -1,3 +1,12 @@
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -10,21 +19,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Serialization;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxToolkit
 {

--- a/src/AasxUANodesetImExport/UANodeSet.cs
+++ b/src/AasxUANodesetImExport/UANodeSet.cs
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
 Copyright (c) 2018-2020 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -9,6 +9,10 @@ Copyright (c) 2020 Fraunhofer IOSB-INA Lemgo,
     eine rechtlich nicht selbständige Einrichtung der Fraunhofer-Gesellschaft
     zur Förderung der angewandten Forschung e.V. <jan.nicolas.weskamp@iosb-ina.fraunhofer.de>
 Author: Jan Nicolas Weskamp
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
 */
 
 using System;

--- a/src/AasxUANodesetImExport/UANodeSetExport.cs
+++ b/src/AasxUANodesetImExport/UANodeSetExport.cs
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
 Copyright (c) 2018-2020 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -9,6 +9,10 @@ Copyright (c) 2020 Fraunhofer IOSB-INA Lemgo,
     eine rechtlich nicht selbständige Einrichtung der Fraunhofer-Gesellschaft
     zur Förderung der angewandten Forschung e.V. <jan.nicolas.weskamp@iosb-ina.fraunhofer.de>
 Author: Jan Nicolas Weskamp
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
 */
 
 using System;

--- a/src/AasxUANodesetImExport/UANodeSetImport.cs
+++ b/src/AasxUANodesetImExport/UANodeSetImport.cs
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
 Copyright (c) 2018-2020 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -9,6 +9,10 @@ Copyright (c) 2020 Fraunhofer IOSB-INA Lemgo,
     eine rechtlich nicht selbständige Einrichtung der Fraunhofer-Gesellschaft
     zur Förderung der angewandten Forschung e.V. <jan.nicolas.weskamp@iosb-ina.fraunhofer.de>
 Author: Jan Nicolas Weskamp
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
 */
 
 using System;

--- a/src/AasxUaNetConsoleServer/Program.cs
+++ b/src/AasxUaNetConsoleServer/Program.cs
@@ -1,4 +1,13 @@
-﻿// TODO (MIHO, 2020-08-03): check SOURCE
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+// TODO (MIHO, 2020-08-03): check SOURCE
 
 using System;
 using System.Collections.Generic;

--- a/src/AasxUaNetServer/AasxServer/AasEntityBuilder.cs
+++ b/src/AasxUaNetServer/AasxServer/AasEntityBuilder.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxUaNetServer/AasxServer/AasEntityDescriptions.cs
+++ b/src/AasxUaNetServer/AasxServer/AasEntityDescriptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxUaNetServer/AasxServer/AasUaEntities.cs
+++ b/src/AasxUaNetServer/AasxServer/AasUaEntities.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/AasxUaNetServer/AasxServer/AasUaEntityFileType.cs
+++ b/src/AasxUaNetServer/AasxServer/AasUaEntityFileType.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxUaNetServer/AasxServer/AasUaNodeHelper.cs
+++ b/src/AasxUaNetServer/AasxServer/AasUaNodeHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxUaNetServer/AasxServer/AasUaUtils.cs
+++ b/src/AasxUaNetServer/AasxServer/AasUaUtils.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxUaNetServer/AasxServer/AasxUaServerOptions.cs
+++ b/src/AasxUaNetServer/AasxServer/AasxUaServerOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/AasxFileRepoControl.xaml
+++ b/src/AasxWpfControlLibrary/AasxFileRepoControl.xaml
@@ -7,6 +7,14 @@
              mc:Ignorable="d" 
              d:DesignHeight="200" d:DesignWidth="300"
              Loaded="UserControl_Loaded" MouseLeave="UserControl_MouseLeave">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- ReSharper disable Xaml.RedundantResource -->
     <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->

--- a/src/AasxWpfControlLibrary/AasxFileRepoControl.xaml.cs
+++ b/src/AasxWpfControlLibrary/AasxFileRepoControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/AasxFileRepository.cs
+++ b/src/AasxWpfControlLibrary/AasxFileRepository.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;

--- a/src/AasxWpfControlLibrary/AasxPrintFunctions.cs
+++ b/src/AasxWpfControlLibrary/AasxPrintFunctions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -14,23 +23,6 @@ using AdminShellNS;
 using Newtonsoft.Json;
 using QRCoder;
 using ZXing;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation (QRCoder) is under the MIT license
-(see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC, ZXing.Net) generation is under Apache license v.2
-(see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/BMEcatTools.cs
+++ b/src/AasxWpfControlLibrary/BMEcatTools.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxWpfControlLibrary/Dictionary1.xaml
+++ b/src/AasxWpfControlLibrary/Dictionary1.xaml
@@ -1,5 +1,13 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxWpfControlLibrary">
-    
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
 </ResourceDictionary>

--- a/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml
+++ b/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml
@@ -6,12 +6,14 @@
              xmlns:local="clr-namespace:AasxPackageExplorer"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="600">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- TODO: Improve data binding? -->
     <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->

--- a/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml.cs
+++ b/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxWpfControlLibrary;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml
+++ b/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml
@@ -6,12 +6,14 @@
              xmlns:local="clr-namespace:AasxPackageExplorer"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <DockPanel x:Name="theMasterPanel" />
 </UserControl>

--- a/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
+++ b/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -21,21 +30,6 @@ using AasxIntegrationBase;
 using AasxPackageExplorer;
 using AasxWpfControlLibrary;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/DispEditHelperBasics.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperBasics.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -14,21 +23,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AasxWpfControlLibrary;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/DispEditHelperCopyPaste.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperCopyPaste.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;

--- a/src/AasxWpfControlLibrary/DispEditHelperModules.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperModules.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;

--- a/src/AasxWpfControlLibrary/EclassUtils.cs
+++ b/src/AasxWpfControlLibrary/EclassUtils.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,21 +15,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/FakeBrowser.xaml
+++ b/src/AasxWpfControlLibrary/FakeBrowser.xaml
@@ -6,12 +6,14 @@
              xmlns:local="clr-namespace:AasxPackageExplorer"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Grid>
         <Viewbox>

--- a/src/AasxWpfControlLibrary/FakeBrowser.xaml.cs
+++ b/src/AasxWpfControlLibrary/FakeBrowser.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,21 +21,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/HintBubble.xaml
+++ b/src/AasxWpfControlLibrary/HintBubble.xaml
@@ -6,12 +6,14 @@
              xmlns:local="clr-namespace:AasxPackageExplorer"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!--
     <Grid>

--- a/src/AasxWpfControlLibrary/HintBubble.xaml.cs
+++ b/src/AasxWpfControlLibrary/HintBubble.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,21 +21,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/ImportCSV.cs
+++ b/src/AasxWpfControlLibrary/ImportCSV.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxWpfControlLibrary/Log.cs
+++ b/src/AasxWpfControlLibrary/Log.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/LogMessageFlyout.xaml
+++ b/src/AasxWpfControlLibrary/LogMessageFlyout.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/LogMessageFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/LogMessageFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxGlobalLogging;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/ModifyRepo.cs
+++ b/src/AasxWpfControlLibrary/ModifyRepo.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,21 +17,6 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using AasxGlobalLogging;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/NodeSetImport.cs
+++ b/src/AasxWpfControlLibrary/NodeSetImport.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxWpfControlLibrary/Options.cs
+++ b/src/AasxWpfControlLibrary/Options.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.IO;
@@ -12,22 +21,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/PackageCentral.cs
+++ b/src/AasxWpfControlLibrary/PackageCentral.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/Plugins.cs
+++ b/src/AasxWpfControlLibrary/Plugins.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,23 +18,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml
+++ b/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,21 +24,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml
@@ -7,13 +7,14 @@
              x:Class="AasxPackageExplorer.SecureConnectFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" MaxHeight="600" MaxWidth="1600" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -20,21 +29,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml
+++ b/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml
@@ -7,14 +7,16 @@
              xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2" x:Class="AasxPackageExplorer.SelectAasEntityFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-    <!-- TODO: fix -->
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
+        <!-- TODO: fix -->
     <!-- ReSharper disable Xaml.MissingGridIndex -->
 
     <UserControl.Resources>

--- a/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,21 +26,6 @@ using AasxIntegrationBase;
 using AasxWpfControlLibrary;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectEclassEntity.xaml
+++ b/src/AasxWpfControlLibrary/SelectEclassEntity.xaml
@@ -6,12 +6,14 @@
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
         Title="Select eCl@ss entity .." Height="300" Width="700" Loaded="Window_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Grid>
 

--- a/src/AasxWpfControlLibrary/SelectEclassEntity.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectEclassEntity.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -16,21 +25,6 @@ using System.Windows.Shapes;
 using System.Xml;
 
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml
@@ -7,13 +7,14 @@
              xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2" x:Class="AasxPackageExplorer.SelectEclassEntityFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml
@@ -8,13 +8,14 @@
              x:Class="AasxPackageExplorer.SelectFromListFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,21 +25,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml
@@ -8,13 +8,14 @@
              x:Class="AasxPackageExplorer.SelectFromReferablesPoolFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml
@@ -6,13 +6,14 @@
              xmlns:local="clr-namespace:AasxWpfControlLibrary"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded" KeyDown="UserControl_KeyDown">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,21 +24,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml
@@ -8,13 +8,14 @@
              x:Class="AasxPackageExplorer.SelectQualifierPresetFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,21 +26,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectableTextBlock.cs
+++ b/src/AasxWpfControlLibrary/SelectableTextBlock.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/AasxWpfControlLibrary/ShowValidationResultsFlyout.xaml
+++ b/src/AasxWpfControlLibrary/ShowValidationResultsFlyout.xaml
@@ -8,13 +8,14 @@
              x:Class="AasxPackageExplorer.ShowValidationResultsFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/ShowValidationResultsFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/ShowValidationResultsFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/TextBoxFlyout.xaml
+++ b/src/AasxWpfControlLibrary/TextBoxFlyout.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/TextBoxFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/TextBoxFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,21 +24,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/TextEditorFlyout.xaml
+++ b/src/AasxWpfControlLibrary/TextEditorFlyout.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/TextEditorFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/TextEditorFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,21 +25,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
 using static AasxPackageExplorer.Plugins;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/Themes/Generic.xaml
+++ b/src/AasxWpfControlLibrary/Themes/Generic.xaml
@@ -1,12 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxWpfControlLibrary">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Style x:Key="TranspRoundCorner" TargetType="{x:Type Button}">
         <Setter Property="HorizontalContentAlignment" Value="Center"/>

--- a/src/AasxWpfControlLibrary/ToolControlFindReplace.xaml
+++ b/src/AasxWpfControlLibrary/ToolControlFindReplace.xaml
@@ -7,6 +7,15 @@
              xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2" x:Class="AasxPackageExplorer.ToolControlFindReplace"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="800" Background="#ffffff" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <UserControl.Resources>
         
     </UserControl.Resources>

--- a/src/AasxWpfControlLibrary/ToolControlFindReplace.xaml.cs
+++ b/src/AasxWpfControlLibrary/ToolControlFindReplace.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/TreeListView.cs
+++ b/src/AasxWpfControlLibrary/TreeListView.cs
@@ -1,4 +1,13 @@
-﻿// see: https://www.codeproject.com/Articles/24973/TreeListView-2
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+// see: https://www.codeproject.com/Articles/24973/TreeListView-2
 
 using System;
 using System.Collections.Generic;
@@ -14,21 +23,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/VisualAasxElements.cs
+++ b/src/AasxWpfControlLibrary/VisualAasxElements.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -8,21 +17,6 @@ using System.Threading.Tasks;
 using System.Windows.Media;
 using AasxGlobalLogging;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 // ReSharper disable VirtualMemberCallInConstructor
 

--- a/src/AasxWpfControlLibrary/VisualElementHistoryControl.xaml
+++ b/src/AasxWpfControlLibrary/VisualElementHistoryControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxPackageExplorer"
              mc:Ignorable="d" 
              d:DesignHeight="20" d:DesignWidth="50">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="20"/>

--- a/src/AasxWpfControlLibrary/VisualElementHistoryControl.xaml.cs
+++ b/src/AasxWpfControlLibrary/VisualElementHistoryControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml
+++ b/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml
@@ -8,12 +8,14 @@
              x:Class="AasxPackageExplorer.TransparentComboBox"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="200" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- TODO : check -->
     <!-- ReSharper disable Xaml.MissingGridIndex -->

--- a/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml.cs
+++ b/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/MsaglWpfControl/Themes/Generic.xaml
+++ b/src/MsaglWpfControl/Themes/Generic.xaml
@@ -2,5 +2,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:MsaglWpfControl">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
 </ResourceDictionary>

--- a/src/WpfMtpControl/AasOpcUaClient.cs
+++ b/src/WpfMtpControl/AasOpcUaClient.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/src/WpfMtpControl/CanvasClickObject.cs
+++ b/src/WpfMtpControl/CanvasClickObject.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DataSources/MtpDataSourceOpcUa.cs
+++ b/src/WpfMtpControl/DataSources/MtpDataSourceOpcUa.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpDynamicInstance.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpDynamicInstance.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaMonTiny.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaMonTiny.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="80">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="3,3,3,3">
         <Grid x:Name="viewGrid" Margin="2">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaMonTiny.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaMonTiny.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewLarge.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewLarge.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="96" d:DesignWidth="130">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="3,3,3,3">
         <Grid x:Name="viewGrid" Margin="2">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewLarge.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewLarge.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewTiny.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewTiny.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="80">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="3,3,3,3">
         <Grid x:Name="viewGrid" Margin="2">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewTiny.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewTiny.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinDrive.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinDrive.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="60" d:DesignWidth="100">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="Transparent" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="4">
         <Grid x:Name="viewGrid" Margin="0">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinDrive.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinDrive.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinValve.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinValve.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="60" d:DesignWidth="100">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="Transparent" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="4">
         <Grid x:Name="viewGrid" Margin="0">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinValve.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinValve.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinViewLarge.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinViewLarge.xaml
@@ -7,6 +7,15 @@
              mc:Ignorable="d" 
              d:DesignHeight="96" d:DesignWidth="130"
              MinHeight="40" MinWidth="50">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="3,3,3,3">
         <Grid x:Name="viewGrid" Margin="2">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinViewLarge.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinViewLarge.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinViewTiny.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinViewTiny.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="40">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="2,2,2,2">
         <Grid x:Name="viewGrid" Margin="0">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinViewTiny.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinViewTiny.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewPIDCntlTiny.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewPIDCntlTiny.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="40">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="2,2,2,2">
         <Grid x:Name="viewGrid" Margin="0">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewPIDCntlTiny.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewPIDCntlTiny.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/MtpAmlHelper.cs
+++ b/src/WpfMtpControl/MtpAmlHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/WpfMtpControl/MtpData.cs
+++ b/src/WpfMtpControl/MtpData.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;

--- a/src/WpfMtpControl/MtpDataSourceSubscriber.cs
+++ b/src/WpfMtpControl/MtpDataSourceSubscriber.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/MtpSymbolLib.cs
+++ b/src/WpfMtpControl/MtpSymbolLib.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/MtpVisuOpcUaClient.cs
+++ b/src/WpfMtpControl/MtpVisuOpcUaClient.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;

--- a/src/WpfMtpControl/MtpVisuOptions.cs
+++ b/src/WpfMtpControl/MtpVisuOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/MtpVisuViewer.xaml
+++ b/src/WpfMtpControl/MtpVisuViewer.xaml
@@ -6,6 +6,14 @@
              xmlns:local="clr-namespace:WpfMtpControl"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="500">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Grid x:Name="gridOuter" Background="#ffe0e0e0">
         <Grid.RowDefinitions>

--- a/src/WpfMtpControl/MtpVisuViewer.xaml.cs
+++ b/src/WpfMtpControl/MtpVisuViewer.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/WpfMtpControl/MtpVisualObjectLib.cs
+++ b/src/WpfMtpControl/MtpVisualObjectLib.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/WpfMtpControl/UiElementHelper.cs
+++ b/src/WpfMtpControl/UiElementHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/WpfMtpVisuViewer/App.xaml
+++ b/src/WpfMtpVisuViewer/App.xaml
@@ -3,6 +3,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:WpfMtpVisuViewer"
              StartupUri="MainWindow.xaml">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Application.Resources>
          
     </Application.Resources>

--- a/src/WpfMtpVisuViewer/App.xaml.cs
+++ b/src/WpfMtpVisuViewer/App.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;

--- a/src/WpfMtpVisuViewer/MainWindow.xaml
+++ b/src/WpfMtpVisuViewer/MainWindow.xaml
@@ -8,6 +8,15 @@
         Title="WPF MTP Viewer prototype" Height="350" Width="525" 
         Loaded="Window_Loaded" DragEnter="Window_DragEnter" Drop="Window_Drop" AllowDrop="True"
         SizeChanged="Window_SizeChanged">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/src/WpfMtpVisuViewer/MainWindow.xaml.cs
+++ b/src/WpfMtpVisuViewer/MainWindow.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/WpfXamlTool/App.xaml
+++ b/src/WpfXamlTool/App.xaml
@@ -3,6 +3,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:WpfXamlTool"
              StartupUri="MainWindow.xaml">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Application.Resources>
          
     </Application.Resources>

--- a/src/WpfXamlTool/App.xaml.cs
+++ b/src/WpfXamlTool/App.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;

--- a/src/WpfXamlTool/MainWindow.xaml
+++ b/src/WpfXamlTool/MainWindow.xaml
@@ -7,6 +7,15 @@
         mc:Ignorable="d"
         Title="WPF XAML Tool for effective XAML snippet creation" Height="450" Width="800" Loaded="Window_Loaded"
         DragEnter="Window_DragEnter" Drop="Window_Drop">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="#303030">
 
         <Grid.RowDefinitions>

--- a/src/WpfXamlTool/MainWindow.xaml.cs
+++ b/src/WpfXamlTool/MainWindow.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;


### PR DESCRIPTION
This patch makes all the headers in the source code uniform to include
the expected copyright notice(s), the license of the software as well
as references to other open source projects used by the software.

Where there was no copyright notice previously and it was obvious that
the code was written for AASX Package Explorer we put Michael
Hoffmeister at Festo 2018-2019 as the copyright holder.

The copyright notices from third-party source codes such as Identity
Server 4 are left as-are.