### PR TITLE
Skip sending coverage on forks

### DIFF
--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Install coveralls.net (to send test coverage)
         working-directory: src
+        if: github.repository == 'admin-shell-io/aasx-package-explorer'
         run: dotnet tool install coveralls.net --version 2.0.0-beta0002
 
       - name: Build
@@ -79,6 +80,7 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        if: github.repository == 'admin-shell-io/aasx-package-explorer'
         run: |
           $headRef = ${env:HEAD_REF}
           if (${env:GITHUB_REF}.StartsWith("refs/pull/"))

--- a/src/AdditionalVerbsInImperativeMood.txt
+++ b/src/AdditionalVerbsInImperativeMood.txt
@@ -17,3 +17,4 @@ untrack
 refine
 dispatch
 export
+skip


### PR DESCRIPTION
Since forked repositories do not share secrets, we can not send test
coverage to coveralls (*e.g.*, see [this page][1]).

We therefore skip sending the coverage on forked repositories.