### PR TITLE
Enforce uniform headers

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -42,6 +42,11 @@ jobs:
         run: powershell .\InstallToolsForStyle.ps1
         if: always()
 
+      - name: Check headers
+        working-directory: src
+        run: powershell .\CheckHeaders.ps1
+        if: always()
+
       - name: Check format
         working-directory: src
         run: powershell .\CheckFormat.ps1

--- a/src/AasxAmlImExport/AasAmlMatcher.cs
+++ b/src/AasxAmlImExport/AasAmlMatcher.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxAmlImExport/AmlConst.cs
+++ b/src/AasxAmlImExport/AmlConst.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxAmlImExport/AmlExport.cs
+++ b/src/AasxAmlImExport/AmlExport.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -9,24 +18,6 @@ using AasxIntegrationBase;
 using AdminShellNS;
 using Aml.Engine.AmlObjects;
 using Aml.Engine.CAEX;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-
-The AutomationML.Engine is under the MIT license.
-(see https://raw.githubusercontent.com/AutomationML/AMLEngine2.1/master/license.txt)
-*/
 
 namespace AasxAmlImExport
 {

--- a/src/AasxAmlImExport/AmlImport.cs
+++ b/src/AasxAmlImExport/AmlImport.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,23 +17,6 @@ using AasxIntegrationBase;
 using AdminShellNS;
 using Aml.Engine.CAEX;
 
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-
-The AutomationML.Engine is under the MIT license.
-(see https://raw.githubusercontent.com/AutomationML/AMLEngine2.1/master/license.txt)
-*/
 
 namespace AasxAmlImExport
 {

--- a/src/AasxCsharpLibrary.Tests/DocTestAdminShellUtil.cs
+++ b/src/AasxCsharpLibrary.Tests/DocTestAdminShellUtil.cs
@@ -8,55 +8,55 @@ namespace AdminShellNS.Tests
     public class DocTest_AdminShellUtil_cs
     {
         [Test]
-        public void AtLine31AndColumn12()
+        public void AtLine40AndColumn12()
         {
             Assert.AreEqual("someName", AdminShellUtil.FilterFriendlyName("someName"));
         }
 
         [Test]
-        public void AtLine32AndColumn12()
+        public void AtLine41AndColumn12()
         {
             Assert.AreEqual("some__name", AdminShellUtil.FilterFriendlyName("some!;name"));
         }
 
         [Test]
-        public void AtLine42AndColumn12()
+        public void AtLine51AndColumn12()
         {
             Assert.IsFalse(AdminShellUtil.HasWhitespace(""));
         }
 
         [Test]
-        public void AtLine43AndColumn12()
+        public void AtLine52AndColumn12()
         {
             Assert.IsTrue(AdminShellUtil.HasWhitespace(" "));
         }
 
         [Test]
-        public void AtLine44AndColumn12()
+        public void AtLine53AndColumn12()
         {
             Assert.IsTrue(AdminShellUtil.HasWhitespace("aa bb"));
         }
 
         [Test]
-        public void AtLine45AndColumn12()
+        public void AtLine54AndColumn12()
         {
             Assert.IsTrue(AdminShellUtil.HasWhitespace(" aabb"));
         }
 
         [Test]
-        public void AtLine46AndColumn12()
+        public void AtLine55AndColumn12()
         {
             Assert.IsTrue(AdminShellUtil.HasWhitespace("aabb "));
         }
 
         [Test]
-        public void AtLine47AndColumn12()
+        public void AtLine56AndColumn12()
         {
             Assert.IsFalse(AdminShellUtil.HasWhitespace("aabb"));
         }
 
         [Test]
-        public void AtLine59AndColumn12()
+        public void AtLine68AndColumn12()
         {
             Assert.IsTrue(AdminShellUtil.ComplyIdShort(""));
         }

--- a/src/AasxCsharpLibrary/AasxCompatibilityModels/V10/AdminShellV10.cs
+++ b/src/AasxCsharpLibrary/AasxCompatibilityModels/V10/AdminShellV10.cs
@@ -1,3 +1,12 @@
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -11,21 +20,6 @@ using System.Xml;
 using System.Xml.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 // ReSharper disable All .. as this is legacy code!
 

--- a/src/AasxCsharpLibrary/AdminShell.cs
+++ b/src/AasxCsharpLibrary/AdminShell.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -14,21 +23,6 @@ using System.Xml;
 using System.Xml.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AdminShellNS
 {

--- a/src/AasxCsharpLibrary/AdminShellCollections.cs
+++ b/src/AasxCsharpLibrary/AdminShellCollections.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxCsharpLibrary/AdminShellConverters.cs
+++ b/src/AasxCsharpLibrary/AdminShellConverters.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
+++ b/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Packaging;

--- a/src/AasxCsharpLibrary/AdminShellUtil.cs
+++ b/src/AasxCsharpLibrary/AdminShellUtil.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;

--- a/src/AasxCsharpLibrary/AdminShellValidate.cs
+++ b/src/AasxCsharpLibrary/AdminShellValidate.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.IO;

--- a/src/AasxCsharpLibrary/IAasxOnlineConnection.cs
+++ b/src/AasxCsharpLibrary/IAasxOnlineConnection.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxDictionaryImport/Cdd/Data.cs
+++ b/src/AasxDictionaryImport/Cdd/Data.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Cdd/Importer.cs
+++ b/src/AasxDictionaryImport/Cdd/Importer.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Cdd/Model.cs
+++ b/src/AasxDictionaryImport/Cdd/Model.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Cdd/Parser.cs
+++ b/src/AasxDictionaryImport/Cdd/Parser.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/ElementDetailsDialog.xaml
+++ b/src/AasxDictionaryImport/ElementDetailsDialog.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxDictionaryImport"
              mc:Ignorable="d"
              MinWidth="300" MinHeight="200" SizeToContent="WidthAndHeight">
+    <!--
+    Copyright (c) 2020 SICK AG <info@sick.de>
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <DockPanel Margin="5" LastChildFill="False">
         <Grid x:Name="Grid" DockPanel.Dock="Top" VerticalAlignment="Stretch">
             <Grid.ColumnDefinitions>

--- a/src/AasxDictionaryImport/ElementDetailsDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ElementDetailsDialog.xaml.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Iec61360Utils.cs
+++ b/src/AasxDictionaryImport/Iec61360Utils.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Import.cs
+++ b/src/AasxDictionaryImport/Import.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/ImportDialog.xaml
+++ b/src/AasxDictionaryImport/ImportDialog.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxDictionaryImport"
              mc:Ignorable="d" 
              Title="Dictionary Import" Width="1000" Height="500" MinWidth="550" MinHeight="200">
+    <!--
+    Copyright (c) 2020 SICK AG <info@sick.de>
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxDictionaryImport/Model.cs
+++ b/src/AasxDictionaryImport/Model.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * Copyright (c) 2020 SICK AG <info@sick.de>
- *
- * This software is licensed under the Apache License 2.0 (Apache-2.0).
- * The ExcelDataReder dependency is licensed under the MIT license
- * (https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE).
- */
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 #nullable enable
 

--- a/src/AasxIntegrationBase/AasxLanguageHelper.cs
+++ b/src/AasxIntegrationBase/AasxLanguageHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBase/AasxPluginHelper.cs
+++ b/src/AasxIntegrationBase/AasxPluginHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxIntegrationBase/AasxPluginInterface.cs
+++ b/src/AasxIntegrationBase/AasxPluginInterface.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBase/AasxPluginOptionsBase.cs
+++ b/src/AasxIntegrationBase/AasxPluginOptionsBase.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxIntegrationBase/Extensions.cs
+++ b/src/AasxIntegrationBase/Extensions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBase/LogInstance.cs
+++ b/src/AasxIntegrationBase/LogInstance.cs
@@ -1,20 +1,18 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
- */
 
 namespace AasxIntegrationBase
 {

--- a/src/AasxIntegrationBase/MinimalLogger.cs
+++ b/src/AasxIntegrationBase/MinimalLogger.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBase/PluginEventStack.cs
+++ b/src/AasxIntegrationBase/PluginEventStack.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/AasFormUtils.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="250" d:DesignWidth="500" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <StackPanel x:Name="OutPanel" Orientation="Vertical" Background="#e8e8e8">
 
         <StackPanel.Resources>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfDifferentControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfSameControl.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfSameControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="250" d:DesignWidth="500" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid x:Name="GridOuterElement" Background="#e8e8e8">
 
         <!-- Here, the different control controls are being defined -->

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfSameControl.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfSameControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlFile.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlFile.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid>
             <Grid.RowDefinitions>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlFile.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlFile.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlMultiLangProp.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlMultiLangProp.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid x:Name="TheGrid">
             <Grid.RowDefinitions>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlMultiLangProp.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlMultiLangProp.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlProperty.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlProperty.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid>
             <Grid.RowDefinitions>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlProperty.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlProperty.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid x:Name="GridAttributes" Background="LightBlue">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferableAttributes.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferenceElement.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferenceElement.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid>
             <Grid.RowDefinitions>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferenceElement.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlReferenceElement.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml
@@ -6,6 +6,14 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <StackPanel>
         <local:FormSubControlReferableAttributes x:Name="TheRefAttributes" Margin="4"

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEBase.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEC.xaml
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEC.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxIntegrationBase.AasForms"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid>
             <Grid.RowDefinitions>

--- a/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEC.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormSubControlSMEC.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasForms/IFormListControl.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/IFormListControl.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/AasxPluginOptionSerialization.cs
+++ b/src/AasxIntegrationBaseWpf/AasxPluginOptionSerialization.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxIntegrationBaseWpf/AasxWpfBaseUtils.cs
+++ b/src/AasxIntegrationBaseWpf/AasxWpfBaseUtils.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml
+++ b/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml
@@ -6,13 +6,14 @@
              xmlns:local="clr-namespace:AasxIntegrationBase"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/EmptyFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,21 +24,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxIntegrationBase
 {

--- a/src/AasxIntegrationBaseWpf/IFlyoutControl.cs
+++ b/src/AasxIntegrationBaseWpf/IFlyoutControl.cs
@@ -1,24 +1,18 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxIntegrationBase
 {

--- a/src/AasxIntegrationBaseWpf/IFlyoutProvider.cs
+++ b/src/AasxIntegrationBaseWpf/IFlyoutProvider.cs
@@ -1,25 +1,19 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxIntegrationBase
 {

--- a/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml
+++ b/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/MessageBoxFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,21 +24,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxIntegrationBase
 {

--- a/src/AasxIntegrationBaseWpf/Resources/Graphics.xaml
+++ b/src/AasxIntegrationBaseWpf/Resources/Graphics.xaml
@@ -1,12 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxIntegrationBase">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Viewbox x:Key="IconDelete" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Stretch="Uniform">
         <Canvas Width="1000" Height="1000">

--- a/src/AasxIntegrationBaseWpf/Themes/Generic.xaml
+++ b/src/AasxIntegrationBaseWpf/Themes/Generic.xaml
@@ -1,9 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxIntegrationBase">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
--->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Style x:Key="TranspRoundCorner" TargetType="{x:Type Button}">
         <Setter Property="HorizontalContentAlignment" Value="Center"/>

--- a/src/AasxIntegrationBaseWpf/WpfViewmodelBase.cs
+++ b/src/AasxIntegrationBaseWpf/WpfViewmodelBase.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/src/AasxIntegrationEmptySample/Plugin.cs
+++ b/src/AasxIntegrationEmptySample/Plugin.cs
@@ -1,15 +1,18 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxMqtt/MqttServer.cs
+++ b/src/AasxMqtt/MqttServer.cs
@@ -1,17 +1,27 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+Copyright (c) 2019 Phoenix Contact GmbH & Co. KG <opensource@phoenixcontact.com>
+Author: Andreas Orzelski
+
+Copyright (c) 2019 Fraunhofer IOSB-INA Lemgo,
+    eine rechtlich nicht selbständige Einrichtung der Fraunhofer-Gesellschaft
+    zur Förderung der angewandten Forschung e.V. <florian.pethig@iosb-ina.fraunhofer.de>
+Author: Florian Pethig
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using MQTTnet;
 using MQTTnet.Server;
-
-/* For Mqtt Content:
-
-MIT License
-
-MQTTnet Copyright (c) 2016-2019 Christian Kratky
-*/
 
 namespace AasxMqttServer
 {

--- a/src/AasxMqtt/Plugin.cs
+++ b/src/AasxMqtt/Plugin.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AasxMqttServer;
-using JetBrains.Annotations;
-
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -18,10 +10,18 @@ Copyright (c) 2019 Fraunhofer IOSB-INA Lemgo,
     zur Förderung der angewandten Forschung e.V. <florian.pethig@iosb-ina.fraunhofer.de>
 Author: Florian Pethig
 
-For Mqtt Content: MIT License
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-MQTTnet Copyright (c) 2016-2019 Christian Kratky
+This source code may use other Open Source software components (see LICENSE.txt).
 */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AasxMqttServer;
+using JetBrains.Annotations;
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxMqttClient/GrapevineLoggerConsumers.cs
+++ b/src/AasxMqttClient/GrapevineLoggerConsumers.cs
@@ -1,26 +1,19 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Grapevine.Interfaces.Shared;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 /*
 Please notice: the API and REST routes implemented in this version of the source code are not specified and

--- a/src/AasxMqttClient/MqttClient.cs
+++ b/src/AasxMqttClient/MqttClient.cs
@@ -1,14 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AdminShellNS;
-using MQTTnet;
-using MQTTnet.Client;
-using MQTTnet.Client.Options;
-
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -20,12 +10,20 @@ Copyright (c) 2019 Fraunhofer IOSB-INA Lemgo,
     zur Förderung der angewandten Forschung e.V. <florian.pethig@iosb-ina.fraunhofer.de>
 Author: Florian Pethig
 
-For Mqtt Content:
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-MIT License
-
-MQTTnet Copyright (c) 2016-2019 Christian Kratky
+This source code may use other Open Source software components (see LICENSE.txt).
 */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AdminShellNS;
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Client.Options;
 
 namespace AasxMqttClient
 {

--- a/src/AasxOpenidClient/ConsoleExtensions.cs
+++ b/src/AasxOpenidClient/ConsoleExtensions.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Diagnostics;
-
-/*
+﻿/*
 Copyright (c) 2020 see https://github.com/IdentityServer/IdentityServer4
 
 We adapted the code marginally and removed the parts that we do not use.
 */
+
+using System;
+using System.Diagnostics;
 
 // ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
 

--- a/src/AasxOpenidClient/Constants.cs
+++ b/src/AasxOpenidClient/Constants.cs
@@ -1,10 +1,10 @@
-﻿// ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
-
-/*
+﻿/*
 Copyright (c) 2020 see https://github.com/IdentityServer/IdentityServer4
 
 We adapted the code marginally and removed the parts that we do not use.
 */
+
+// ReSharper disable All .. as this is code from others (adapted from IdentityServer4).
 
 namespace AasxOpenIdClient
 {

--- a/src/AasxPackageExplorer/AboutBox.xaml
+++ b/src/AasxPackageExplorer/AboutBox.xaml
@@ -6,13 +6,15 @@
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
         Title="About" Height="500" Width="600" Loaded="Window_Loaded" MinWidth="150">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
- <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
-    
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="100"/>

--- a/src/AasxPackageExplorer/AboutBox.xaml.cs
+++ b/src/AasxPackageExplorer/AboutBox.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -13,21 +22,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxPackageExplorer/App.xaml
+++ b/src/AasxPackageExplorer/App.xaml
@@ -3,12 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:AasxPackageExplorer"             
              Startup="Application_Startup">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Application.Resources>
         <!--OZ, UT: external dictionary for theme colors-->

--- a/src/AasxPackageExplorer/App.xaml.cs
+++ b/src/AasxPackageExplorer/App.xaml.cs
@@ -1,22 +1,16 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Windows;
-using AasxGlobalLogging;
-
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
+This source code may use other Open Source software components (see LICENSE.txt).
 */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Windows;
+using AasxGlobalLogging;
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxPackageExplorer/BrowserContainer.cs
+++ b/src/AasxPackageExplorer/BrowserContainer.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;

--- a/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
+++ b/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
@@ -6,15 +6,17 @@
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
         Title="AASX Package Explorer Splash Screen" Width="650" Height="350" Background="White" WindowStyle="None" WindowStartupLocation="CenterScreen" Topmost="True" MouseDown="Image_MouseDown">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- -->    
     
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
-
     <Grid>
 
         <Border Margin="4" BorderBrush="{DynamicResource DarkestAccentColor}" BorderThickness="2" Padding="4">

--- a/src/AasxPackageExplorer/CustomSplashScreenNew.xaml.cs
+++ b/src/AasxPackageExplorer/CustomSplashScreenNew.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,21 +23,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using System.Windows.Threading;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -1,3 +1,15 @@
+/*
+Copyright (c) 2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+Copyright (c) 2019 Phoenix Contact GmbH & Co. KG <>
+Author: Andreas Orzelski
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/AasxPackageExplorer/MainWindow.xaml
+++ b/src/AasxPackageExplorer/MainWindow.xaml
@@ -10,14 +10,16 @@
         Title="AASX Package Explorer" Height="350" Width="700" Loaded="Window_Loaded" AllowDrop="True" 
         DragEnter="Window_DragEnter" Drop="Window_Drop" Closing="Window_Closing" SizeChanged="Window_SizeChanged" 
         PreviewKeyDown="mainWindow_PreviewKeyDown" >
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-    <!-- TODO: fix again -->
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
+        <!-- TODO: fix again -->
     <!-- ReSharper disable Xaml.MissingGridIndex -->
     
     <Window.Resources>

--- a/src/AasxPackageExplorer/MainWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MainWindow.xaml.cs
@@ -1,4 +1,12 @@
-﻿
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -18,21 +26,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AasxWpfControlLibrary;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxPackageExplorer/MessageReportWindow.xaml
+++ b/src/AasxPackageExplorer/MessageReportWindow.xaml
@@ -6,12 +6,14 @@
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
         Title="Message Report" Height="600" Width="800">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Grid>
         <Grid.RowDefinitions>

--- a/src/AasxPackageExplorer/MessageReportWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MessageReportWindow.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,21 +22,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using AasxGlobalLogging;
 using AasxIntegrationBase;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxPackageExplorer/Themes/Brandlabel.xaml
+++ b/src/AasxPackageExplorer/Themes/Brandlabel.xaml
@@ -1,6 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxPackageExplorer" xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- -->
 

--- a/src/AasxPackageExplorer/Themes/Generic.xaml
+++ b/src/AasxPackageExplorer/Themes/Generic.xaml
@@ -2,6 +2,14 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:AasxPackageExplorer;assembly=AasxWpfControlLibrary">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- ReSharper disable Xaml.PathError -->
     

--- a/src/AasxPluginAdvancedTextEditor/AdvancedTextEditOptions.cs
+++ b/src/AasxPluginAdvancedTextEditor/AdvancedTextEditOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginAdvancedTextEditor/Plugin.cs
+++ b/src/AasxPluginAdvancedTextEditor/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -10,15 +19,6 @@ using System.Windows.Controls;
 using AasxPluginAdvancedTextEditor;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The AvalonEdit component, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginAdvancedTextEditor/UserControlAdvancedTextEditor.xaml
+++ b/src/AasxPluginAdvancedTextEditor/UserControlAdvancedTextEditor.xaml
@@ -8,6 +8,15 @@
              xmlns:local="clr-namespace:AasxPluginAdvancedTextEditor"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <DockPanel>
         <ToolBar DockPanel.Dock="Top">
             <ToolBar.Resources>

--- a/src/AasxPluginAdvancedTextEditor/UserControlAdvancedTextEditor.xaml.cs
+++ b/src/AasxPluginAdvancedTextEditor/UserControlAdvancedTextEditor.xaml.cs
@@ -1,3 +1,12 @@
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/AasxPluginBomStructure/AasReferenceStore.cs
+++ b/src/AasxPluginBomStructure/AasReferenceStore.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;

--- a/src/AasxPluginBomStructure/BomStructureOptions.cs
+++ b/src/AasxPluginBomStructure/BomStructureOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginBomStructure/GenericBomControl.cs
+++ b/src/AasxPluginBomStructure/GenericBomControl.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,14 +17,6 @@ using System.Windows.Controls;
 using AasxIntegrationBase;
 using AdminShellNS;
 
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 namespace AasxPluginBomStructure
 {
     public class GenericBomCreator

--- a/src/AasxPluginBomStructure/Plugin.cs
+++ b/src/AasxPluginBomStructure/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,15 +16,6 @@ using System.Text;
 using System.Threading.Tasks;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginDocumentShelf/DocumentEntity.cs
+++ b/src/AasxPluginDocumentShelf/DocumentEntity.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginDocumentShelf/DocumentShelfOptions.cs
+++ b/src/AasxPluginDocumentShelf/DocumentShelfOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxPluginDocumentShelf/EnumBooleanConverter.cs
+++ b/src/AasxPluginDocumentShelf/EnumBooleanConverter.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginDocumentShelf/Plugin.cs
+++ b/src/AasxPluginDocumentShelf/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,15 +16,6 @@ using System.Text;
 using System.Threading.Tasks;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginDocumentShelf/ShelfControl.xaml
+++ b/src/AasxPluginDocumentShelf/ShelfControl.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxPluginDocumentShelf"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="500">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- There seems to be an issue to load the CountryFlag.dll for the Relase version of the binaries in XAML-->
     <!-- Solution: do everything in code behind -->

--- a/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
+++ b/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/AasxPluginDocumentShelf/ShelfItemBar.xaml
+++ b/src/AasxPluginDocumentShelf/ShelfItemBar.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxPluginDocumentShelf"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- There seems to be an issue to load the CountryFlag.dll for the Relase version of the binaries in XAML-->
     <!-- xmlns:cf="clr-namespace:CountryFlag;assembly=CountryFlag" -->

--- a/src/AasxPluginDocumentShelf/ShelfItemBar.xaml.cs
+++ b/src/AasxPluginDocumentShelf/ShelfItemBar.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginDocumentShelf/ShelfItemGrid.xaml
+++ b/src/AasxPluginDocumentShelf/ShelfItemGrid.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxPluginDocumentShelf"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- There seems to be an issue to load the CountryFlag.dll for the Relase version of the binaries in XAML-->
     <!-- xmlns:cf="clr-namespace:CountryFlag;assembly=CountryFlag" -->

--- a/src/AasxPluginDocumentShelf/ShelfItemGrid.xaml.cs
+++ b/src/AasxPluginDocumentShelf/ShelfItemGrid.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginExportTable/ExportTableFlyout.xaml
+++ b/src/AasxPluginExportTable/ExportTableFlyout.xaml
@@ -7,13 +7,14 @@
              x:Class="AasxPluginExportTable.ExportTableFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxPluginExportTable/ExportTableFlyout.xaml.cs
+++ b/src/AasxPluginExportTable/ExportTableFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -19,21 +28,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPluginExportTable
 {

--- a/src/AasxPluginExportTable/ExportTableOptions.cs
+++ b/src/AasxPluginExportTable/ExportTableOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginExportTable/ExportTableRecord.cs
+++ b/src/AasxPluginExportTable/ExportTableRecord.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxPluginExportTable/Plugin.cs
+++ b/src/AasxPluginExportTable/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,15 +18,6 @@ using System.Windows;
 using AasxPluginExportTable;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginExportTable/Themes/Generic.xaml
+++ b/src/AasxPluginExportTable/Themes/Generic.xaml
@@ -1,10 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxPluginExportTable">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The OpenXML SDK is under MIT license. 
--->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Style x:Key="TranspRoundCorner" TargetType="{x:Type Button}">
         <Setter Property="HorizontalContentAlignment" Value="Center"/>

--- a/src/AasxPluginGenericForms/GenericFormsControl.xaml
+++ b/src/AasxPluginGenericForms/GenericFormsControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxPluginGenericForms"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="400">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <TabControl x:Name="OuterTabControl">
         <TabItem x:Name="TabPanelEdit" Visibility="Collapsed">
             <Grid Background="#e8e8e8" Loaded="Grid_Loaded">

--- a/src/AasxPluginGenericForms/GenericFormsControl.xaml.cs
+++ b/src/AasxPluginGenericForms/GenericFormsControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/AasxPluginGenericForms/GenericFormsOptions.cs
+++ b/src/AasxPluginGenericForms/GenericFormsOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxPluginGenericForms/Plugin.cs
+++ b/src/AasxPluginGenericForms/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,15 +17,6 @@ using System.Threading.Tasks;
 using AdminShellNS;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginImageMap/ImageMapControl.xaml
+++ b/src/AasxPluginImageMap/ImageMapControl.xaml
@@ -7,6 +7,14 @@
              xmlns:local="clr-namespace:AasxPluginImageMap"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="400">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- There seems to be an issue to load the CountryFlag.dll for the Relase version of the binaries in XAML-->
     <!-- Solution: do everything in code behind -->

--- a/src/AasxPluginImageMap/ImageMapControl.xaml.cs
+++ b/src/AasxPluginImageMap/ImageMapControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/AasxPluginImageMap/ImageMapOptions.cs
+++ b/src/AasxPluginImageMap/ImageMapOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginImageMap/Plugin.cs
+++ b/src/AasxPluginImageMap/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,10 +16,6 @@ using System.Text;
 using System.Threading.Tasks;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, 
- * author: Michael Hoffmeister
- */
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginMtpViewer/MtpViewerOptions.cs
+++ b/src/AasxPluginMtpViewer/MtpViewerOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginMtpViewer/Plugin.cs
+++ b/src/AasxPluginMtpViewer/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,10 +16,6 @@ using System.Text;
 using System.Threading.Tasks;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, 
- * author: Michael Hoffmeister
- */
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml
+++ b/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:WpfMtpControl;assembly=WpfMtpControl"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml.cs
+++ b/src/AasxPluginMtpViewer/WpfMtpControlWrapper.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginTechnicalData/PimpedPaginator.cs
+++ b/src/AasxPluginTechnicalData/PimpedPaginator.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/AasxPluginTechnicalData/Plugin.cs
+++ b/src/AasxPluginTechnicalData/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,15 +17,6 @@ using System.Threading.Tasks;
 using System.Windows.Controls;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginTechnicalData/TechDataFooterControl.xaml
+++ b/src/AasxPluginTechnicalData/TechDataFooterControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxPluginTechnicalData"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="600">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="White">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/src/AasxPluginTechnicalData/TechDataFooterControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechDataFooterControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginTechnicalData/TechDataHeaderControl.xaml
+++ b/src/AasxPluginTechnicalData/TechDataHeaderControl.xaml
@@ -6,7 +6,15 @@
              xmlns:local="clr-namespace:AasxPluginTechnicalData"
              mc:Ignorable="d" 
              d:DesignHeight="180" d:DesignWidth="600">
-    
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <!-- Not sure, if binding can be improved -->
     <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
     

--- a/src/AasxPluginTechnicalData/TechDataHeaderControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechDataHeaderControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginTechnicalData/TechDataPropertiesControl.xaml
+++ b/src/AasxPluginTechnicalData/TechDataPropertiesControl.xaml
@@ -7,6 +7,14 @@
              xmlns:doc="clr-namespace:System.Windows.Documents;assembly=PresentationFramework"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="600">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- styles declared for use in code -->
     <!-- ReSharper disable Xaml.RedundantResource -->

--- a/src/AasxPluginTechnicalData/TechDataPropertiesControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechDataPropertiesControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginTechnicalData/TechnicalDataOptions.cs
+++ b/src/AasxPluginTechnicalData/TechnicalDataOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml
+++ b/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxPluginTechnicalData"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="40"/>

--- a/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml.cs
+++ b/src/AasxPluginTechnicalData/TechnicalDataViewControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginUaNetClient/ExitCode.cs
+++ b/src/AasxPluginUaNetClient/ExitCode.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPluginUaNetClient/Plugin.cs
+++ b/src/AasxPluginUaNetClient/Plugin.cs
@@ -1,17 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>,
+Author: Michael Hoffmeister.
 
-/* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, 
- * author: Michael Hoffmeister.
- * Copyright (c) 2019 Phoenix Contact GmbH & Co. KG <>, author: Andreas Orzelski
-*/
+Copyright (c) 2019 Phoenix Contact GmbH & Co. KG <>
+Author: Andreas Orzelski
 
-/* For OPC Content
+For OPC Content:
 
 Copyright (c) 1996-2016, OPC Foundation. All rights reserved.
 The source code in this file is covered under a dual-license scenario:
@@ -24,6 +18,14 @@ This source code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE
 */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginUaNetServer/Plugin.cs
+++ b/src/AasxPluginUaNetServer/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,10 +21,6 @@ using AdminShellNS;
 using Opc.Ua;
 using Opc.Ua.Configuration;
 using Opc.Ua.Server;
-
-/* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, 
- * author: Michael Hoffmeister.
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginWebBrowser/Plugin.cs
+++ b/src/AasxPluginWebBrowser/Plugin.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,15 +18,6 @@ using System.Windows;
 using System.Windows.Controls;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The Microsoft Microsoft Automatic Graph Layout, MSAGL, is licensed under the MIT license (MIT).
-*/
 
 namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 {

--- a/src/AasxPluginWebBrowser/Themes/Generic.xaml
+++ b/src/AasxPluginWebBrowser/Themes/Generic.xaml
@@ -2,4 +2,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:AasxPluginWebBrowser">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
 </ResourceDictionary>

--- a/src/AasxPluginWebBrowser/WebBrowserOptions.cs
+++ b/src/AasxPluginWebBrowser/WebBrowserOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/AasxDefinitionBase.cs
+++ b/src/AasxPredefinedConcepts/AasxDefinitionBase.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxPredefinedConcepts/ConceptModel/ConceptModelZveiTechnicalData.cs
+++ b/src/AasxPredefinedConcepts/ConceptModel/ConceptModelZveiTechnicalData.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertDocumentationHsuToSg2.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertDocumentationHsuToSg2.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToHsu.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToHsu.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToV11.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertDocumentationSg2ToV11.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertPredefinedConcepts.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertPredefinedConcepts.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataToFlat.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataToFlat.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataV10ToV11.cs
+++ b/src/AasxPredefinedConcepts/Convert/ConvertTechnicalDataV10ToV11.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsExperimental.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsExperimental.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsImageMap.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsImageMap.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsLanguages.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsLanguages.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsMTP.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsMTP.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsPool.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsPool.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Authentication.ExtendedProtection;

--- a/src/AasxPredefinedConcepts/DefinitionsV2770v11.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsV2770v11.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/AasxPredefinedConcepts/DefinitionsVDI2770.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsVDI2770.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsZveiDigitalTypeplate.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsZveiDigitalTypeplate.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalData.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalData.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;

--- a/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalDataV11.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsZveiTechnicalDataV11.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/AasxPredefinedConcepts/ExportPredefinedConcepts.cs
+++ b/src/AasxPredefinedConcepts/ExportPredefinedConcepts.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxPredefinedConcepts/PackageExplorer.cs
+++ b/src/AasxPredefinedConcepts/PackageExplorer.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxRestConsoleServer/Program.cs
+++ b/src/AasxRestConsoleServer/Program.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxRestServerLibrary/AasxHttpContextHelper.cs
+++ b/src/AasxRestServerLibrary/AasxHttpContextHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Globalization;
@@ -16,22 +25,6 @@ using Grapevine.Server.Attributes;
 using Grapevine.Shared;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 /*
 Please notice:

--- a/src/AasxRestServerLibrary/AasxHttpHandleStore.cs
+++ b/src/AasxRestServerLibrary/AasxHttpHandleStore.cs
@@ -1,26 +1,19 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 /*
 Please notice:

--- a/src/AasxRestServerLibrary/AasxRestClient.cs
+++ b/src/AasxRestServerLibrary/AasxRestClient.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxRestServerLibrary/AasxRestServer.cs
+++ b/src/AasxRestServerLibrary/AasxRestServer.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -13,22 +22,6 @@ using Grapevine.Server;
 using Grapevine.Server.Attributes;
 using Grapevine.Shared;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 /*
 Please notice:

--- a/src/AasxRestServerLibrary/GrapevineLoggerConsumers.cs
+++ b/src/AasxRestServerLibrary/GrapevineLoggerConsumers.cs
@@ -1,25 +1,18 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Grapevine.Interfaces.Shared;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 /*
 Please notice:

--- a/src/AasxSignature/AasxSignature.cs
+++ b/src/AasxSignature/AasxSignature.cs
@@ -1,9 +1,14 @@
-﻿/* Copyright(c) 2020 Schneider Electric Automation GmbH <marco.mendes@se.com>, author: Marco Mendes */
+﻿/*
+Copyright(c) 2020 Schneider Electric Automation GmbH <marco.mendes@se.com>
+Author: Marco Mendes
 
-/*
 This file has been shortened to include only the features needed by AASX Package Explorer.
 The original file is available at: obsolete/2020-07-20/AasxLibrary/AasxLibrary.cs
- */
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
 
 using System;
 using System.Collections.Generic;

--- a/src/AasxToolkit.Tests/DocTestCli.cs
+++ b/src/AasxToolkit.Tests/DocTestCli.cs
@@ -8,26 +8,26 @@ namespace AasxToolkit.Tests
     public class DocTest_Cli_cs
     {
         [Test]
-        public void AtLine189AndColumn16()
+        public void AtLine198AndColumn16()
         {
             Assert.AreEqual("", Cli.Indentation.Indent("", "  "));
         }
 
         [Test]
-        public void AtLine190AndColumn16()
+        public void AtLine199AndColumn16()
         {
             Assert.AreEqual("  test", Cli.Indentation.Indent("test", "  "));
         }
 
         [Test]
-        public void AtLine191AndColumn16()
+        public void AtLine200AndColumn16()
         {
             var nl = System.Environment.NewLine;
             Assert.AreEqual($"  test{nl}  me", Cli.Indentation.Indent("test\nme", "  "));
         }
 
         [Test]
-        public void AtLine195AndColumn16()
+        public void AtLine204AndColumn16()
         {
             var nl = System.Environment.NewLine;
             Assert.AreEqual($"  test{nl}  me", Cli.Indentation.Indent("test\r\nme", "  "));

--- a/src/AasxToolkit/Cli.cs
+++ b/src/AasxToolkit/Cli.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ArgumentException = System.ArgumentException;

--- a/src/AasxToolkit/Execution.cs
+++ b/src/AasxToolkit/Execution.cs
@@ -1,4 +1,13 @@
-﻿using System.Collections.Generic;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System.Collections.Generic;
 using AasFormUtils = AasxIntegrationBase.AasForms.AasFormUtils;
 using AasSchemaValidation = AdminShellNS.AasSchemaValidation;
 using AasValidationRecordList = AdminShellNS.AasValidationRecordList;

--- a/src/AasxToolkit/Generate.cs
+++ b/src/AasxToolkit/Generate.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;

--- a/src/AasxToolkit/Instruction.cs
+++ b/src/AasxToolkit/Instruction.cs
@@ -1,4 +1,13 @@
-﻿namespace AasxToolkit.Instruction
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+namespace AasxToolkit.Instruction
 {
     /// <summary>
     /// Represents a single instruction to the program.

--- a/src/AasxToolkit/Log.cs
+++ b/src/AasxToolkit/Log.cs
@@ -1,21 +1,15 @@
-using System;
-using System.IO;
-using System.Text;
-
 /*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
+This source code may use other Open Source software components (see LICENSE.txt).
 */
+
+using System;
+using System.IO;
+using System.Text;
 
 namespace AasxToolkit
 {

--- a/src/AasxToolkit/Program.cs
+++ b/src/AasxToolkit/Program.cs
@@ -1,22 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-
 /*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
+This source code may use other Open Source software components (see LICENSE.txt).
 */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 /*
 Many parts of the program became obsolete over time (such as a method <c>CreateSubmodelDocumentation</c>).

--- a/src/AasxToolkit/UriIdentifierRepository.cs
+++ b/src/AasxToolkit/UriIdentifierRepository.cs
@@ -1,3 +1,12 @@
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -10,21 +19,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Serialization;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxToolkit
 {

--- a/src/AasxUANodesetImExport/UANodeSet.cs
+++ b/src/AasxUANodesetImExport/UANodeSet.cs
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
 Copyright (c) 2018-2020 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -9,6 +9,10 @@ Copyright (c) 2020 Fraunhofer IOSB-INA Lemgo,
     eine rechtlich nicht selbständige Einrichtung der Fraunhofer-Gesellschaft
     zur Förderung der angewandten Forschung e.V. <jan.nicolas.weskamp@iosb-ina.fraunhofer.de>
 Author: Jan Nicolas Weskamp
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
 */
 
 using System;

--- a/src/AasxUANodesetImExport/UANodeSetExport.cs
+++ b/src/AasxUANodesetImExport/UANodeSetExport.cs
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
 Copyright (c) 2018-2020 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -9,6 +9,10 @@ Copyright (c) 2020 Fraunhofer IOSB-INA Lemgo,
     eine rechtlich nicht selbständige Einrichtung der Fraunhofer-Gesellschaft
     zur Förderung der angewandten Forschung e.V. <jan.nicolas.weskamp@iosb-ina.fraunhofer.de>
 Author: Jan Nicolas Weskamp
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
 */
 
 using System;

--- a/src/AasxUANodesetImExport/UANodeSetImport.cs
+++ b/src/AasxUANodesetImExport/UANodeSetImport.cs
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
 Copyright (c) 2018-2020 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -9,6 +9,10 @@ Copyright (c) 2020 Fraunhofer IOSB-INA Lemgo,
     eine rechtlich nicht selbständige Einrichtung der Fraunhofer-Gesellschaft
     zur Förderung der angewandten Forschung e.V. <jan.nicolas.weskamp@iosb-ina.fraunhofer.de>
 Author: Jan Nicolas Weskamp
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
 */
 
 using System;

--- a/src/AasxUaNetConsoleServer/Program.cs
+++ b/src/AasxUaNetConsoleServer/Program.cs
@@ -1,4 +1,13 @@
-﻿// TODO (MIHO, 2020-08-03): check SOURCE
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+// TODO (MIHO, 2020-08-03): check SOURCE
 
 using System;
 using System.Collections.Generic;

--- a/src/AasxUaNetServer/AasxServer/AasEntityBuilder.cs
+++ b/src/AasxUaNetServer/AasxServer/AasEntityBuilder.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxUaNetServer/AasxServer/AasEntityDescriptions.cs
+++ b/src/AasxUaNetServer/AasxServer/AasEntityDescriptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxUaNetServer/AasxServer/AasUaEntities.cs
+++ b/src/AasxUaNetServer/AasxServer/AasUaEntities.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/AasxUaNetServer/AasxServer/AasUaEntityFileType.cs
+++ b/src/AasxUaNetServer/AasxServer/AasUaEntityFileType.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxUaNetServer/AasxServer/AasUaNodeHelper.cs
+++ b/src/AasxUaNetServer/AasxServer/AasUaNodeHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxUaNetServer/AasxServer/AasUaUtils.cs
+++ b/src/AasxUaNetServer/AasxServer/AasUaUtils.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxUaNetServer/AasxServer/AasxUaServerOptions.cs
+++ b/src/AasxUaNetServer/AasxServer/AasxUaServerOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/AasxFileRepoControl.xaml
+++ b/src/AasxWpfControlLibrary/AasxFileRepoControl.xaml
@@ -7,6 +7,14 @@
              mc:Ignorable="d" 
              d:DesignHeight="200" d:DesignWidth="300"
              Loaded="UserControl_Loaded" MouseLeave="UserControl_MouseLeave">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- ReSharper disable Xaml.RedundantResource -->
     <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->

--- a/src/AasxWpfControlLibrary/AasxFileRepoControl.xaml.cs
+++ b/src/AasxWpfControlLibrary/AasxFileRepoControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/AasxFileRepository.cs
+++ b/src/AasxWpfControlLibrary/AasxFileRepository.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;

--- a/src/AasxWpfControlLibrary/AasxPrintFunctions.cs
+++ b/src/AasxWpfControlLibrary/AasxPrintFunctions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -14,23 +23,6 @@ using AdminShellNS;
 using Newtonsoft.Json;
 using QRCoder;
 using ZXing;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation (QRCoder) is under the MIT license
-(see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC, ZXing.Net) generation is under Apache license v.2
-(see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/BMEcatTools.cs
+++ b/src/AasxWpfControlLibrary/BMEcatTools.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxWpfControlLibrary/Dictionary1.xaml
+++ b/src/AasxWpfControlLibrary/Dictionary1.xaml
@@ -1,5 +1,13 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxWpfControlLibrary">
-    
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
 </ResourceDictionary>

--- a/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml
+++ b/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml
@@ -6,12 +6,14 @@
              xmlns:local="clr-namespace:AasxPackageExplorer"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="600">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- TODO: Improve data binding? -->
     <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->

--- a/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml.cs
+++ b/src/AasxWpfControlLibrary/DiplayVisualAasxElements.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxWpfControlLibrary;
 using AdminShellNS;
 using JetBrains.Annotations;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml
+++ b/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml
@@ -6,12 +6,14 @@
              xmlns:local="clr-namespace:AasxPackageExplorer"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <DockPanel x:Name="theMasterPanel" />
 </UserControl>

--- a/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
+++ b/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -21,21 +30,6 @@ using AasxIntegrationBase;
 using AasxPackageExplorer;
 using AasxWpfControlLibrary;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/DispEditHelperBasics.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperBasics.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -14,21 +23,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AasxWpfControlLibrary;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/DispEditHelperCopyPaste.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperCopyPaste.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;

--- a/src/AasxWpfControlLibrary/DispEditHelperModules.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperModules.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;

--- a/src/AasxWpfControlLibrary/EclassUtils.cs
+++ b/src/AasxWpfControlLibrary/EclassUtils.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,21 +15,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/FakeBrowser.xaml
+++ b/src/AasxWpfControlLibrary/FakeBrowser.xaml
@@ -6,12 +6,14 @@
              xmlns:local="clr-namespace:AasxPackageExplorer"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Grid>
         <Viewbox>

--- a/src/AasxWpfControlLibrary/FakeBrowser.xaml.cs
+++ b/src/AasxWpfControlLibrary/FakeBrowser.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,21 +21,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/HintBubble.xaml
+++ b/src/AasxWpfControlLibrary/HintBubble.xaml
@@ -6,12 +6,14 @@
              xmlns:local="clr-namespace:AasxPackageExplorer"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="300">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!--
     <Grid>

--- a/src/AasxWpfControlLibrary/HintBubble.xaml.cs
+++ b/src/AasxWpfControlLibrary/HintBubble.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,21 +21,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/ImportCSV.cs
+++ b/src/AasxWpfControlLibrary/ImportCSV.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxWpfControlLibrary/Log.cs
+++ b/src/AasxWpfControlLibrary/Log.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/LogMessageFlyout.xaml
+++ b/src/AasxWpfControlLibrary/LogMessageFlyout.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/LogMessageFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/LogMessageFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxGlobalLogging;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/ModifyRepo.cs
+++ b/src/AasxWpfControlLibrary/ModifyRepo.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,21 +17,6 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using AasxGlobalLogging;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/NodeSetImport.cs
+++ b/src/AasxWpfControlLibrary/NodeSetImport.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AasxWpfControlLibrary/Options.cs
+++ b/src/AasxWpfControlLibrary/Options.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.IO;
@@ -12,22 +21,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-The Grapevine REST server framework is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/PackageCentral.cs
+++ b/src/AasxWpfControlLibrary/PackageCentral.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/Plugins.cs
+++ b/src/AasxWpfControlLibrary/Plugins.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,23 +18,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The Newtonsoft.JSON serialization is licensed under the MIT License (MIT).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml
+++ b/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/ProgressBarFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,21 +24,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml
@@ -7,13 +7,14 @@
              x:Class="AasxPackageExplorer.SecureConnectFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" MaxHeight="600" MaxWidth="1600" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -20,21 +29,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml
+++ b/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml
@@ -7,14 +7,16 @@
              xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2" x:Class="AasxPackageExplorer.SelectAasEntityFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
-    <!-- TODO: fix -->
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
+        <!-- TODO: fix -->
     <!-- ReSharper disable Xaml.MissingGridIndex -->
 
     <UserControl.Resources>

--- a/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectAasEntityFlout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,21 +26,6 @@ using AasxIntegrationBase;
 using AasxWpfControlLibrary;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectEclassEntity.xaml
+++ b/src/AasxWpfControlLibrary/SelectEclassEntity.xaml
@@ -6,12 +6,14 @@
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
         Title="Select eCl@ss entity .." Height="300" Width="700" Loaded="Window_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Grid>
 

--- a/src/AasxWpfControlLibrary/SelectEclassEntity.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectEclassEntity.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -16,21 +25,6 @@ using System.Windows.Shapes;
 using System.Xml;
 
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml
@@ -7,13 +7,14 @@
              xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2" x:Class="AasxPackageExplorer.SelectEclassEntityFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectEclassEntityFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml
@@ -8,13 +8,14 @@
              x:Class="AasxPackageExplorer.SelectFromListFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectFromListFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,21 +25,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml
@@ -8,13 +8,14 @@
              x:Class="AasxPackageExplorer.SelectFromReferablesPoolFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectFromReferablesPoolFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml
@@ -6,13 +6,14 @@
              xmlns:local="clr-namespace:AasxWpfControlLibrary"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded" KeyDown="UserControl_KeyDown">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,21 +24,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml
+++ b/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml
@@ -8,13 +8,14 @@
              x:Class="AasxPackageExplorer.SelectQualifierPresetFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,21 +26,6 @@ using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/SelectableTextBlock.cs
+++ b/src/AasxWpfControlLibrary/SelectableTextBlock.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/AasxWpfControlLibrary/ShowValidationResultsFlyout.xaml
+++ b/src/AasxWpfControlLibrary/ShowValidationResultsFlyout.xaml
@@ -8,13 +8,14 @@
              x:Class="AasxPackageExplorer.ShowValidationResultsFlyout"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-    <!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/ShowValidationResultsFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/ShowValidationResultsFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/TextBoxFlyout.xaml
+++ b/src/AasxWpfControlLibrary/TextBoxFlyout.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/TextBoxFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/TextBoxFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,21 +24,6 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/TextEditorFlyout.xaml
+++ b/src/AasxWpfControlLibrary/TextEditorFlyout.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="900" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary Source="Themes/Generic.xaml"/>

--- a/src/AasxWpfControlLibrary/TextEditorFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/TextEditorFlyout.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,21 +25,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using Newtonsoft.Json;
 using static AasxPackageExplorer.Plugins;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/Themes/Generic.xaml
+++ b/src/AasxWpfControlLibrary/Themes/Generic.xaml
@@ -1,12 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AasxWpfControlLibrary">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Style x:Key="TranspRoundCorner" TargetType="{x:Type Button}">
         <Setter Property="HorizontalContentAlignment" Value="Center"/>

--- a/src/AasxWpfControlLibrary/ToolControlFindReplace.xaml
+++ b/src/AasxWpfControlLibrary/ToolControlFindReplace.xaml
@@ -7,6 +7,15 @@
              xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2" x:Class="AasxPackageExplorer.ToolControlFindReplace"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="800" Background="#ffffff" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <UserControl.Resources>
         
     </UserControl.Resources>

--- a/src/AasxWpfControlLibrary/ToolControlFindReplace.xaml.cs
+++ b/src/AasxWpfControlLibrary/ToolControlFindReplace.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/TreeListView.cs
+++ b/src/AasxWpfControlLibrary/TreeListView.cs
@@ -1,4 +1,13 @@
-﻿// see: https://www.codeproject.com/Articles/24973/TreeListView-2
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+// see: https://www.codeproject.com/Articles/24973/TreeListView-2
 
 using System;
 using System.Collections.Generic;
@@ -14,21 +23,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/AasxWpfControlLibrary/VisualAasxElements.cs
+++ b/src/AasxWpfControlLibrary/VisualAasxElements.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -8,21 +17,6 @@ using System.Threading.Tasks;
 using System.Windows.Media;
 using AasxGlobalLogging;
 using AdminShellNS;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 // ReSharper disable VirtualMemberCallInConstructor
 

--- a/src/AasxWpfControlLibrary/VisualElementHistoryControl.xaml
+++ b/src/AasxWpfControlLibrary/VisualElementHistoryControl.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:AasxPackageExplorer"
              mc:Ignorable="d" 
              d:DesignHeight="20" d:DesignWidth="50">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="20"/>

--- a/src/AasxWpfControlLibrary/VisualElementHistoryControl.xaml.cs
+++ b/src/AasxWpfControlLibrary/VisualElementHistoryControl.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml
+++ b/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml
@@ -8,12 +8,14 @@
              x:Class="AasxPackageExplorer.TransparentComboBox"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="200" Loaded="UserControl_Loaded">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
 
-<!-- Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
-The browser functionality is under the cefSharp license (see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-The JSON serialization is under the MIT license (see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0). -->
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <!-- TODO : check -->
     <!-- ReSharper disable Xaml.MissingGridIndex -->

--- a/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml.cs
+++ b/src/AasxWpfControlLibrary/WpfControls/TransparentComboBox.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -17,21 +26,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
-
-/*
-Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
-Author: Michael Hoffmeister
-
-The browser functionality is under the cefSharp license
-(see https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE).
-
-The JSON serialization is under the MIT license
-(see https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md).
-
-The QR code generation is under the MIT license (see https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
-
-The Dot Matrix Code (DMC) generation is under Apache license v.2 (see http://www.apache.org/licenses/LICENSE-2.0).
-*/
 
 namespace AasxPackageExplorer
 {

--- a/src/CheckHeaders.ps1
+++ b/src/CheckHeaders.ps1
@@ -1,0 +1,67 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    This script checks the headers of the source files and makes sure that the
+    copyright notices and references to the licenses are in place.
+#>
+
+$ErrorActionPreference = "Stop"
+
+Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
+    AssertDotnet
+
+
+function Main
+{
+    AssertDotnet
+    Set-Location $PSScriptRoot
+
+    # We exclude some projects and files from the check as we do not re-license
+    # the source code, but merely include them in our code base from external
+    # sources.
+
+    & dotnet.exe run --project CheckHeadersScript `
+        --inputs "**\*.cs" "**\*.xaml" `
+        --excludes `
+            "packages\**" `
+            "**\obj\**" `
+            "**\bin\**" `
+            "**\AssemblyInfo.cs" `
+            "**\Properties\*.Designer.cs" `
+            "**\DocTest*.cs" `
+            "*.Tests\**\*.cs" `
+            "*.GuiTests\**\*.cs" `
+            "AasxOpenidClient\*.cs" `
+            "AasxUaNetServer\AasxServer\AasNodeManager.cs" `
+            "AasxPluginUaNetClient\Plugin.cs" `
+            "AasxPluginUaNetClient\UASampleClient.cs" `
+            "AasxUaNetServer\Base\*.cs" `
+            "AasxUaNetServer\SampleServer.cs" `
+            "AasxUaNetServer\SampleServer.SampleModel.cs" `
+            "AasxUaNetServer\SampleServer.UserAuthentication.cs" `
+            "AasxUaNetServer\UaServerWrapper.cs" `
+            "MsaglWpfControl\*" `
+            "CheckHeadersScript\*.cs" `
+            "CheckScript\*.cs" `
+            "AasxIntegrationBaseWpf\OriginalResources\*.xaml" `
+            "WpfMtpControl\Resources\PNID_DIN_EN_ISO_10628.xaml" `
+            "WpfMtpControl\Resources\PNID_Festo.xaml" `
+            "WpfXamlTool\Resources\preset0.xaml" `
+            "WpfXamlTool\Resources\preset1.xaml"
+
+    if($LASTEXITCODE -ne 0)
+    {
+        throw "The CheckHeadersScript failed, see above."
+    }
+
+    Write-Host "All the inspected headers were OK."
+}
+
+$previousLocation = Get-Location; try
+{
+    Main
+}
+finally
+{
+    Set-Location $previousLocation
+}

--- a/src/CheckHeadersScript/CheckHeadersScript.csproj
+++ b/src/CheckHeadersScript/CheckHeadersScript.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Glob" Version="1.1.6" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20303.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/CheckHeadersScript/Folder.DotSettings
+++ b/src/CheckHeadersScript/Folder.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dedented/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=textwrap/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/CheckHeadersScript/Input.cs
+++ b/src/CheckHeadersScript/Input.cs
@@ -1,0 +1,103 @@
+﻿using ArgumentException = System.ArgumentException;
+using StringComparer = System.StringComparer;
+using Path = System.IO.Path;
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CheckHeadersScript
+{
+    public static class Input
+    {
+                /// <summary>
+        /// Matches all the files defined by the patterns, includes and excludes.
+        /// If any of the patterns is given as a relative directory,
+        /// current working directory is prepended.
+        /// </summary>
+        /// <param name="cwd">current working directory</param>
+        /// <param name="patterns">GLOB patterns to match files for inspection</param>
+        /// <param name="excludes">GLOB patterns to exclude files matching patterns</param>
+        /// <returns>Paths of the matched files</returns>
+        public static IEnumerable<string> MatchFiles(
+            string cwd,
+            List<string> patterns,
+            List<string> excludes)
+        {
+            ////
+            // Pre-condition(s)
+            ////
+
+            if (cwd.Length == 0)
+            {
+                throw new ArgumentException("Expected a non-empty cwd");
+            }
+
+            if (!Path.IsPathRooted(cwd))
+            {
+                throw new ArgumentException("Expected cwd to be rooted");
+            }
+
+            ////
+            // Implementation
+            ////
+
+            if (patterns.Count == 0)
+            {
+                yield break;
+            }
+
+            var globExcludes = excludes.Select(
+                (pattern) =>
+                {
+                    string rootedPattern = (Path.IsPathRooted(pattern))
+                        ? pattern
+                        : Path.Join(cwd, pattern);
+
+                    return new GlobExpressions.Glob(rootedPattern);
+                }).ToList();
+
+            foreach (var pattern in patterns)
+            {
+                IEnumerable<string>? files;
+
+                if (Path.IsPathRooted(pattern))
+                {
+                    var root = Path.GetPathRoot(pattern);
+                    if (root == null)
+                    {
+                        throw new ArgumentException(
+                            $"Root could not be retrieved from rooted pattern: {pattern}");
+                    }
+
+                    var relPattern = Path.GetRelativePath(root, pattern);
+
+                    files = GlobExpressions.Glob.Files(root, relPattern)
+                        .Select((path) => Path.Join(root, path));
+                }
+                else
+                {
+                    files = GlobExpressions.Glob.Files(cwd, pattern);
+                }
+
+                List<string> accepted =
+                    files
+                        .Where((path) =>
+                        {
+                            string rootedPath = (Path.IsPathRooted(path))
+                                ? path
+                                : Path.Join(cwd, path);
+
+                            return globExcludes.TrueForAll((glob) => !glob.IsMatch(rootedPath));
+                        })
+                        .ToList();
+
+                accepted.Sort(StringComparer.InvariantCulture);
+
+                foreach (string path in accepted)
+                {
+                    yield return path;
+                }
+            }
+        }
+    }
+}

--- a/src/CheckHeadersScript/LICENSE.txt
+++ b/src/CheckHeadersScript/LICENSE.txt
@@ -1,0 +1,1010 @@
+Copyright (c) 2018-2020 Festo AG & Co. KG
+<https://www.festo.com/net/de_de/Forms/web/contact_international>,
+author: Michael Hoffmeister
+
+Copyright (c) 2019-2020 PHOENIX CONTACT GmbH & Co. KG
+<opensource@phoenixcontact.com>,
+author: Andreas Orzelski
+
+Copyright (c) 2019-2020 Fraunhofer IOSB-INA Lemgo,
+    eine rechtlich nicht selbstaendige Einrichtung der Fraunhofer-Gesellschaft
+    zur Foerderung der angewandten Forschung e.V.
+
+Copyright (c) 2020 Schneider Electric Automation GmbH
+<marco.mendes@se.com>,
+author: Marco Mendes
+
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+The AASX Package Explorer is licensed under the Apache License 2.0
+(Apache-2.0, see below).
+
+The AASX Package Explorer is a sample application for demonstration of the
+features of the Asset Administration Shell.
+The implementation uses the concepts of the document "Details of the Asset
+Administration Shell" published on www.plattform-i40.de which is licensed
+under Creative Commons CC BY-ND 3.0 DE.
+
+When using eCl@ss or IEC CDD data, please check the corresponding license
+conditions.
+
+-------------------------------------------------------------------------------
+
+The components below are used in AASX Package Explorer.
+The related licenses are listed for information purposes only.
+Some licenses may only apply to their related plugins.
+
+The browser functionality is licensed under the cefSharp license (see below).
+
+The Newtonsoft.JSON serialization is licensed under the MIT License
+(MIT, see below).
+
+The QR code generation is licensed under the MIT license (MIT, see below).
+
+The Zxing.Net Dot Matrix Code (DMC) generation is licensed under
+the Apache License 2.0 (Apache-2.0, see below).
+
+The Grapevine REST server framework is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The AutomationML.Engine is licensed under the MIT license (MIT, see below).
+
+The MQTT server and client is licensed under the MIT license (MIT, see below).
+
+The ClosedXML Excel reader/writer is licensed under the MIT license (MIT,
+see below).
+
+The CountryFlag WPF control is licensed under the Code Project Open License
+(CPOL, see below).
+
+The DocumentFormat.OpenXml SDK is licensed under the MIT license (MIT,
+see below).
+
+The ExcelNumberFormat number parser is licensed under the MIT license (MIT,
+see below).
+
+The FastMember reflection access is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The IdentityModel OpenID client is licensed under Apache License 2.0
+(Apache-2.0, see below).
+
+The jose-jwt object signing and encryption is licensed under the
+MIT license (MIT, see below).
+
+The ExcelDataReader is licensed under the MIT license (MIT, see below).
+
+The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
+(MIT, see below).
+
+The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
+(MIT) (see below)
+
+
+-------------------------------------------------------------------------------
+
+
+With respect to AASX Package Explorer
+=====================================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to cefSharp
+========================
+
+(https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE)
+
+Copyright © The CefSharp Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+     Framework nor the name CefSharp nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+With respect to Newtonsoft.Json
+===============================
+
+(https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md)
+
+The MIT License (MIT)
+
+Copyright (c) 2007 James Newton-King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to QRcoder
+=======================
+
+(https://github.com/codebude/QRCoder/blob/master/LICENSE.txt)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2018 Raffael Herrmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to ZXing.Net
+=========================
+With respect to Grapevine
+=========================
+With respect to FastMember
+==========================
+With respect to IdentityModel
+=============================
+
+(http://www.apache.org/licenses/LICENSE-2.0)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+With respect to AutomationML.Engine
+===================================
+
+(https://raw.githubusercontent.com/AutomationML/AMLEngine2.1/master/license.txt)
+
+The MIT License (MIT)
+
+Copyright 2017 AutomationML e.V.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+With respect to MQTTnet
+=======================
+
+(https://github.com/chkr1011/MQTTnet/blob/master/LICENSE)
+
+MIT License
+
+MQTTnet Copyright (c) 2016-2019 Christian Kratky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to ClosedXML
+=========================
+
+(https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE)
+
+MIT License
+
+Copyright (c) 2016 ClosedXML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepct to CountryFlag
+===========================
+
+(https://www.codeproject.com/Articles/190722/WPF-CountryFlag-Control)
+
+The Code Project Open License (CPOL) 1.02
+
+Copyright © 2017 Meshack Musundi
+
+Preamble
+
+This License governs Your use of the Work. This License is intended to allow
+developers to use the Source Code and Executable Files provided as part of
+the Work in any application in any form.
+
+The main points subject to the terms of the License are:
+
+    Source Code and Executable Files can be used in commercial applications;
+    Source Code and Executable Files can be redistributed; and
+    Source Code can be modified to create derivative works.
+    No claim of suitability, guarantee, or any warranty whatsoever is provided.
+	The software is provided "as-is".
+    The Article(s) accompanying the Work may not be distributed or republished
+	without the Author's consent
+
+This License is entered between You, the individual or other entity reading or
+otherwise making use of the Work licensed pursuant to this License and the
+individual or other entity which offers the Work under the terms of this
+License ("Author").
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+CODE PROJECT OPEN LICENSE ("LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT
+AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED
+UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HEREIN, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. THE AUTHOR GRANTS YOU THE RIGHTS
+CONTAINED HEREIN IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS. IF YOU DO NOT AGREE TO ACCEPT AND BE BOUND BY THE TERMS OF THIS
+LICENSE, YOU CANNOT MAKE ANY USE OF THE WORK.
+
+Definitions.
+    "Articles" means, collectively, all articles written by Author which
+describes how the Source Code and Executable Files for the Work may
+be used by a user.
+    "Author" means the individual or entity that offers the Work under
+the terms of this License.
+    "Derivative Work" means a work based upon the Work or upon the Work
+and other pre-existing works.
+    "Executable Files" refer to the executables, binary files,
+configuration and any required data files included in the Work.
+    "Publisher" means the provider of the website, magazine, CD-ROM,
+DVD or other medium from or by which the Work is obtained by You.
+    "Source Code" refers to the collection of source code and
+configuration files used to create the Executable Files.
+    "Standard Version" refers to such a Work if it has not been modified,
+or has been modified in accordance with the consent of the Author,
+such consent being in the full discretion of the Author.
+    "Work" refers to the collection of files distributed by the Publisher,
+including the Source Code, Executable Files, binaries, data files,
+documentation, whitepapers and the Articles.
+    "You" is you, an individual or entity wishing to use the Work and
+exercise your rights under this License.
+
+Fair Use/Fair Use Rights. Nothing in this License is intended to reduce,
+limit, or restrict any rights arising from fair use, fair dealing,
+first sale or other limitations on the exclusive rights of the
+copyright owner under copyright law or other applicable laws.
+
+License Grant. Subject to the terms and conditions of this License, the
+Author hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license
+to exercise the rights in the Work as stated below:
+    You may use the standard version of the Source Code or Executable
+Files in Your own applications.
+    You may apply bug fixes, portability fixes and other modifications
+obtained from the Public Domain or from the Author. A Work modified
+in such a way shall still be considered the standard version and will
+be subject to this License.
+    You may otherwise modify Your copy of this Work (excluding the Articles)
+in any way to create a Derivative Work, provided that You insert a prominent
+notice in each changed file stating how, when and where You changed that file.
+    You may distribute the standard version of the Executable Files and Source
+Code or Derivative Work in aggregate with other (possibly commercial)
+programs as part of a larger (possibly commercial) software distribution.
+    The Articles discussing the Work published in any form by the author may
+not be distributed or republished without the Author's consent. The author
+retains copyright to any such Articles. You may use the Executable Files and
+Source Code pursuant to this License but you may not repost or republish or
+otherwise distribute or make available the Articles, without the prior written
+consent of the Author.
+
+Any subroutines or modules supplied by You and linked into the Source Code
+or Executable Files of this Work shall not be considered part of this Work
+and will not be subject to the terms of this License.
+
+Patent License. Subject to the terms and conditions of this License, each
+Author hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, import, and otherwise transfer the Work.
+
+Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+    You agree not to remove any of the original copyright, patent, trademark,
+and attribution notices and associated disclaimers that may appear in the
+Source Code or Executable Files.
+    You agree not to advertise or in any way imply that this Work is a product
+of Your own.
+    The name of the Author may not be used to endorse or promote products
+derived from the Work without the prior written consent of the Author.
+    You agree not to sell, lease, or rent any part of the Work. This does
+not restrict you from including the Work or any part of the Work inside
+a larger software distribution that itself is being sold. The Work by itself,
+though, cannot be sold, leased or rented.
+    You may distribute the Executable Files and Source Code only under the terms
+of this License, and You must include a copy of, or the Uniform Resource
+Identifier for, this License with every copy of the Executable Files or
+Source Code You distribute and ensure that anyone receiving such Executable
+Files and Source Code agrees that the terms of this License apply to such
+Executable Files and/or Source Code. You may not offer or impose any terms
+on the Work that alter or restrict the terms of this License or the
+recipients' exercise of the rights granted hereunder. You may not sublicense
+the Work. You must keep intact all notices that refer to this License and to
+the disclaimer of warranties. You may not distribute the Executable Files or
+Source Code with any technological measures that control access or use of the
+Work in a manner inconsistent with the terms of this License.
+    You agree not to use the Work for illegal, immoral or improper
+purposes, or on pages containing illegal, immoral or improper material.
+The Work is subject to applicable export laws. You agree to comply with all
+such laws and regulations that may apply to the Work after Your receipt of
+the Work.
+
+Representations, Warranties and Disclaimer. THIS WORK IS PROVIDED "AS IS",
+"WHERE IS" AND "AS AVAILABLE", WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES OR
+CONDITIONS OR GUARANTEES. YOU, THE USER, ASSUME ALL RISK IN ITS USE,
+INCLUDING COPYRIGHT INFRINGEMENT, PATENT INFRINGEMENT, SUITABILITY, ETC.
+AUTHOR EXPRESSLY DISCLAIMS ALL EXPRESS, IMPLIED OR STATUTORY WARRANTIES
+OR CONDITIONS, INCLUDING WITHOUT LIMITATION, WARRANTIES OR CONDITIONS
+OF MERCHANTABILITY, MERCHANTABLE QUALITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR ANY WARRANTY OF TITLE OR NON-INFRINGEMENT, OR THAT THE WORK
+(OR ANY PORTION THEREOF) IS CORRECT, USEFUL, BUG-FREE OR FREE OF VIRUSES.
+YOU MUST PASS THIS DISCLAIMER ON WHENEVER YOU DISTRIBUTE THE WORK OR DERIVATIVE
+WORKS.
+
+Indemnity. You agree to defend, indemnify and hold harmless the Author and the
+Publisher from and against any claims, suits, losses, damages, liabilities,
+costs, and expenses (including reasonable legal or attorneys’ fees)
+resulting from or relating to any use of the Work by You.
+
+Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+IN NO EVENT WILL THE AUTHOR OR THE PUBLISHER BE LIABLE TO YOU ON ANY LEGAL
+THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK OR OTHERWISE,
+EVEN IF THE AUTHOR OR THE PUBLISHER HAS BEEN ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+Termination.
+    This License and the rights granted hereunder will terminate
+automatically upon any breach by You of any term of this License.
+Individuals or entities who have received Derivative Works from You under
+this License, however, will not have their licenses terminated provided such
+individuals or entities remain in full compliance with those licenses.
+Sections 1, 2, 6, 7, 8, 9, 10 and 11 will survive any termination of
+this License.
+    If You bring a copyright, trademark, patent or any other infringement
+claim against any contributor over infringements You claim are made by the
+Work, your License from such contributor to the Work ends automatically.
+    Subject to the above terms and conditions, this License is perpetual
+(for the duration of the applicable copyright in the Work).
+Notwithstanding the above, the Author reserves the right to release the Work
+under different license terms or to stop distributing the Work at any time;
+provided, however that any such election will not serve to withdraw this
+License (or any other license that has been, or is required to be,
+granted under the terms of this License), and this License will continue
+in full force and effect unless terminated as stated above.
+
+Publisher. The parties hereby confirm that the Publisher shall not, under
+any circumstances, be responsible for and shall not have any liability
+in respect of the subject matter of this License. The Publisher makes no
+warranty whatsoever in connection with the Work and shall not be liable
+to You or any party on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or consequential damages
+arising in connection to this license. The Publisher reserves the right to
+cease making the Work available to You at any time without notice
+
+Miscellaneous
+    This License shall be governed by the laws of the location of the head
+office of the Author or if the Author is an individual, the laws of
+location of the principal place of residence of the Author.
+    If any provision of this License is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this License, and without further action by the
+parties to this License, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+    No term or provision of this License shall be deemed waived and no
+breach consented to unless such waiver or consent shall be in writing
+and signed by the party to be charged with such waiver or consent.
+    This License constitutes the entire agreement between the parties
+with respect to the Work licensed herein. There are no understandings,
+agreements or representations with respect to the Work not specified herein.
+The Author shall not be bound by any additional provisions that may appear
+in any communication from You. This License may not be modified without
+the mutual written agreement of the Author and You.
+
+
+With respect to DocumentFormat.OpenXml
+======================================
+
+(https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to ExcelNumberFormat
+=================================
+
+(https://github.com/andersnm/ExcelNumberFormat/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 andersnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With respect to jose-jwt
+========================
+
+(https://github.com/dvsekhvalnov/jose-jwt/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 dvsekhvalnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+With resepect to ExcelDataReader
+================================
+
+(https://github.com/ExcelDataReader/ExcelDataReader/blob/develop/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 ExcelDataReader
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+With resepect to OPC UA Example Code
+====================================
+
+ * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+
+
+
+With respect to MSAGL (Microsoft Automatic Graph Layout)
+========================================================
+(see: https://github.com/microsoft/automatic-graph-layout/blob/master/LICENSE)
+
+Microsoft Automatic Graph Layout, MSAGL 
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved. 
+
+MIT License 
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+""Software""), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/CheckHeadersScript/Program.cs
+++ b/src/CheckHeadersScript/Program.cs
@@ -1,0 +1,392 @@
+﻿using Console = System.Console;
+using Directory = System.IO.Directory;
+using File = System.IO.File;
+using InvalidOperationException = System.InvalidOperationException;
+using Path = System.IO.Path;
+using Regex = System.Text.RegularExpressions.Regex;
+using StringComparison = System.StringComparison;
+using StringSplitOptions = System.StringSplitOptions;
+using XmlReaderSettings = System.Xml.XmlReaderSettings;
+using XmlReader = System.Xml.XmlReader;
+using XmlDocument = System.Xml.XmlDocument;
+using XmlNode = System.Xml.XmlNode;
+
+using System.Collections.Generic;
+using System.CommandLine;
+
+
+
+namespace CheckHeadersScript
+{
+    internal static class Program
+    {
+        private static readonly Regex OnlySpaceRe = new Regex(@"^\s+$");
+
+        private static List<string> ExamineContent(string[] lines)
+        {
+            if (lines.Length < 7)
+            {
+                return new List<string>
+                {
+                    "Expected at least 7 lines " +
+                    "(empty, copyright, empty, our license, empty, reference to licenses, empty), " +
+                    $"but got only {lines.Length} line(s)"
+                };
+            }
+
+            var result = new List<string>();
+
+            if (lines[0] != "")
+            {
+                result.Add($"Expected the first line to be empty, but got: {Quote(lines[0])}");
+            }
+
+            if (lines[^1] != "")
+            {
+                result.Add($"Expected the last line to be empty, but got: {Quote(lines[^1])}");
+            }
+
+            if (!lines[1].StartsWith("Copyright"))
+            {
+                result.Add(
+                    "Expected the second line to start with 'Copyright', " +
+                    $"but got: {Quote(lines[1])}");
+            }
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (OnlySpaceRe.IsMatch(lines[i]))
+                {
+                    result.Add($"Unexpected trailing space on line {i + 1}: {Quote(lines[i])}");
+                }
+            }
+
+            for (var i = 0; i < lines.Length - 1; i++)
+            {
+                if (lines[i] == "" && lines[i + 1] == "")
+                {
+                    result.Add($"Unexpected vertical space (more than one empty line) at line {i + 1}");
+                }
+            }
+
+            const string ourLicense = "This source code is licensed under the Apache License 2.0 (see LICENSE.txt).";
+
+            int licenseLine = lines.Length - 3;
+
+            if (lines[licenseLine - 1] != ourLicense)
+            {
+                result.Add(
+                    $"Expected the penultimate paragraph on line {licenseLine} to be a reference to our license " +
+                    $"({Quote(ourLicense)}), " +
+                    $"but got: {Quote(lines[licenseLine - 1])}");
+            }
+
+            const string referenceToLicenses =
+                "This source code may use other Open Source software components (see LICENSE.txt).";
+
+            var referenceLine = lines.Length - 1;
+            if (lines[referenceLine - 1] != referenceToLicenses)
+            {
+                result.Add(
+                    $"Expected the last paragraph on line {referenceLine} to be " +
+                    $"{Quote(referenceToLicenses)}, " +
+                    $"but got: {Quote(lines[referenceLine - 1])}");
+            }
+
+            return result;
+        }
+
+        class InvalidHeader
+        {
+            public readonly string? Comment;
+            public readonly List<string> Errors;
+
+            public InvalidHeader(string? comment, List<string> errors)
+            {
+                Comment = comment;
+                Errors = errors;
+            }
+        }
+
+        /// <summary>
+        /// Adds quotes around the text and escapes a couple of common special characters.
+        /// </summary>
+        /// <remarks>Do not use <see cref="System.Text.Json.JsonSerializer"/> since it escapes so many common
+        /// characters that the output is unreadable.
+        /// See <a href="https://github.com/dotnet/runtime/issues/1564">this GitHub issue</a></remarks>
+        private static string Quote(string text)
+        {
+            string escaped =
+                text
+                    .Replace("\\", "\\\\")
+                    .Replace("\"", "\\\"")
+                    .Replace("\n", "\\n")
+                    .Replace("\r", "\\r")
+                    .Replace("\t", "\\t")
+                    .Replace("\a", "\\b")
+                    .Replace("\b", "\\b")
+                    .Replace("\v", "\\v")
+                    .Replace("\f", "\\f");
+
+            return $"\"{escaped}\"";
+        }
+
+        /// <summary>
+        /// Imitates the Python's
+        /// <a href="https://docs.python.org/3/library/textwrap.html#textwrap.dedent"><c>textwrap.dedent</c></a>.
+        /// </summary>
+        /// <param name="text">Text to be dedented</param>
+        /// <returns>array of dedented lines</returns>
+        private static string[] Dedent(string text)
+        {
+            var lines = text.Split(
+                new[] {"\r\n", "\r", "\n"},
+                StringSplitOptions.None);
+
+            // Search for the first non-empty line starting from the second line.
+            // The first line is not expected to be indented.
+            var firstNonemptyLine = -1;
+            for (var i = 1; i < lines.Length; i++)
+            {
+                if (lines[i].Length == 0) continue;
+
+                firstNonemptyLine = i;
+                break;
+            }
+
+            if (firstNonemptyLine < 0) return lines;
+
+            // Search for the second non-empty line.
+            // If there is no second non-empty line, we can return immediately as we
+            // can not pin the indent.
+            var secondNonemptyLine = -1;
+            for (var i = firstNonemptyLine + 1; i < lines.Length; i++)
+            {
+                if (lines[i].Length == 0) continue;
+
+                secondNonemptyLine = i;
+                break;
+            }
+
+            if (secondNonemptyLine < 0) return lines;
+
+            // Match the common prefix with at least two non-empty lines
+            
+            var firstNonemptyLineLength = lines[firstNonemptyLine].Length;
+            var prefixLength = 0;
+            
+            for (int column = 0; column < firstNonemptyLineLength; column++)
+            {
+                char c = lines[firstNonemptyLine][column];
+                if (c != ' ' && c != '\t') break;
+                
+                bool matched = true;
+                for (int lineIdx = firstNonemptyLine + 1; lineIdx < lines.Length; lineIdx++)
+                {
+                    if (lines[lineIdx].Length == 0) continue;
+                    
+                    if (lines[lineIdx].Length < column + 1)
+                    {
+                        matched = false;
+                        break;
+                    }
+
+                    if (lines[lineIdx][column] != c)
+                    {
+                        matched = false;
+                        break;
+                    }
+                }
+
+                if (!matched) break;
+                
+                prefixLength++;
+            }
+
+            if (prefixLength == 0) return lines;
+            
+            for (var i = 1; i < lines.Length; i++)
+            {
+                if (lines[i].Length > 0) lines[i] = lines[i].Substring(prefixLength);
+            }
+
+            return lines;
+        }
+        
+        private static InvalidHeader? Examine(string path)
+        {
+            string extension = Path.GetExtension(path).ToLower();
+            switch (extension)
+            {
+                case ".cs":
+                {
+                    string text = File.ReadAllText(path);
+
+                    if (text.Length <= 4)
+                    {
+                        return new InvalidHeader(
+                            null, new List<string>
+                            {
+                                $"The file is too short (only {text.Length} character(s)). No header could be found."
+                            });
+                    }
+
+                    if (!text.StartsWith("/*"))
+                    {
+                        return new InvalidHeader(
+                            null, new List<string>
+                            {
+                                "The file does not start with '/*'. The first 4 characters are: " +
+                                Quote(text.Substring(0, 4))
+                            });
+                    }
+
+                    var commentEnds = text.IndexOf("*/", 2, StringComparison.InvariantCulture);
+                    if (commentEnds == -1)
+                    {
+                        return new InvalidHeader(
+                            null, new List<string> {"The closing '*/' could not be found."});
+                    }
+
+                    string comment = text.Substring(0, commentEnds + 2);
+                    if (!comment.StartsWith("/*") || !comment.EndsWith("*/"))
+                    {
+                        throw new InvalidOperationException(
+                            $"Invalid parsing of the comment: {Quote(comment)}");
+                    }
+
+                    string content = comment.Substring(2, comment.Length - 4);
+
+                    string[] lines = content.Split(
+                        new[] {"\r\n", "\r", "\n"},
+                        StringSplitOptions.None);
+                    
+                    var errors = ExamineContent(lines);
+                    return errors.Count == 0 ? null : new InvalidHeader(comment, errors);
+                }
+                case ".xaml":
+                {
+                    XmlReaderSettings readerSettings = new XmlReaderSettings {IgnoreComments = false};
+
+                    using XmlReader reader = XmlReader.Create(path, readerSettings);
+                    XmlDocument doc = new XmlDocument();
+                    doc.Load(reader);
+                    XmlNode root = doc.DocumentElement;
+
+                    if (root.ChildNodes.Count == 0)
+                    {
+                        return new InvalidHeader(
+                            null, new List<string>
+                            {
+                                $"Expected the comment node just beneath the root node ({root.Name}), " +
+                                "but found no children."
+                            });
+                    }
+                    if (!(root.ChildNodes[0] is System.Xml.XmlComment))
+                    {
+                        return new InvalidHeader(
+                            null, new List<string>
+                            {
+                                $"Expected the comment node just beneath the root node (<{root.Name}>), " +
+                                $"but the first child was a node of type {root.ChildNodes[0].NodeType}."
+                            });
+                    }
+
+                    string content = root.ChildNodes[0].InnerText;
+                    string[] lines = Dedent(content);
+
+                    var errors = ExamineContent(lines);
+                    return errors.Count == 0 ? null : new InvalidHeader(content, errors);
+                }
+                default:
+                    return new InvalidHeader(
+                        null, new List<string>
+                        {
+                            "We do not know how to inspect the header of this file " +
+                            "(only *.cs and *.xaml are supported)."
+                        });
+            }
+        }
+
+        private static int Scan(string[] inputs, string[]? excludes, bool verbose)
+        {
+            string cwd = Directory.GetCurrentDirectory();
+            IEnumerable<string> paths = Input.MatchFiles(
+                cwd,
+                new List<string>(inputs),
+                new List<string>(excludes ?? new string[0]));
+
+            int exitCode = 0;
+
+            foreach (string path in paths)
+            {
+                InvalidHeader? invalidHeader = Examine(path);
+
+                if (invalidHeader == null)
+                {
+                    if (verbose)
+                    {
+                        Console.Out.WriteLine($"OK: {path}");
+                    }
+                }
+                else
+                {
+                    exitCode = 1;
+                    Console.Error.WriteLine($"FAIL: {path}: invalid header:");
+                    if (invalidHeader.Comment != null)
+                    {
+                        var lines = invalidHeader.Comment.Split(
+                            new[] {"\r\n", "\r", "\n"},
+                            StringSplitOptions.None);
+                        for (var i = 0; i < lines.Length; i++)
+                        {
+                            Console.Error.WriteLine($"{i + 1,2}: {lines[i]}");
+                        }
+
+                        Console.Error.WriteLine();
+                    }
+
+                    foreach (var error in invalidHeader.Errors)
+                    {
+                        Console.Error.WriteLine($" * {error}");
+                    }
+                }
+            }
+
+            return exitCode;
+        }
+
+        private static int MainWithCode(string[] args)
+        {
+            var rootCommand = new RootCommand(
+                "Examines the headers of the source code files for copyrights and licenses.")
+            {
+                new Option<string[]>(
+                        new[] {"--inputs", "-i"},
+                        "Glob patterns of the files to be inspected")
+                    {Required = true},
+
+                new Option<string[]>(
+                    new[] {"--excludes", "-e"},
+                    "Glob patterns of the files to be excluded from inspection"),
+
+                new Option<bool>(
+                    new[] {"--verbose"},
+                    "If set, makes the console output more verbose"
+                )
+            };
+
+            rootCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create(
+                (string[] inputs, string[] excludes, bool verbose) => Scan(inputs, excludes, verbose));
+
+            var exitCode = rootCommand.InvokeAsync(args).Result;
+            return exitCode;
+        }
+
+        public static void Main(string[] args)
+        {
+            var exitCode = MainWithCode(args);
+            System.Environment.ExitCode = exitCode;
+        }
+    }
+}

--- a/src/CheckScript/Program.cs
+++ b/src/CheckScript/Program.cs
@@ -133,6 +133,7 @@ namespace CheckScript
             var scriptsLabels = new List<(string, string)>
             {
                 ("CheckLicenses.ps1", "Licenses"),
+                ("CheckHeaders.ps1", "Headers"),
                 ("CheckFormat.ps1", "Format"),
                 ("CheckBiteSized.ps1", "BiteSized"),
                 ("CheckDeadCode.ps1", "DeadCode"),

--- a/src/MsaglWpfControl/Themes/Generic.xaml
+++ b/src/MsaglWpfControl/Themes/Generic.xaml
@@ -2,5 +2,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:MsaglWpfControl">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
 </ResourceDictionary>

--- a/src/WpfMtpControl/AasOpcUaClient.cs
+++ b/src/WpfMtpControl/AasOpcUaClient.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/src/WpfMtpControl/CanvasClickObject.cs
+++ b/src/WpfMtpControl/CanvasClickObject.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DataSources/MtpDataSourceOpcUa.cs
+++ b/src/WpfMtpControl/DataSources/MtpDataSourceOpcUa.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpDynamicInstance.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpDynamicInstance.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaMonTiny.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaMonTiny.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="80">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="3,3,3,3">
         <Grid x:Name="viewGrid" Margin="2">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaMonTiny.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaMonTiny.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewLarge.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewLarge.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="96" d:DesignWidth="130">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="3,3,3,3">
         <Grid x:Name="viewGrid" Margin="2">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewLarge.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewLarge.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewTiny.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewTiny.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="80">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="3,3,3,3">
         <Grid x:Name="viewGrid" Margin="2">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewTiny.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewAnaViewTiny.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinDrive.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinDrive.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="60" d:DesignWidth="100">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="Transparent" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="4">
         <Grid x:Name="viewGrid" Margin="0">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinDrive.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinDrive.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinValve.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinValve.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="60" d:DesignWidth="100">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="Transparent" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="4">
         <Grid x:Name="viewGrid" Margin="0">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinValve.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinValve.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinViewLarge.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinViewLarge.xaml
@@ -7,6 +7,15 @@
              mc:Ignorable="d" 
              d:DesignHeight="96" d:DesignWidth="130"
              MinHeight="40" MinWidth="50">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="3,3,3,3">
         <Grid x:Name="viewGrid" Margin="2">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinViewLarge.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinViewLarge.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinViewTiny.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinViewTiny.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="40">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="2,2,2,2">
         <Grid x:Name="viewGrid" Margin="0">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewBinViewTiny.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewBinViewTiny.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/DynamicInstances/MtpViewPIDCntlTiny.xaml
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewPIDCntlTiny.xaml
@@ -6,6 +6,15 @@
              xmlns:local="clr-namespace:Mtp.DynamicInstances"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="40">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Border Background="#202020" BorderThickness="1" BorderBrush="DarkGray" CornerRadius="2,2,2,2">
         <Grid x:Name="viewGrid" Margin="0">
             <Grid.RowDefinitions>

--- a/src/WpfMtpControl/DynamicInstances/MtpViewPIDCntlTiny.xaml.cs
+++ b/src/WpfMtpControl/DynamicInstances/MtpViewPIDCntlTiny.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/MtpAmlHelper.cs
+++ b/src/WpfMtpControl/MtpAmlHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/WpfMtpControl/MtpData.cs
+++ b/src/WpfMtpControl/MtpData.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;

--- a/src/WpfMtpControl/MtpDataSourceSubscriber.cs
+++ b/src/WpfMtpControl/MtpDataSourceSubscriber.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/MtpSymbolLib.cs
+++ b/src/WpfMtpControl/MtpSymbolLib.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/MtpVisuOpcUaClient.cs
+++ b/src/WpfMtpControl/MtpVisuOpcUaClient.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;

--- a/src/WpfMtpControl/MtpVisuOptions.cs
+++ b/src/WpfMtpControl/MtpVisuOptions.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMtpControl/MtpVisuViewer.xaml
+++ b/src/WpfMtpControl/MtpVisuViewer.xaml
@@ -6,6 +6,14 @@
              xmlns:local="clr-namespace:WpfMtpControl"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="500">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
 
     <Grid x:Name="gridOuter" Background="#ffe0e0e0">
         <Grid.RowDefinitions>

--- a/src/WpfMtpControl/MtpVisuViewer.xaml.cs
+++ b/src/WpfMtpControl/MtpVisuViewer.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/WpfMtpControl/MtpVisualObjectLib.cs
+++ b/src/WpfMtpControl/MtpVisualObjectLib.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/WpfMtpControl/UiElementHelper.cs
+++ b/src/WpfMtpControl/UiElementHelper.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/WpfMtpVisuViewer/App.xaml
+++ b/src/WpfMtpVisuViewer/App.xaml
@@ -3,6 +3,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:WpfMtpVisuViewer"
              StartupUri="MainWindow.xaml">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Application.Resources>
          
     </Application.Resources>

--- a/src/WpfMtpVisuViewer/App.xaml.cs
+++ b/src/WpfMtpVisuViewer/App.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;

--- a/src/WpfMtpVisuViewer/MainWindow.xaml
+++ b/src/WpfMtpVisuViewer/MainWindow.xaml
@@ -8,6 +8,15 @@
         Title="WPF MTP Viewer prototype" Height="350" Width="525" 
         Loaded="Window_Loaded" DragEnter="Window_DragEnter" Drop="Window_Drop" AllowDrop="True"
         SizeChanged="Window_SizeChanged">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/src/WpfMtpVisuViewer/MainWindow.xaml.cs
+++ b/src/WpfMtpVisuViewer/MainWindow.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/WpfXamlTool/App.xaml
+++ b/src/WpfXamlTool/App.xaml
@@ -3,6 +3,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:WpfXamlTool"
              StartupUri="MainWindow.xaml">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Application.Resources>
          
     </Application.Resources>

--- a/src/WpfXamlTool/App.xaml.cs
+++ b/src/WpfXamlTool/App.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;

--- a/src/WpfXamlTool/MainWindow.xaml
+++ b/src/WpfXamlTool/MainWindow.xaml
@@ -7,6 +7,15 @@
         mc:Ignorable="d"
         Title="WPF XAML Tool for effective XAML snippet creation" Height="450" Width="800" Loaded="Window_Loaded"
         DragEnter="Window_DragEnter" Drop="Window_Drop">
+    <!--
+    Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+    Author: Michael Hoffmeister
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
     <Grid Background="#303030">
 
         <Grid.RowDefinitions>

--- a/src/WpfXamlTool/MainWindow.xaml.cs
+++ b/src/WpfXamlTool/MainWindow.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿/*
+Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
+Author: Michael Hoffmeister
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;


### PR DESCRIPTION
This patch introduces a check that enforces uniform headers in all
`*.cs` and `*.xaml` files.