### PR TITLE
Add Glob to LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxAmlImExport/LICENSE.txt
+++ b/src/AasxAmlImExport/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxCsharpLibrary.Tests/LICENSE.txt
+++ b/src/AasxCsharpLibrary.Tests/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxCsharpLibrary/LICENSE.txt
+++ b/src/AasxCsharpLibrary/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxDictionaryImport.Tests/LICENSE.txt
+++ b/src/AasxDictionaryImport.Tests/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxDictionaryImport/LICENSE.txt
+++ b/src/AasxDictionaryImport/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxIntegrationBase/LICENSE.txt
+++ b/src/AasxIntegrationBase/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxIntegrationBaseWpf/LICENSE.txt
+++ b/src/AasxIntegrationBaseWpf/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxIntegrationEmptySample/LICENSE.txt
+++ b/src/AasxIntegrationEmptySample/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxMqtt/LICENSE.txt
+++ b/src/AasxMqtt/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxMqttClient/LICENSE.txt
+++ b/src/AasxMqttClient/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxOpenidClient/LICENSE.txt
+++ b/src/AasxOpenidClient/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxPackageExplorer.GuiTests/LICENSE.txt
+++ b/src/AasxPackageExplorer.GuiTests/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxPackageExplorer.Tests/LICENSE.txt
+++ b/src/AasxPackageExplorer.Tests/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxPackageExplorer/LICENSE.txt
+++ b/src/AasxPackageExplorer/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxPluginAdvancedTextEditor/LICENSE.TXT
+++ b/src/AasxPluginAdvancedTextEditor/LICENSE.TXT
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxPluginImageMap/LICENSE.TXT
+++ b/src/AasxPluginImageMap/LICENSE.TXT
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxPredefinedConcepts/LICENSE.txt
+++ b/src/AasxPredefinedConcepts/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxRestConsoleServer/LICENSE.txt
+++ b/src/AasxRestConsoleServer/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxRestServerLibrary/LICENSE.txt
+++ b/src/AasxRestServerLibrary/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxSignature/LICENSE.txt
+++ b/src/AasxSignature/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxToolkit.Tests/LICENSE.txt
+++ b/src/AasxToolkit.Tests/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxToolkit/LICENSE.txt
+++ b/src/AasxToolkit/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxUANodesetImExport/LICENSE.txt
+++ b/src/AasxUANodesetImExport/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxUaNetConsoleServer/LICENSE.txt
+++ b/src/AasxUaNetConsoleServer/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxUaNetServer/LICENSE.txt
+++ b/src/AasxUaNetServer/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/AasxWpfControlLibrary/LICENSE.txt
+++ b/src/AasxWpfControlLibrary/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/CheckHeadersScript/LICENSE.txt
+++ b/src/CheckHeadersScript/LICENSE.txt
@@ -11,7 +11,7 @@ Copyright (c) 2019-2020 Fraunhofer IOSB-INA Lemgo,
     zur Foerderung der angewandten Forschung e.V.
 
 Copyright (c) 2020 Schneider Electric Automation GmbH
-<marco.mendes@se.com>,
+<https://www.se.com/ww/en/work/support>,
 author: Marco Mendes
 
 Copyright (c) 2020 SICK AG <info@sick.de>
@@ -74,13 +74,17 @@ MIT license (MIT, see below).
 
 The ExcelDataReader is licensed under the MIT license (MIT, see below).
 
+Portions copyright (c) by OPC Foundation, Inc. and licensed under the
+Reciprocal Community License (RCL, see below)
+
 The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 (MIT, see below).
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
-(MIT) (see below)
+(MIT, see below)
 
-
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -952,7 +956,7 @@ With resepect to OPC UA Example Code
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
- * 
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -961,7 +965,7 @@ With resepect to OPC UA Example Code
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -976,19 +980,30 @@ With resepect to OPC UA Example Code
  * The complete license agreement can be found here:
  * http://opcfoundation.org/License/MIT/1.00/
 
+With respect to OPC Foundation
+==============================
 
+RCL License
+Reciprocal Community License 1.00 (RCL1.00)
+Version 1.00, June 24, 2009
+Copyright (C) 2008,2009 OPC Foundation, Inc., All Rights Reserved.
+
+https://opcfoundation.org/license/rcl.html
+
+Remark: PHOENIX CONTACT GmbH & Co. KG and Festo SE & Co. KG are members
+of OPC foundation.
 
 With respect to MSAGL (Microsoft Automatic Graph Layout)
 ========================================================
 (see: https://github.com/microsoft/automatic-graph-layout/blob/master/LICENSE)
 
-Microsoft Automatic Graph Layout, MSAGL 
+Microsoft Automatic Graph Layout, MSAGL
 
 Copyright (c) Microsoft Corporation
 
-All rights reserved. 
+All rights reserved.
 
-MIT License 
+MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -1008,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/CheckScript/LICENSE.txt
+++ b/src/CheckScript/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/LICENSE.txt
+++ b/src/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/MsaglWpfControl/LICENSE.txt
+++ b/src/MsaglWpfControl/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/WpfMtpControl/LICENSE.txt
+++ b/src/WpfMtpControl/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/WpfMtpVisuViewer/LICENSE.txt
+++ b/src/WpfMtpVisuViewer/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/WpfXamlTool/LICENSE.txt
+++ b/src/WpfXamlTool/LICENSE.txt
@@ -82,6 +82,9 @@ The OPC UA Example Code of OPC UA Standard is licensed under the MIT license
 
 The MSAGL (Microsoft Automatic Graph Layout) is licensed under the MIT license
 (MIT, see below)
+
+Glob (https://www.nuget.org/packages/Glob/) is licensed under the MIT license
+(MIT, see below).
 -------------------------------------------------------------------------------
 
 
@@ -1020,3 +1023,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+With respect to Glob (https://www.nuget.org/packages/Glob/)
+===========================================================
+(see: https://raw.githubusercontent.com/kthompson/glob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Kevin Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This patch includes Glob's license into LICENSE.txt since it was
introduced in `CheckHeadersScript` project.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.