### PR TITLE
Fix opening an invalid AASX

### DIFF
--- a/src/AasxPackageExplorer.GuiTests/Common.cs
+++ b/src/AasxPackageExplorer.GuiTests/Common.cs
@@ -239,8 +239,6 @@ namespace AasxPackageExplorer.GuiTests
                 throw new AssertionException(
                     "The application unexpectedly exited. " +
                     $"Check manually why the file could not be opened: {path}");
-
-            AssertNoErrors(application, mainWindow);
         }
     }
 }

--- a/src/AasxPackageExplorer.GuiTests/TemporaryDirectory.cs
+++ b/src/AasxPackageExplorer.GuiTests/TemporaryDirectory.cs
@@ -1,0 +1,23 @@
+using IDisposable = System.IDisposable;
+
+namespace AasxPackageExplorer.GuiTests
+{
+    class TemporaryDirectory : IDisposable
+    {
+        public readonly string Path;
+
+        public TemporaryDirectory()
+        {
+            this.Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                System.IO.Path.GetRandomFileName());
+
+            System.IO.Directory.CreateDirectory(this.Path);
+        }
+
+        public void Dispose()
+        {
+            System.IO.Directory.Delete(this.Path, true);
+        }
+    }
+}

--- a/src/AasxPackageExplorer.GuiTests/Test.cs
+++ b/src/AasxPackageExplorer.GuiTests/Test.cs
@@ -2,6 +2,8 @@
 using FlaUI.Core.AutomationElements;
 using Assert = NUnit.Framework.Assert;
 using AssertionException = NUnit.Framework.AssertionException;
+using File = System.IO.File;
+using Path = System.IO.Path;
 using Retry = FlaUI.Core.Tools.Retry;
 using TestAttribute = NUnit.Framework.TestAttribute;
 using TimeSpan = System.TimeSpan;
@@ -71,6 +73,7 @@ namespace AasxPackageExplorer.GuiTests
             Common.RunWithMainWindow((application, automation, mainWindow) =>
             {
                 Common.AssertLoadAasx(application, mainWindow, path);
+                Common.AssertNoErrors(application, mainWindow);
             });
         }
 
@@ -81,6 +84,7 @@ namespace AasxPackageExplorer.GuiTests
             Common.RunWithMainWindow((application, automation, mainWindow) =>
             {
                 Common.AssertLoadAasx(application, mainWindow, path);
+                Common.AssertNoErrors(application, mainWindow);
 
                 const string automationId = "AssetPic";
 
@@ -99,6 +103,26 @@ namespace AasxPackageExplorer.GuiTests
                         $"width is {assetPic.BoundingRectangle.Width} and " +
                         $"height is {assetPic.BoundingRectangle.Height}");
                 }
+            });
+        }
+
+        [Test]
+        public void Test_that_opening_an_invalid_AASX_does_not_break_the_app()
+        {
+            using var tmpDir = new TemporaryDirectory();
+            var path = Path.Combine(tmpDir.Path, "invalid.aasx");
+            File.WriteAllText(path, "totally invalid");
+
+            Common.RunWithMainWindow((application, automation, mainWindow) =>
+            {
+                Common.AssertLoadAasx(application, mainWindow, path);
+                var numberErrors = Retry.Find(
+                    () => (application.HasExited)
+                        ? null
+                        : mainWindow.FindFirstChild(cf => cf.ByAutomationId("LabelNumberErrors")),
+                    new RetrySettings { ThrowOnTimeout = true, Timeout = TimeSpan.FromSeconds(5) });
+
+                Assert.AreEqual("Errors: 1", numberErrors.AsLabel().Text);
             });
         }
     }

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -129,14 +129,33 @@ namespace AasxPackageExplorer
                 if (res == true)
                 {
                     RememberForInitialDirectory(dlg.FileName);
-                    if (cmd == "open")
-                        UiLoadPackageWithNew(
-                            packages.MainContainer, new AdminShellPackageEnv(dlg.FileName), dlg.FileName,
-                            onlyAuxiliary: false);
-                    if (cmd == "openaux")
-                        UiLoadPackageWithNew(
-                            packages.AuxContainer,
-                            new AdminShellPackageEnv(dlg.FileName), dlg.FileName, onlyAuxiliary: true);
+
+                    AdminShellPackageEnv packnew = null;
+                    try
+                    {
+                        packnew = new AdminShellPackageEnv(dlg.FileName);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, $"When opening {dlg.FileName}");
+                    }
+
+                    if (packnew != null)
+                    {
+                        switch (cmd)
+                        {
+                            case "open":
+                                UiLoadPackageWithNew(
+                                    packages.MainContainer, packnew, dlg.FileName, onlyAuxiliary: false);
+                                break;
+                            case "openaux":
+                                UiLoadPackageWithNew(
+                                    packages.AuxContainer, packnew, dlg.FileName, onlyAuxiliary: true);
+                                break;
+                            default:
+                                throw new InvalidOperationException($"Unexpected {nameof(cmd)}: {cmd}");
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
This patch fixes the bug in the Package Explorer which caused the
application to break down when an invalid AASX file was opened.