### PR TITLE
Redirect silent Explorer logs to STDERR

### DIFF
--- a/src/AasxIntegrationBase/LogInstance.cs
+++ b/src/AasxIntegrationBase/LogInstance.cs
@@ -21,40 +21,36 @@ namespace AasxIntegrationBase
     /// </summary>
     public class StoredPrint
     {
-        // constants
-        public const int ColorBlack = 0;
-        public const int ColorBlue = 1;
-        public const int ColorRed = 2;
-        public const int ColorNoDisplay = 3;
+        public enum Color
+        {
+            Black = 0,
+            Blue = 1,
+            Red = 2,
+        }
 
-        // members
-        public int color = 0;
+        public Color color = Color.Black;
         public bool isError = false;
         public string msg = "";
         public string linkTxt = null;
         public string linkUri = null;
         public string stackTrace = null;
-        public Exception origException = null;
 
-        // constructurs
-
-        /// <param name="msg">The complete message; can contain %LINK% as substitude position for link text</param>
+        /// <param name="msg">The complete message; can contain %LINK% as substitute position for link text</param>
         public StoredPrint(string msg)
         {
-            this.color = ColorBlack;
+            this.color = Color.Black;
             this.msg = msg;
         }
 
         /// <param name="color">Color code black/ blue/ red</param>
-        /// <param name="msg">The complete message; can contain %LINK% as substitude position for link text</param>
+        /// <param name="msg">The complete message; can contain %LINK% as substitute position for link text</param>
         /// <param name="linkTxt">Link text to be shown</param>
         /// <param name="linkUri">Link URI to be navigated to</param>
         /// <param name="isError">Represents an error, e.g. will be counted</param>
         /// <param name="stackTrace">string serialized stack trace information</param>
-        /// <param name="origException">original exception information</param>
         public StoredPrint(
-            int color, string msg, string linkTxt = null, string linkUri = null, bool isError = false,
-            string stackTrace = null, Exception origException = null)
+            Color color, string msg, string linkTxt = null, string linkUri = null, bool isError = false,
+            string stackTrace = null)
         {
             this.color = color;
             this.msg = msg;
@@ -62,10 +58,7 @@ namespace AasxIntegrationBase
             this.linkUri = linkUri;
             this.isError = isError;
             this.stackTrace = stackTrace;
-            this.origException = origException;
         }
-
-        // serialization
 
         public new string ToString()
         {
@@ -73,101 +66,21 @@ namespace AasxIntegrationBase
         }
     }
 
-    /// <summary>
-    /// Implements the management of stores prints, such as in a store.
-    /// </summary>
-    public interface IManageStoredPrints
-    {
-        /// <summary>
-        /// For compatibility reasons with MinimalLogger. Pop the oldest messages as string.
-        /// </summary>
-        string CheckForLogMessage();
-
-        /// <summary>
-        /// Pop the oldest messages as string.
-        /// </summary>
-        StoredPrint PopLastStoredPrint();
-
-        /// <summary>
-        /// Clear all stored prints
-        /// </summary>
-        void ClearStoredPrints();
-
-        /// <summary>
-        /// Directly apped a stored print.
-        /// </summary>
-        void Append(StoredPrint sp);
-    }
-
-    /// <summary>
-    /// This is the standardized interface to provide logging facilities
-    /// </summary>
-    public interface ILogProvider
-    {
-        /// <summary>
-        /// Only append to longterm or to file, if file name is set
-        /// </summary>
-        void Silent(string msg, params object[] args);
-
-        /// <summary>
-        /// Display a message, which is for information only
-        /// </summary>
-        void Info(string msg, params object[] args);
-
-        /// <summary>
-        /// Display a message, which is for information only
-        /// </summary>
-        void Info(int level, string msg, params object[] args);
-
-        /// <summary>
-        /// Display a message, which is for information only
-        /// </summary>
-        void InfoWithHyperlink(int level, string msg, string linkTxt, string linkUri, params object[] args);
-
-        /// <summary>
-        /// Display a message, which is for errors
-        /// </summary>
-        void Error(string msg, params object[] args);
-
-        /// <summary>
-        /// Display a message, which is for derrors
-        /// </summary>
-        void ErrorWithHyperlink(string msg, string linkTxt, string linkUri, params object[] args);
-
-        /// <summary>
-        /// Display a message, which is for errors
-        /// </summary>
-        void Error(Exception ex, string where);
-    }
-
-    public class StoredPrintsMinimalStore : IManageStoredPrints
+    public class StoredPrintsMinimalStore
     {
         // private members
         private List<StoredPrint> StoredPrints = new List<StoredPrint>();
-
-        // Interface
-
-        /// <summary>
-        /// For compatibility reasons with MinimalLogger. Pop the oldest messages as string.
-        /// </summary>
-        public string CheckForLogMessage()
-        {
-            var sp = PopLastStoredPrint();
-            if (sp == null)
-                return null;
-            return sp.ToString();
-        }
 
         /// <summary>
         /// Pop the oldest messages as string.
         /// </summary>
         public StoredPrint PopLastStoredPrint()
         {
-            if (StoredPrints.Count < 1)
-                return null;
-
             lock (StoredPrints)
             {
+                if (StoredPrints.Count < 1)
+                    return null;
+
                 var sp = StoredPrints.First();
                 StoredPrints.Remove(sp);
                 return sp;
@@ -175,20 +88,15 @@ namespace AasxIntegrationBase
         }
 
         /// <summary>
-        /// Get all stored prints. Does not clear the bffer.
+        /// Get all stored prints. Does not clear the buffer.
         /// </summary>
         /// <returns></returns>
         public StoredPrint[] GetStoredPrints()
         {
-            return StoredPrints.ToArray();
-        }
-
-        /// <summary>
-        /// Clear all stored prints
-        /// </summary>
-        public void ClearStoredPrints()
-        {
-            StoredPrints.Clear();
+            lock (StoredPrints)
+            {
+                return StoredPrints.ToArray();
+            }
         }
 
         /// <summary>
@@ -205,19 +113,13 @@ namespace AasxIntegrationBase
                 StoredPrints.Add(sp);
             }
         }
-
     }
 
     /// <summary>
     /// This class is intended to be used as static Log facility.
     /// </summary>
-    public class LogInstance : ILogProvider
+    public class LogInstance
     {
-        /// <summary>
-        /// Will display debug messages only if level is smaller/equal than this level
-        /// </summary>
-        public int DebugLevel = 0;
-
         private StoredPrintsMinimalStore shortTermStore = new StoredPrintsMinimalStore();
         private StoredPrintsMinimalStore longTermStore = null;
 
@@ -226,16 +128,6 @@ namespace AasxIntegrationBase
         public void EnableLongTermStore()
         {
             longTermStore = new StoredPrintsMinimalStore();
-        }
-
-        // Interface
-
-        /// <summary>
-        /// For compatibility reasons with MinimalLogger. Pop the oldest messages as string.
-        /// </summary>
-        public string CheckForShortTermMessage()
-        {
-            return shortTermStore?.CheckForLogMessage();
         }
 
         /// <summary>
@@ -247,21 +139,12 @@ namespace AasxIntegrationBase
         }
 
         /// <summary>
-        /// Get all stored prints. Does not clear the bffer.
+        /// Get all stored prints. Does not clear the buffer.
         /// </summary>
         /// <returns></returns>
         public StoredPrint[] GetStoredLongTermPrints()
         {
             return longTermStore?.GetStoredPrints();
-        }
-
-        /// <summary>
-        /// Clear all stored prints
-        /// </summary>
-        public void ClearStoredPrints()
-        {
-            shortTermStore?.ClearStoredPrints();
-            longTermStore?.ClearStoredPrints();
         }
 
         /// <summary>
@@ -286,29 +169,14 @@ namespace AasxIntegrationBase
             NumberErrors = 0;
         }
 
-        private void InternalPrint(int color, string msg, params object[] args)
-        {
-            var s = String.Format(msg, args);
-            var p = new StoredPrint(color, s);
-            Append(p);
-        }
-
-        private void InternalPrintWithHyperlink(int color, string msg, string link, params object[] args)
-        {
-            var s = String.Format(msg, args);
-            var p = new StoredPrint(color, s, link);
-            Append(p);
-        }
-
         #region //////// Append to Log
 
         /// <summary>
-        /// Only append to longterm or to file, if file name is set
+        /// Writes the message to STDERR skipping the both the short-term and the long-term storages.
         /// </summary>
         public void Silent(string msg, params object[] args)
         {
-            var p = new StoredPrint(StoredPrint.ColorNoDisplay, String.Format(msg, args));
-            Append(p);
+            System.Console.Error.WriteLine(msg, args);
         }
 
         /// <summary>
@@ -316,28 +184,17 @@ namespace AasxIntegrationBase
         /// </summary>
         public void Info(string msg, params object[] args)
         {
-            var p = new StoredPrint(StoredPrint.ColorBlack, String.Format(msg, args));
+            var p = new StoredPrint(StoredPrint.Color.Black, String.Format(msg, args));
             Append(p);
         }
 
         /// <summary>
         /// Display a message, which is for information only
         /// </summary>
-        public void Info(int level, string msg, params object[] args)
-        {
-            var p = new StoredPrint(StoredPrint.ColorBlack, String.Format(msg, args));
-            if (level <= DebugLevel)
-                Append(p);
-        }
-
-        /// <summary>
-        /// Display a message, which is for information only
-        /// </summary>
-        public void Info(int level, int color, string msg, params object[] args)
+        public void Info(StoredPrint.Color color, string msg, params object[] args)
         {
             var p = new StoredPrint(color, String.Format(msg, args));
-            if (level <= DebugLevel)
-                Append(p);
+            Append(p);
         }
 
         /// <summary>
@@ -346,9 +203,8 @@ namespace AasxIntegrationBase
         public void InfoWithHyperlink(int level, string msg, string linkTxt, string linkUri, params object[] args)
         {
             var p = new StoredPrint(
-                StoredPrint.ColorBlack, String.Format(msg, args), linkTxt: linkTxt, linkUri: linkUri);
-            if (level <= DebugLevel)
-                Append(p);
+                StoredPrint.Color.Black, String.Format(msg, args), linkTxt: linkTxt, linkUri: linkUri);
+            Append(p);
         }
 
         /// <summary>
@@ -356,20 +212,9 @@ namespace AasxIntegrationBase
         /// </summary>
         public void Error(string msg, params object[] args)
         {
-            var p = new StoredPrint(StoredPrint.ColorRed, String.Format(msg, args), isError: true);
+            var p = new StoredPrint(StoredPrint.Color.Red, String.Format(msg, args), isError: true);
             NumberErrors++;
             Append(p);
-        }
-
-        /// <summary>
-        /// Display a message, which is for derrors
-        /// </summary>
-        public void ErrorWithHyperlink(string msg, string linkTxt, string linkUri, params object[] args)
-        {
-            var p = new StoredPrint(
-                StoredPrint.ColorRed, String.Format(msg, args), linkTxt: linkTxt, linkUri: linkUri, isError: true);
-            NumberErrors++;
-            shortTermStore?.Append(p);
         }
 
         /// <summary>
@@ -386,14 +231,12 @@ namespace AasxIntegrationBase
                 ((ex.InnerException != null) ? ex.InnerException.Message : ""),
                 AdminShellNS.AdminShellUtil.ShortLocation(ex));
 
-            var p = new StoredPrint(StoredPrint.ColorRed, s, isError: true);
+            var p = new StoredPrint(StoredPrint.Color.Red, s, isError: true);
             p.stackTrace = ex.StackTrace;
             NumberErrors++;
             Append(p);
         }
 
         #endregion
-
     }
-
 }

--- a/src/AasxIntegrationBaseWpf/AasxIntegrationBaseWpf.csproj
+++ b/src/AasxIntegrationBaseWpf/AasxIntegrationBaseWpf.csproj
@@ -17,6 +17,7 @@
     <Resource Include="Resources\msg_warning.png" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AasxIntegrationBaseWpf/AasxWpfBaseUtils.cs
+++ b/src/AasxIntegrationBaseWpf/AasxWpfBaseUtils.cs
@@ -20,6 +20,8 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using AdminShellNS;
 
+using ExhaustiveMatch = ExhaustiveMatching.ExhaustiveMatch;
+
 namespace AasxIntegrationBase
 {
     public static class AasxWpfBaseUtils
@@ -205,14 +207,19 @@ namespace AasxIntegrationBase
             }
             else
             {
-                if (sp.color == StoredPrint.ColorRed)
+                switch (sp.color)
                 {
-                    tr.ApplyPropertyValue(TextElement.ForegroundProperty, colors.BrushRed);
-                }
-
-                if (sp.color == StoredPrint.ColorBlue)
-                {
-                    tr.ApplyPropertyValue(TextElement.ForegroundProperty, colors.BrushBlue);
+                    default:
+                        throw ExhaustiveMatch.Failed(sp.color);
+                    case StoredPrint.Color.Red:
+                        tr.ApplyPropertyValue(TextElement.ForegroundProperty, colors.BrushRed);
+                        break;
+                    case StoredPrint.Color.Blue:
+                        tr.ApplyPropertyValue(TextElement.ForegroundProperty, colors.BrushBlue);
+                        break;
+                    case StoredPrint.Color.Black:
+                        tr.ApplyPropertyValue(TextElement.ForegroundProperty, new SolidColorBrush(Colors.Black));
+                        break;
                 }
             }
 

--- a/src/AasxPackageExplorer/AasxPackageExplorer.csproj
+++ b/src/AasxPackageExplorer/AasxPackageExplorer.csproj
@@ -100,6 +100,7 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
     <PackageReference Include="jose-jwt" Version="2.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/AasxPackageExplorer/App.xaml.cs
+++ b/src/AasxPackageExplorer/App.xaml.cs
@@ -7,6 +7,7 @@ This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 This source code may use other Open Source software components (see LICENSE.txt).
 */
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Windows;

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -954,8 +954,8 @@ namespace AasxPackageExplorer
                     for (double j = 0; j < 1; j += 0.0025)
                         sb.Append($"{j}");
                     logger.Info("The output is: {0} gives {1} was {0}", i, sb.ToString());
-                    logger.Info(0, StoredPrint.ColorBlue, "This is blue");
-                    logger.Info(0, StoredPrint.ColorRed, "This is red");
+                    logger.Info(StoredPrint.Color.Blue, "This is blue");
+                    logger.Info(StoredPrint.Color.Red, "This is red");
                     logger.Error("This is an error!");
                     logger.InfoWithHyperlink(0, "This is an link", "(Link)", "https://www.google.de");
                     logger.Info("----");

--- a/src/AasxPackageExplorer/MessageReportWindow.xaml
+++ b/src/AasxPackageExplorer/MessageReportWindow.xaml
@@ -5,7 +5,9 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
-        Title="Message Report" Height="600" Width="800">
+        Title="Message Report"
+        Height="600" 
+        Width="800">
     <!--
     Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
     Author: Michael Hoffmeister

--- a/src/AasxPackageExplorer/MessageReportWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MessageReportWindow.xaml.cs
@@ -27,20 +27,16 @@ namespace AasxPackageExplorer
 {
     public partial class MessageReportWindow : Window
     {
-        public MessageReportWindow()
+        public MessageReportWindow(IEnumerable<StoredPrint> storedPrints)
         {
             InitializeComponent();
-        }
 
-        public void Append(StoredPrint sp)
-        {
-            // access
-            if (sp == null || sp.msg == null)
-                return;
-
-            // add to rich text box
-            AasxWpfBaseUtils.StoredPrintToRichTextBox(
-                this.RichTextTextReport, sp, AasxWpfBaseUtils.DarkPrintColors, linkClickHandler: link_Click);
+            foreach (var sp in storedPrints)
+            {
+                // Add to rich text box
+                AasxWpfBaseUtils.StoredPrintToRichTextBox(
+                    this.RichTextTextReport, sp, AasxWpfBaseUtils.DarkPrintColors, linkClickHandler: link_Click);
+            }
         }
 
         protected void link_Click(object sender, RoutedEventArgs e)

--- a/src/AasxWpfControlLibrary/DispEditHelperCopyPaste.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperCopyPaste.cs
@@ -181,7 +181,7 @@ namespace AasxPackageExplorer
 
                         // user feedback
                         Log.Info(
-                            0, StoredPrint.ColorBlue,
+                            StoredPrint.Color.Blue,
                             "Stored SubmodelElement '{0}'({1}) to internal buffer.{2}", "" + sme.idShort,
                             "" + sme?.GetElementName(),
                             cpb.duplicate
@@ -324,7 +324,7 @@ namespace AasxPackageExplorer
 
                         // user feedback
                         Log.Info(
-                            0, StoredPrint.ColorBlue,
+                            StoredPrint.Color.Blue,
                             "Stored Submodel '{0}' to internal buffer.{1}", "" + sm.idShort,
                             cpb.duplicate
                                 ? " Paste will duplicate."
@@ -472,7 +472,7 @@ namespace AasxPackageExplorer
 
                         // user feedback
                         Log.Info(
-                            0, StoredPrint.ColorBlue,
+                            StoredPrint.Color.Blue,
                             "Stored {0} '{1}' to internal buffer.{1}",
                             "" + entity.GetElementName(),
                             "" + entity.idShort,

--- a/src/AasxWpfControlLibrary/Log.cs
+++ b/src/AasxWpfControlLibrary/Log.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AasxIntegrationBase;
 
 namespace AasxGlobalLogging
 {
@@ -26,7 +27,7 @@ namespace AasxGlobalLogging
         public static AasxIntegrationBase.LogInstance LogInstance { get { return logInstance; } }
 
         /// <summary>
-        /// Only append to longterm or to file, if file name is set
+        /// Writes the message to STDERR skipping the both the short-term and the long-term storages.
         /// </summary>
         public static void Silent(string msg, params object[] args)
         {
@@ -44,26 +45,9 @@ namespace AasxGlobalLogging
         /// <summary>
         /// Display a message, which is for information only
         /// </summary>
-        public static void Info(int level, string msg, params object[] args)
+        public static void Info(StoredPrint.Color color, string msg, params object[] args)
         {
-            logInstance?.Info(level, msg, args);
-        }
-
-        /// <summary>
-        /// Display a message, which is for information only
-        /// </summary>
-        public static void Info(int level, int color, string msg, params object[] args)
-        {
-            logInstance?.Info(level, color, msg, args);
-        }
-
-        /// <summary>
-        /// Display a message, which is for information only
-        /// </summary>
-        public static void InfoWithHyperlink(
-            int level, string msg, string linkTxt, string linkUri, params object[] args)
-        {
-            logInstance?.InfoWithHyperlink(level, msg, linkTxt, linkUri, args);
+            logInstance?.Info(color, msg, args);
         }
 
         /// <summary>
@@ -72,14 +56,6 @@ namespace AasxGlobalLogging
         public static void Error(string msg, params object[] args)
         {
             logInstance?.Error(msg, args);
-        }
-
-        /// <summary>
-        /// Display a message, which is for derrors
-        /// </summary>
-        public static void ErrorWithHyperlink(string msg, string linkTxt, string linkUri, params object[] args)
-        {
-            logInstance?.ErrorWithHyperlink(msg, linkTxt, linkUri, args);
         }
 
         /// <summary>

--- a/src/AdditionalVerbsInImperativeMood.txt
+++ b/src/AdditionalVerbsInImperativeMood.txt
@@ -18,3 +18,4 @@ refine
 dispatch
 export
 skip
+redirect


### PR DESCRIPTION
This patch removes `NoDisplay` color from the `StoredPrint` and
redirects the `Silent` messages to STDERR, surpassing both short-term
and long-term storage of log print messages.

Additionally, unused interfaces and methods are removed from the logging
module.