### PR TITLE
Write silently caught exceptions to STDERR

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,3 +1,6 @@
+# Throw-away scripts
+deleteme.py
+
 # AASX Package Explorer-specific ignores
 artefacts/
 */bin/

--- a/src/AasxCsharpLibrary/AdminShell.cs
+++ b/src/AasxCsharpLibrary/AdminShell.cs
@@ -4514,7 +4514,10 @@ namespace AdminShellNS
                     {
                         rec.Fix.Invoke();
                     }
-                    catch { res--; }
+                    catch
+                    {
+                        res--;
+                    }
                 }
 
                 // return number of applied fixes

--- a/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
+++ b/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
@@ -85,7 +85,6 @@ namespace AdminShellNS
         public static string TryReadXmlFirstElementNamespaceURI(Stream s)
         {
             string res = null;
-            // ReSharper disable EmptyGeneralCatchClause
             try
             {
                 var xr = System.Xml.XmlReader.Create(s);
@@ -107,8 +106,10 @@ namespace AdminShellNS
                 }
                 xr.Close();
             }
-            catch { }
-            // ReSharper enable EmptyGeneralCatchClause
+            catch (Exception ex)
+            {
+                LogInternally.That.SilentlyIgnoredError(ex);
+            }
 
             // return to zero pos
             s.Seek(0, SeekOrigin.Begin);
@@ -482,7 +483,6 @@ namespace AdminShellNS
                     // fn could be changed, therefore close "old" package first
                     if (this.openPackage != null)
                     {
-                        // ReSharper disable EmptyGeneralCatchClause
                         try
                         {
                             this.openPackage.Close();
@@ -494,8 +494,10 @@ namespace AdminShellNS
                                     System.IO.File.Copy(this.fn, fn);
                             }
                         }
-                        catch { }
-                        // ReSharper enable EmptyGeneralCatchClause
+                        catch (Exception ex)
+                        {
+                            LogInternally.That.SilentlyIgnoredError(ex);
+                        }
                         this.openPackage = null;
                     }
 
@@ -562,15 +564,16 @@ namespace AdminShellNS
                              || (name.StartsWith("aasenv-with-no-id")))
                         {
                             // try kill specpart
-                            // ReSharper disable EmptyGeneralCatchClause
                             try
                             {
                                 originPart.DeleteRelationship(specRel.Id);
                                 package.DeletePart(specPart.Uri);
                             }
-                            catch { }
+                            catch (Exception ex)
+                            {
+                                LogInternally.That.SilentlyIgnoredError(ex);
+                            }
                             finally { specPart = null; specRel = null; }
-                            // ReSharper enable EmptyGeneralCatchClause
                         }
                     }
 
@@ -793,7 +796,6 @@ namespace AdminShellNS
                 return;
 
             // we do it not caring on any errors
-            // ReSharper disable EmptyGeneralCatchClause
             try
             {
                 // get index in form
@@ -820,8 +822,10 @@ namespace AdminShellNS
                     serializer.Serialize(s, this.aasenv, nss);
                 }
             }
-            catch { }
-            // ReSharper enable EmptyGeneralCatchClause
+            catch (Exception ex)
+            {
+                LogInternally.That.SilentlyIgnoredError(ex);
+            }
         }
 
         public Stream GetStreamFromUriOrLocalPackage(string uriString,
@@ -849,8 +853,9 @@ namespace AdminShellNS
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 return null;
             }
         }
@@ -895,7 +900,11 @@ namespace AdminShellNS
                     res = s.Length;
                 }
             }
-            catch { return 0; }
+            catch (Exception ex)
+            {
+                LogInternally.That.SilentlyIgnoredError(ex);
+                return 0;
+            }
             return res;
         }
 

--- a/src/AasxCsharpLibrary/LogInternally.cs
+++ b/src/AasxCsharpLibrary/LogInternally.cs
@@ -1,0 +1,54 @@
+﻿/*
+Copyright (c) 2020 ZHAW Zürcher Hochschule für Angewandte Wissenschaften <http://www.zhaw.ch>
+Author: Marko Ristin
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+using Exception = System.Exception;
+
+namespace AdminShellNS
+{
+    public static class Logging
+    {
+        public static string FormatError(Exception ex, string where)
+        {
+            return string.Format("Error {0}: {1} {2} at {3}.",
+                where,
+                ex.Message,
+                ((ex.InnerException != null) ? ex.InnerException.Message : ""),
+                AdminShellUtil.ShortLocation(ex));
+        }
+    }
+
+    public class InternalLog
+    {
+        /// <summary>
+        /// Logs the exception to STDERR.
+        /// </summary>
+        public void Error(Exception ex, string where)
+        {
+            System.Console.WriteLine(Logging.FormatError(ex, where));
+        }
+
+        /// <summary>
+        /// Logs that the exception is silently ignored to STDERR.
+        /// </summary>
+        public void SilentlyIgnoredError(Exception ex)
+        {
+            Error(ex, "The exception is silently ignored.");
+        }
+    }
+
+    /// <summary>
+    /// Handles logging meant to be read by developers (*i.e*, not by the users of the software).
+    /// </summary>
+    /// <remarks>Please see AasxIntegrationBase\LogInstance.cs for how to keep logs intended
+    /// for the user.</remarks>
+    public static class LogInternally
+    {
+        public static readonly InternalLog That = new InternalLog();
+    }
+}

--- a/src/AasxIntegrationBase/AasxPluginOptionsBase.cs
+++ b/src/AasxIntegrationBase/AasxPluginOptionsBase.cs
@@ -69,7 +69,6 @@ namespace AasxIntegrationBase
             // search
             var files = Directory.GetFiles(baseDir, "*.add-options.json");
 
-            // ReSharper disable EmptyGeneralCatchClause
             foreach (var fn in files)
                 try
                 {
@@ -81,7 +80,6 @@ namespace AasxIntegrationBase
                 {
                     log?.Error(ex, $"loading additional options (${fn})");
                 }
-            // ReSharper enable EmptyGeneralCatchClause
         }
     }
 }

--- a/src/AasxIntegrationBase/LogInstance.cs
+++ b/src/AasxIntegrationBase/LogInstance.cs
@@ -225,11 +225,7 @@ namespace AasxIntegrationBase
             if (ex == null)
                 return;
 
-            var s = String.Format("Error {0}: {1} {2} at {3}.",
-                where,
-                ex.Message,
-                ((ex.InnerException != null) ? ex.InnerException.Message : ""),
-                AdminShellNS.AdminShellUtil.ShortLocation(ex));
+            var s = AdminShellNS.Logging.FormatError(ex, where);
 
             var p = new StoredPrint(StoredPrint.Color.Red, s, isError: true);
             p.stackTrace = ex.StackTrace;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormListOfSameControl.xaml.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormListOfSameControl.xaml.cs
@@ -190,13 +190,14 @@ namespace AasxIntegrationBase.AasForms
                             if (inst.SubInstances.Count > this.minRows)
                             {
                                 // carefully delete
-                                // ReSharper disable EmptyGeneralCatchClause
                                 try
                                 {
                                     masterInst.SubInstances.Remove(subInst);
                                 }
-                                catch { }
-                                // ReSharper enable EmptyGeneralCatchClause
+                                catch (Exception ex)
+                                {
+                                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                                }
 
                                 // redraw
                                 UpdateDisplay();

--- a/src/AasxIntegrationBaseWpf/AasxWpfBaseUtils.cs
+++ b/src/AasxIntegrationBaseWpf/AasxWpfBaseUtils.cs
@@ -142,7 +142,6 @@ namespace AasxIntegrationBase
             if (package == null || path == null)
                 return null;
 
-            // ReSharper disable EmptyGeneralCatchClause
             try
             {
                 var thumbStream = package.GetLocalStreamFromPackage(path);
@@ -160,8 +159,10 @@ namespace AasxIntegrationBase
                 // give this back
                 return bi;
             }
-            catch { }
-            // ReSharper enable EmptyGeneralCatchClause
+            catch (Exception ex)
+            {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+            }
 
             return null;
         }
@@ -236,7 +237,6 @@ namespace AasxIntegrationBase
                 var link = new Hyperlink(rtb.Document.ContentEnd, rtb.Document.ContentEnd);
                 link.IsEnabled = true;
 
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
                     link.Inlines.Add("" + sp.linkTxt + Environment.NewLine);
@@ -244,8 +244,10 @@ namespace AasxIntegrationBase
                     if (linkClickHandler != null)
                         link.Click += linkClickHandler;
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
             }
         }
     }

--- a/src/AasxMqtt/Plugin.cs
+++ b/src/AasxMqtt/Plugin.cs
@@ -70,14 +70,14 @@ namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
             {
                 Log.Info("Starting Mqtt Server...");
 
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
                     AASMqttServer.MqttSeverStartAsync().Wait();
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
-
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
 
                 // return as plain object
                 var res = new AasxPluginResultBaseObject();

--- a/src/AasxOpenidClient/OpenIDCLient.cs
+++ b/src/AasxOpenidClient/OpenIDCLient.cs
@@ -80,10 +80,9 @@ namespace AasxOpenIdClient
                         outputDir = sr.ReadLine();
                     }
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Console.WriteLine(e.Message);
-                    Console.WriteLine(tag + ".dat " + " can not be read!");
+                    AdminShellNS.LogInternally.That.Error(ex, $"The file {tag}.dat can not be read.");
                     return;
                 }
                 withOpenidFile = true;
@@ -208,9 +207,9 @@ namespace AasxOpenIdClient
                                         Console.WriteLine("Writing file: " + outputDir + "\\" + "download.aasx");
                                         File.WriteAllBytes(outputDir + "\\" + "download.aasx", fileBytes4);
                                     }
-                                    catch (Exception e)
+                                    catch (Exception ex)
                                     {
-                                        Console.WriteLine(e.Message);
+                                        AdminShellNS.LogInternally.That.Error(ex, $"Failed at operation: {operation}");
                                         lastOperation = operation;
                                         operation = "error";
                                     }
@@ -218,9 +217,9 @@ namespace AasxOpenIdClient
                                     break;
                             }
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
-                            Console.WriteLine(e.Message);
+                            AdminShellNS.LogInternally.That.Error(ex, $"Failed at operation: {operation}");
                             lastOperation = operation;
                             operation = "error";
                         }
@@ -245,16 +244,15 @@ namespace AasxOpenIdClient
                             operation = lastOperation;
                             lastOperation = "";
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
-                            Console.WriteLine(e.Message);
+                            AdminShellNS.LogInternally.That.Error(ex, $"Failed at operation: {operation}");
                             lastOperation = operation;
                             operation = "error";
                         }
                         break;
                     case "error":
-                        Console.WriteLine("Can not " + lastOperation + "!");
-                        System.Windows.Forms.MessageBox.Show("Can not " + lastOperation + "!",
+                        System.Windows.Forms.MessageBox.Show($"Can not perform: {lastOperation}",
                             "Error", MessageBoxButtons.OK);
                         break;
                 }
@@ -344,10 +342,9 @@ namespace AasxOpenIdClient
                 Console.WriteLine("Writing file: " + outputDir + "\\" + "download.aasx");
                 File.WriteAllBytes(outputDir + "\\" + "download.aasx", fileBytes4);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Console.WriteLine(e.Message);
-                Console.WriteLine("Can not get .AASX!");
+                AdminShellNS.LogInternally.That.Error(ex, $"Can not get .AASX.");
                 return;
             }
         }

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -56,7 +56,6 @@ namespace AasxPackageExplorer
 
         public string DetermineInitialDirectory(string existingFn = null)
         {
-            // ReSharper disable EmptyGeneralCatchClause
             string res = null;
 
             if (existingFn != null)
@@ -64,7 +63,10 @@ namespace AasxPackageExplorer
                 {
                     res = System.IO.Path.GetDirectoryName(existingFn);
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
 
             // may be can used last?
             if (res == null && lastFnForInitialDirectory != null)
@@ -72,9 +74,11 @@ namespace AasxPackageExplorer
                 {
                     res = System.IO.Path.GetDirectoryName(lastFnForInitialDirectory);
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
 
-            // ReSharper enable EmptyGeneralCatchClause
             return res;
         }
 
@@ -1444,7 +1448,10 @@ namespace AasxPackageExplorer
                         worker.CancelAsync();
                         worker.Dispose();
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                    }
 #endif
             });
         }
@@ -2349,7 +2356,10 @@ namespace AasxPackageExplorer
                                         ));
                         }
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                    }
             }
 
             // could be nothing
@@ -2397,7 +2407,10 @@ namespace AasxPackageExplorer
                         cdres = rgsm.cds;
                     }
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
 
                 // something
                 if (smres == null)

--- a/src/AasxPackageExplorer/MainWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MainWindow.xaml.cs
@@ -460,7 +460,6 @@ namespace AasxPackageExplorer
                             AdminShellUtil.EvalToNonNullString("{0}", asset.identification.id));
 
                     // asset thumbnail
-                    // ReSharper disable EmptyGeneralCatchClause
                     try
                     {
                         // identify which stream to use..
@@ -484,7 +483,10 @@ namespace AasxPackageExplorer
                                     }
                                 }
                             }
-                            catch { }
+                            catch (Exception ex)
+                            {
+                                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                            }
 
                         if (this.theOnlineConnection != null && this.theOnlineConnection.IsValid() &&
                             this.theOnlineConnection.IsConnected())
@@ -506,15 +508,18 @@ namespace AasxPackageExplorer
                                     }
                                 }
                             }
-                            catch { }
+                            catch (Exception ex)
+                            {
+                                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                            }
 
                     }
-                    catch
+                    catch (Exception ex)
                     {
                         // no error, intended behaviour, as thumbnail might not exist / be faulty in some way
                         // (not violating the spec)
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                     }
-                    // ReSharper enable EmptyGeneralCatchClause
                 }
             }
 
@@ -547,7 +552,10 @@ namespace AasxPackageExplorer
                     this.LogoImage.Source = bi;
                     this.LogoImage.UpdateLayout();
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
 
             // adding the CEF Browser conditionally
             theContentBrowser.Start(Options.Curr.ContentHome, Options.Curr.InternalBrowser);
@@ -1285,14 +1293,14 @@ namespace AasxPackageExplorer
             }
 
             Log.Info("Closing ..");
-            // ReSharper disable EmptyGeneralCatchClause
             try
             {
                 packages.Main.Close();
             }
-            catch (Exception)
-            { }
-            // ReSharper enable EmptyGeneralCatchClause
+            catch (Exception ex)
+            {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+            }
 
             e.Cancel = false;
         }

--- a/src/AasxPluginBomStructure/GenericBomControl.cs
+++ b/src/AasxPluginBomStructure/GenericBomControl.cs
@@ -355,7 +355,6 @@ namespace AasxPluginBomStructure
                     // now, try to finally draw relationships
                     if (pass == 3)
                     {
-                        // ReSharper disable EmptyGeneralCatchClause
                         try
                         {
                             // build label text
@@ -393,8 +392,10 @@ namespace AasxPluginBomStructure
                             e.Attr.ArrowheadAtTarget = Microsoft.Msagl.Drawing.ArrowStyle.Normal;
                             e.Attr.LineWidth = 1;
                         }
-                        catch { }
-                        // ReSharper enable EmptyGeneralCatchClause
+                        catch (Exception ex)
+                        {
+                            AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                        }
                     }
                 }
 
@@ -426,7 +427,6 @@ namespace AasxPluginBomStructure
                     if (pass == 3 && parentRef != null)
                     {
                         // get nodes
-                        // ReSharper disable EmptyGeneralCatchClause
                         try
                         {
                             if (!referableToNode.ContainsKey(parentRef) || !referableToNode.ContainsKey(prop))
@@ -442,8 +442,10 @@ namespace AasxPluginBomStructure
                             e.Attr.LineWidth = 2;
                             e.Attr.Weight = 10;
                         }
-                        catch { }
-                        // ReSharper enable EmptyGeneralCatchClause
+                        catch (Exception ex)
+                        {
+                            AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                        }
                     }
                 }
 
@@ -661,7 +663,6 @@ namespace AasxPluginBomStructure
             if (e != null && e.Clicks > 1 && e.LeftButtonIsPressed && theViewer != null && this.eventStack != null)
             {
                 // double-click detected, can access the viewer?
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
                     var x = theViewer.ObjectUnderMouseCursor;
@@ -691,8 +692,10 @@ namespace AasxPluginBomStructure
                         }
                     }
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
             }
         }
 
@@ -742,7 +745,6 @@ namespace AasxPluginBomStructure
             if (cb == null || theGraph == null || theViewer == null)
                 return;
 
-            // ReSharper disable EmptyGeneralCatchClause
             try
             {
                 // try to remember preferred setting
@@ -759,8 +761,10 @@ namespace AasxPluginBomStructure
                 theViewer.Graph = null;
                 theViewer.Graph = theGraph;
             }
-            catch { }
-            // ReSharper enable EmptyGeneralCatchClause
+            catch (Exception ex)
+            {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+            }
         }
     }
 }

--- a/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
+++ b/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
@@ -187,7 +187,6 @@ namespace AasxPluginDocumentShelf
                     theDocEntitiesToPreview.RemoveAt(0);
                 }
 
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
                     // temp input
@@ -240,8 +239,10 @@ namespace AasxPluginDocumentShelf
                         }
                     }
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
             }
 
             // over all items in order to check, if a prepared image shall be displayed
@@ -258,7 +259,6 @@ namespace AasxPluginDocumentShelf
                     de.ImageReadyToBeLoaded = null;
 
                     // try load
-                    // ReSharper disable EmptyGeneralCatchClause
                     try
                     {
                         // convert here, as the tick-Thread in STA / UI thread
@@ -275,15 +275,20 @@ namespace AasxPluginDocumentShelf
                                 {
                                     File.Delete(fn);
                                 }
-                                catch { }
+                                catch (Exception ex)
+                                {
+                                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                                }
 
                         // remember in the cache
                         if (referableHashToCachedBitmap != null &&
                             !referableHashToCachedBitmap.ContainsKey(de.ReferableHash))
                             referableHashToCachedBitmap[de.ReferableHash] = bi;
                     }
-                    catch { }
-                    // ReSharper enable EmptyGeneralCatchClause
+                    catch (Exception ex)
+                    {
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                    }
                 }
             }
         }

--- a/src/AasxPluginExportTable/ExportTableFlyout.xaml.cs
+++ b/src/AasxPluginExportTable/ExportTableFlyout.xaml.cs
@@ -225,14 +225,15 @@ namespace AasxPluginExportTable
                 // save
                 if (true == dlg.ShowDialog())
                 {
-                    // ReSharper disable EmptyGeneralCatchClause
                     try
                     {
                         var pr = this.ThisToPreset();
                         pr.SaveToFile(dlg.FileName);
                     }
-                    catch { }
-                    // ReSharper enable EmptyGeneralCatchClause
+                    catch (Exception ex)
+                    {
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                    }
                 }
             }
 
@@ -247,14 +248,15 @@ namespace AasxPluginExportTable
                 // save
                 if (true == dlg.ShowDialog())
                 {
-                    // ReSharper disable EmptyGeneralCatchClause
                     try
                     {
                         var pr = ExportTableRecord.LoadFromFile(dlg.FileName);
                         this.ThisFromPreset(pr);
                     }
-                    catch { }
-                    // ReSharper enable EmptyGeneralCatchClause
+                    catch (Exception ex)
+                    {
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                    }
                 }
             }
         }

--- a/src/AasxPluginExportTable/ExportTableRecord.cs
+++ b/src/AasxPluginExportTable/ExportTableRecord.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -756,29 +756,31 @@ namespace AasxPluginExportTable
             // colors
             if (cr.Bg != null)
             {
-                // ReSharper disable EmptyGeneralCatchClause
                 // ReSharper disable PossibleNullReferenceException
                 try
                 {
                     var bgc = (System.Windows.Media.Color)ColorConverter.ConvertFromString(cr.Bg);
                     cell.Style.Fill.BackgroundColor = XLColor.FromArgb(bgc.A, bgc.R, bgc.G, bgc.B);
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
                 // ReSharper enable PossibleNullReferenceException
             }
 
             if (cr.Fg != null)
             {
-                // ReSharper disable EmptyGeneralCatchClause
                 // ReSharper disable PossibleNullReferenceException
                 try
                 {
                     var fgc = (System.Windows.Media.Color)ColorConverter.ConvertFromString(cr.Fg);
                     cell.Style.Font.FontColor = XLColor.FromArgb(fgc.A, fgc.R, fgc.G, fgc.B);
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
                 // ReSharper enable PossibleNullReferenceException
             }
 
@@ -969,7 +971,6 @@ namespace AasxPluginExportTable
 
                 if (cr.Bg != null)
                 {
-                    // ReSharper disable EmptyGeneralCatchClause
                     // ReSharper disable PossibleNullReferenceException
                     try
                     {
@@ -983,8 +984,10 @@ namespace AasxPluginExportTable
                             Val = ShadingPatternValues.Clear
                         });
                     }
-                    catch { }
-                    // ReSharper enable EmptyGeneralCatchClause
+                    catch (Exception ex)
+                    {
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                    }
                     // ReSharper enable PossibleNullReferenceException
                 }
             }
@@ -1002,7 +1005,6 @@ namespace AasxPluginExportTable
 
             if (cr.Fg != null || cr.Font != null)
             {
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
                     var rp = new RunProperties();
@@ -1026,8 +1028,10 @@ namespace AasxPluginExportTable
 
                     run.RunProperties = rp;
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
             }
 
             para.Append(run);

--- a/src/AasxPluginExportTable/Plugin.cs
+++ b/src/AasxPluginExportTable/Plugin.cs
@@ -146,14 +146,15 @@ namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
 
                 // get the output file
                 var dlg = new Microsoft.Win32.SaveFileDialog();
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
                     dlg.InitialDirectory = System.IO.Path.GetDirectoryName(
                         System.AppDomain.CurrentDomain.BaseDirectory);
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
                 dlg.Title = "Select text file to be exported";
 
                 if (job.Format == (int)ExportTableRecord.FormatEnum.TSF)

--- a/src/AasxPluginImageMap/ImageMapControl.xaml.cs
+++ b/src/AasxPluginImageMap/ImageMapControl.xaml.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -179,8 +179,9 @@ namespace AasxPluginImageMap
                 var x = JsonConvert.DeserializeObject<List<double>>(input);
                 return x.ToArray();
             }
-            catch
+            catch (Exception ex)
             {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 return null;
             }
         }

--- a/src/AasxPluginUaNetClient/UASampleClient.cs
+++ b/src/AasxPluginUaNetClient/UASampleClient.cs
@@ -52,10 +52,7 @@ namespace SampleClient
             }
             catch (Exception ex)
             {
-                Utils.Trace("ServiceResultException:" + ex.Message);
-                Console.WriteLine("Exception: {0}", ex.Message);
-                //// Console.WriteLine("press any key to continue");
-                //// Console.ReadKey();
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 return;
             }
 
@@ -68,9 +65,9 @@ namespace SampleClient
                     eArgs.Cancel = true;
                 };
             }
-            // ReSharper disable once EmptyGeneralCatchClause
-            catch (Exception)
+            catch (Exception ex)
             {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
             }
 
             // wait for timeout or Ctrl-C

--- a/src/AasxPredefinedConcepts/AasxDefinitionBase.cs
+++ b/src/AasxPredefinedConcepts/AasxDefinitionBase.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -129,8 +129,9 @@ namespace AasxPredefinedConcepts
                 var r = JsonConvert.DeserializeObject<T>(entry.contents);
                 return r;
             }
-            catch
+            catch (Exception ex)
             {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 return null;
             }
         }

--- a/src/AasxRestServerLibrary/AasxHttpContextHelper.cs
+++ b/src/AasxRestServerLibrary/AasxHttpContextHelper.cs
@@ -81,7 +81,6 @@ namespace AasxRestServerLibrary
             // over all query strings
             foreach (var kr in queryStrings.AllKeys)
             {
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
                     var k = kr.Trim().ToLower();
@@ -97,8 +96,10 @@ namespace AasxRestServerLibrary
                         }
                     }
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
             }
 
             // done

--- a/src/AasxRestServerLibrary/AasxRestServer.cs
+++ b/src/AasxRestServerLibrary/AasxRestServer.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -403,15 +403,16 @@ namespace AasxRestServerLibrary
 
         public static void Stop()
         {
-            // ReSharper disable EmptyGeneralCatchClause
             if (startedRestServer != null)
                 try
                 {
                     startedRestServer.Stop();
                     startedRestServer = null;
                 }
-                catch { }
-            // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
         }
     }
 }

--- a/src/AasxSignature/AasxSignature.cs
+++ b/src/AasxSignature/AasxSignature.cs
@@ -78,9 +78,9 @@ namespace AasxSignature
                                     relationship.SourceUri, PackageRelationshipSelectorType.Id, relationship.Id));
                         }
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // Ignore the exception
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                     }
                 }
 
@@ -106,9 +106,9 @@ namespace AasxSignature
                     {
                         dlg.InitialDirectory = System.IO.Path.GetDirectoryName("\\");
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // Ignore the exception
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                     }
                     dlg.Filter = ".pfx files (*.pfx)|*.pfx";
                     dlg.ShowDialog();

--- a/src/AasxSignature/AasxSignature.csproj
+++ b/src/AasxSignature/AasxSignature.csproj
@@ -8,4 +8,8 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/AasxUANodesetImExport/UANodeSetImport.cs
+++ b/src/AasxUANodesetImExport/UANodeSetImport.cs
@@ -161,13 +161,14 @@ namespace AasxUANodesetImExport
         private static UANode getRoot()
         {
             //the root node will always have the BrowseName AASAssetAdministrationShell
-            // ReSharper disable EmptyGeneralCatchClause
             try
             {
                 return InformationModel.Items.First(x => x.BrowseName == "1:AASAssetAdministrationShell");
             }
-            catch { }
-            // ReSharper enable EmptyGeneralCatchClause
+            catch (Exception ex)
+            {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+            }
             return null;
         }
 

--- a/src/AasxUaNetConsoleServer/Program.cs
+++ b/src/AasxUaNetConsoleServer/Program.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -123,9 +123,9 @@ namespace Net46ConsoleServer
                     return await Task.FromResult((result.KeyChar == 'y') || (result.KeyChar == 'Y')
                         || (result.KeyChar == '\r'));
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // intentionally fall through
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 }
             }
             return await Task.FromResult(true);

--- a/src/AasxUaNetServer/AasxServer/AasNodeManager.cs
+++ b/src/AasxUaNetServer/AasxServer/AasNodeManager.cs
@@ -264,8 +264,10 @@ namespace AasOpcUaServer
                         {
                             stream.Close();
                         }
-                        // ReSharper disable once EmptyGeneralCatchClause
-                        catch { }
+                        catch (Exception ex)
+                        {
+                            AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                        }
 
                         // stop afterwards
                         if (theServerOptions.FinalizeAction != null)

--- a/src/AasxUaNetServer/AasxServer/AasUaEntityFileType.cs
+++ b/src/AasxUaNetServer/AasxServer/AasUaEntityFileType.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -200,8 +200,9 @@ namespace AasOpcUaServer
             {
                 s = package.GetLocalStreamFromPackage(file.value);
             }
-            catch
+            catch (Exception ex)
             {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 return false;
             }
 
@@ -378,8 +379,10 @@ namespace AasOpcUaServer
                     instData.UpdateSize(Convert.ToUInt64(instData.packHandler.GetLength(fh)));
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                AdminShellNS.LogInternally.That.Error(ex, "The method could not be executed.");
+
                 // treat every exception the same
                 return new ServiceResult(StatusCodes.BadInvalidArgument);
             }

--- a/src/AasxWpfControlLibrary/AasxFileRepository.cs
+++ b/src/AasxWpfControlLibrary/AasxFileRepository.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -337,8 +337,9 @@ namespace AasxPackageExplorer
                 if (!Path.IsPathRooted(fn) && this.Filename != null)
                     fn = Path.Combine(Path.GetDirectoryName(this.Filename), fn);
             }
-            catch
+            catch (Exception ex)
             {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 return null;
             }
 
@@ -360,7 +361,6 @@ namespace AasxPackageExplorer
                 basePath += "\\";
 
             // each file
-            // ReSharper disable EmptyGeneralCatchClause
             foreach (var fi in this.FileMap)
                 try
                 {
@@ -373,8 +373,10 @@ namespace AasxPackageExplorer
 
                     fi.Filename = relPath;
                 }
-                catch { }
-            // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
         }
 
         public void AddByAas(AdminShell.AdministrationShellEnv env, AdminShell.AdministrationShell aas, string fn)
@@ -392,7 +394,6 @@ namespace AasxPackageExplorer
 
             // try determine tag
             // ReSharper disable ConditionIsAlwaysTrueOrFalse
-            // ReSharper disable EmptyGeneralCatchClause
             var tag = "";
             try
             {
@@ -405,8 +406,10 @@ namespace AasxPackageExplorer
                 if (tag == null || tag.Length < 3)
                     tag = ("" + threeFn).SubstringMax(0, 3).ToUpper();
             }
-            catch { }
-            // ReSharper enable EmptyGeneralCatchClause
+            catch (Exception ex)
+            {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+            }
             // ReSharper enable ConditionIsAlwaysTrueOrFalse
 
             // build description
@@ -445,7 +448,10 @@ namespace AasxPackageExplorer
                 // close directly!
                 pkg.Close();
             }
-            catch { }
+            catch (Exception ex)
+            {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+            }
         }
 
         // Converter
@@ -547,8 +553,9 @@ namespace AasxPackageExplorer
                             if (asset.identification != null)
                                 assetIds.Add(asset.identification.id);
                 }
-                catch
+                catch (Exception ex)
                 {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                     res = false;
                 }
 

--- a/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
+++ b/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -225,7 +225,6 @@ namespace AasxPackageExplorer
                             {
                                 var res = false;
 
-                                // ReSharper disable EmptyGeneralCatchClause
                                 try
                                 {
                                     res = env.RenameIdentifiable<AdminShell.Asset>(
@@ -233,8 +232,10 @@ namespace AasxPackageExplorer
                                         new AdminShell.Identification(
                                             asset.identification.idType, uc.Text));
                                 }
-                                catch { }
-                                // ReSharper enable EmptyGeneralCatchClause
+                                catch (Exception ex)
+                                {
+                                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                                }
 
                                 if (!res)
                                     helper.flyoutProvider.MessageBoxFlyoutShow(
@@ -1357,7 +1358,6 @@ namespace AasxPackageExplorer
                                     {
                                         var res = false;
 
-                                        // ReSharper disable EmptyGeneralCatchClause
                                         try
                                         {
                                             res = env.RenameIdentifiable<AdminShell.Submodel>(
@@ -1365,8 +1365,10 @@ namespace AasxPackageExplorer
                                                 new AdminShell.Identification(
                                                     submodel.identification.idType, uc.Text));
                                         }
-                                        catch { }
-                                        // ReSharper enable EmptyGeneralCatchClause
+                                        catch (Exception ex)
+                                        {
+                                            AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                                        }
 
                                         if (!res)
                                             helper.flyoutProvider.MessageBoxFlyoutShow(
@@ -1496,15 +1498,16 @@ namespace AasxPackageExplorer
                             {
                                 var res = false;
 
-                                // ReSharper disable EmptyGeneralCatchClause
                                 try
                                 {
                                     res = env.RenameIdentifiable<AdminShell.ConceptDescription>(
                                         cd.identification,
                                         new AdminShell.Identification(cd.identification.idType, uc.Text));
                                 }
-                                catch { }
-                                // ReSharper enable EmptyGeneralCatchClause
+                                catch (Exception ex)
+                                {
+                                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                                }
 
                                 if (!res)
                                     helper.flyoutProvider.MessageBoxFlyoutShow(
@@ -3568,7 +3571,6 @@ namespace AasxPackageExplorer
                 // create controls
                 object result = null;
 
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
                     // replace at top level
@@ -3577,8 +3579,10 @@ namespace AasxPackageExplorer
                         result = x.thePlugin.InvokeAction(
                             "fill-panel-visual-extension", x.thePackage, x.theReferable, theMasterPanel);
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
 
                 // add?
                 if (result == null)

--- a/src/AasxWpfControlLibrary/DispEditHelperBasics.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperBasics.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -124,7 +124,6 @@ namespace AasxPackageExplorer
                 this.lastHighlightedField = fe;
 
             // be a little careful
-            // ReSharper disable EmptyGeneralCatchClause
             try
             {
                 // Textbox
@@ -176,7 +175,10 @@ namespace AasxPackageExplorer
                                 }
                             }
                         }
-                        catch { }
+                        catch (Exception ex)
+                        {
+                            AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                        }
 
                         cb.Focus();
                     }
@@ -187,21 +189,24 @@ namespace AasxPackageExplorer
                     }
                 }
             }
-            catch { }
-            // ReSharper enable EmptyGeneralCatchClause
+            catch (Exception ex)
+            {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+            }
         }
 
         public void ClearHighlights()
         {
-            // ReSharper disable EmptyGeneralCatchClause
             try
             {
                 if (this.lastHighlightedField == null)
                     return;
                 HighligtStateElement(this.lastHighlightedField, highlighted: false);
             }
-            catch { }
-            // ReSharper enable EmptyGeneralCatchClause
+            catch (Exception ex)
+            {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+            }
         }
 
         //

--- a/src/AasxWpfControlLibrary/EclassUtils.cs
+++ b/src/AasxWpfControlLibrary/EclassUtils.cs
@@ -168,7 +168,6 @@ namespace AasxPackageExplorer
             {
                 long totalSize = 1 + new System.IO.FileInfo(a.eclassFiles[fileNdx].fn).Length;
 
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
 
@@ -246,8 +245,10 @@ namespace AasxPackageExplorer
                         }
                     }
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
             }
         }
 
@@ -279,7 +280,6 @@ namespace AasxPackageExplorer
 
                 long totalSize = 1 + new System.IO.FileInfo(a.eclassFiles[fileNdx].fn).Length;
 
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
 
@@ -345,8 +345,10 @@ namespace AasxPackageExplorer
                         }
                     }
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
             }
 
             // 2st pass: search all unit files only for unit-IRDIs
@@ -360,7 +362,6 @@ namespace AasxPackageExplorer
 
                 long totalSize = 1 + new System.IO.FileInfo(a.eclassFiles[fileNdx].fn).Length;
 
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
 
@@ -414,8 +415,10 @@ namespace AasxPackageExplorer
                         }
                     }
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
             }
 
         }
@@ -612,7 +615,6 @@ namespace AasxPackageExplorer
             // Phase 2: fix some shortcomings
             //
 
-            // ReSharper disable EmptyGeneralCatchClause
             try
             {
                 if (ds.shortName == null || ds.shortName.Count < 1) // TBD: multi-language short name?!
@@ -647,8 +649,10 @@ namespace AasxPackageExplorer
                     }
                 }
             }
-            catch { }
-            // ReSharper enable EmptyGeneralCatchClause
+            catch (Exception ex)
+            {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+            }
 
             // ok
             return res;

--- a/src/AasxWpfControlLibrary/Options.cs
+++ b/src/AasxWpfControlLibrary/Options.cs
@@ -548,15 +548,16 @@ namespace AasxPackageExplorer
                     for (int i = 0; i < 10; i++)
                         if (arg == $"-c{i:0}" && morearg > 0)
                         {
-                            // ReSharper disable EmptyGeneralCatchClause
                             // ReSharper disable PossibleNullReferenceException
                             try
                             {
                                 var c = (Color)ColorConverter.ConvertFromString(args[index + 1]);
                                 optionsInformation.AccentColors.Add(i, c);
                             }
-                            catch { }
-                            // ReSharper enable EmptyGeneralCatchClause
+                            catch (Exception ex)
+                            {
+                                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                            }
                             // ReSharper enable PossibleNullReferenceException
 
                             index++;

--- a/src/AasxWpfControlLibrary/Plugins.cs
+++ b/src/AasxWpfControlLibrary/Plugins.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -223,7 +223,6 @@ namespace AasxPackageExplorer
             // over all loaded plugins
             foreach (var pi in LoadedPlugins.Values)
             {
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
                     var x = pi.InvokeAction("get-licenses") as AasxPluginResultLicense;
@@ -239,8 +238,10 @@ namespace AasxPackageExplorer
                         }
                     }
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
             }
 
             // OK
@@ -329,7 +330,6 @@ namespace AasxPackageExplorer
             // over all loaded plugins
             foreach (var pluginInstance in LoadedPlugins.Values)
             {
-                // ReSharper disable EmptyGeneralCatchClause
                 try
                 {
                     for (int i = 0; i < 999; i++)
@@ -358,8 +358,10 @@ namespace AasxPackageExplorer
                         }
                     }
                 }
-                catch { }
-                // ReSharper enable EmptyGeneralCatchClause
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
             }
         }
 

--- a/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml.cs
@@ -251,14 +251,15 @@ namespace AasxPackageExplorer
                 // save
                 if (true == dlg.ShowDialog())
                 {
-                    // ReSharper disable EmptyGeneralCatchClause
                     try
                     {
                         var pr = this.ThisToPreset();
                         pr.SaveToFile(dlg.FileName);
                     }
-                    catch { }
-                    // ReSharper enable EmptyGeneralCatchClause
+                    catch (Exception ex)
+                    {
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                    }
                 }
             }
 
@@ -273,14 +274,15 @@ namespace AasxPackageExplorer
                 // save
                 if (true == dlg.ShowDialog())
                 {
-                    // ReSharper disable EmptyGeneralCatchClause
                     try
                     {
                         var pr = SecureConnectPreset.LoadFromFile(dlg.FileName);
                         this.ActivatePreset(pr);
                     }
-                    catch { }
-                    // ReSharper enable EmptyGeneralCatchClause
+                    catch (Exception ex)
+                    {
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                    }
                 }
             }
 

--- a/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectFromRepositoryFlyout.xaml.cs
@@ -95,8 +95,9 @@ namespace AasxPackageExplorer
                 }
 
             }
-            catch
+            catch (Exception ex)
             {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 this.TheAasxRepo = null;
                 return false;
             }

--- a/src/AasxWpfControlLibrary/VisualAasxElements.cs
+++ b/src/AasxWpfControlLibrary/VisualAasxElements.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -987,7 +987,6 @@ namespace AasxPackageExplorer
             if (Plugins.LoadedPlugins != null)
                 foreach (var lpi in Plugins.LoadedPlugins.Values)
                 {
-                    // ReSharper disable EmptyGeneralCatchClause
                     try
                     {
                         var x =
@@ -996,8 +995,10 @@ namespace AasxPackageExplorer
                         if (x != null && (bool)x.obj)
                             pluginsToCheck.Add(lpi);
                     }
-                    catch { }
-                    // ReSharper enable EmptyGeneralCatchClause
+                    catch (Exception ex)
+                    {
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                    }
                 }
 
             // many operytions -> make it bulletproof
@@ -1072,7 +1073,6 @@ namespace AasxPackageExplorer
                             // check for visual extensions
                             foreach (var lpi in pluginsToCheck)
                             {
-                                // ReSharper disable EmptyGeneralCatchClause
                                 try
                                 {
                                     var ext = lpi.InvokeAction(
@@ -1085,8 +1085,10 @@ namespace AasxPackageExplorer
                                         tiSm.Members.Add(tiExt);
                                     }
                                 }
-                                catch { }
-                                // ReSharper enable EmptyGeneralCatchClause
+                                catch (Exception ex)
+                                {
+                                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                                }
                             }
 
                             // recursively into the submodel elements

--- a/src/WpfMtpControl/AasOpcUaClient.cs
+++ b/src/WpfMtpControl/AasOpcUaClient.cs
@@ -67,7 +67,6 @@ namespace WpfMtpControl
         {
             // start server as a worker (will start in the background)
             // ReSharper disable once LocalVariableHidesMember
-            // ReSharper disable EmptyGeneralCatchClause
             var worker = new BackgroundWorker();
             worker.WorkerSupportsCancellation = true;
             worker.DoWork += (s1, e1) =>
@@ -87,8 +86,9 @@ namespace WpfMtpControl
                         Thread.Sleep(200);
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 }
             };
             worker.RunWorkerCompleted += (s1, e1) =>
@@ -96,7 +96,6 @@ namespace WpfMtpControl
                 ;
             };
             worker.RunWorkerAsync();
-            // ReSharper enable EmptyGeneralCatchClause
         }
 
         public void Cancel()
@@ -107,9 +106,9 @@ namespace WpfMtpControl
                     worker.CancelAsync();
                     worker.Dispose();
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // ignored
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 }
         }
 
@@ -141,8 +140,9 @@ namespace WpfMtpControl
             {
                 config = await application.LoadApplicationConfiguration(false);
             }
-            catch
+            catch (Exception ex)
             {
+                AdminShellNS.LogInternally.That.Error(ex, "Error reading the config file");
                 exitCode = AasOpcUaClientStatus.ErrorReadConfigFile;
                 return;
             }

--- a/src/WpfMtpControl/MtpDataSourceSubscriber.cs
+++ b/src/WpfMtpControl/MtpDataSourceSubscriber.cs
@@ -68,8 +68,10 @@ namespace WpfMtpControl
                         if (si.ConvertToType == typeof(uint))
                             o = Convert.ToUInt32(o);
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+
                         // on any error, simply do not call lambda
                         return;
                     }

--- a/src/WpfMtpControl/MtpVisuOpcUaClient.cs
+++ b/src/WpfMtpControl/MtpVisuOpcUaClient.cs
@@ -143,9 +143,9 @@ namespace WpfMtpControl
                                     nids.Add(ir.nid);
                                     this.nodeIdToItemRef.Add(ir.nid, ir);
                                 }
-                                catch
+                                catch (Exception ex)
                                 {
-                                    // ignored
+                                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                                 }
                             }
 

--- a/src/WpfMtpControl/MtpVisuOptions.cs
+++ b/src/WpfMtpControl/MtpVisuOptions.cs
@@ -48,7 +48,6 @@ namespace WpfMtpControl
         private static void PrepareColor(string preset, ref Brush color)
         {
             // going mad about this ..
-            // ReSharper disable once EmptyGeneralCatchClause
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             // ReSharper disable once PossibleNullReferenceException
             if (preset.HasContent())
@@ -58,7 +57,10 @@ namespace WpfMtpControl
                     if (c != null)
                         color = new SolidColorBrush(c);
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                }
         }
 
         public void Prepare()

--- a/src/WpfMtpControl/MtpVisuViewer.xaml.cs
+++ b/src/WpfMtpControl/MtpVisuViewer.xaml.cs
@@ -599,8 +599,9 @@ namespace WpfMtpControl
                 if (ratio > 0.05)
                     ApplyCanvasZoom(1.0f / ratio);
             }
-            catch
+            catch (Exception ex)
             {
+                AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 ApplyCanvasZoom(1.0f);
             }
         }

--- a/src/WpfMtpVisuViewer/MainWindow.xaml.cs
+++ b/src/WpfMtpVisuViewer/MainWindow.xaml.cs
@@ -82,9 +82,9 @@ namespace WpfMtpVisuViewer
                     var x = testOpcUaClient.ReadSubmodelElementValueAsString(
                         "|var|CODESYS Control Win V3.Application.SENSORS.L001.V", 2);
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // ignored
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 }
 
             if (testOpcUaClient != null && opcCounter % 100 == 0)
@@ -93,9 +93,9 @@ namespace WpfMtpVisuViewer
                     testOpcUaClient.Cancel();
                     testOpcUaClient.Close();
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // ignored
+                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
                 }
         }
 


### PR DESCRIPTION
This patch enhances the AasxCsharpLibrary to include a logging singleton
such that exceptions which were previously just caught and ignored are
at least made visible on STDERR.