### PR TITLE
Deduplicate Log singleton and LogInstance

### DIFF
--- a/src/AasxDictionaryImport/Import.cs
+++ b/src/AasxDictionaryImport/Import.cs
@@ -11,7 +11,6 @@ This source code may use other Open Source software components (see LICENSE.txt)
 using System;
 using System.Linq;
 using System.Windows.Input;
-using AasxGlobalLogging;
 using AdminShellNS;
 
 namespace AasxDictionaryImport
@@ -124,7 +123,8 @@ namespace AasxDictionaryImport
         {
             if (context.UnknownReferences.Count > 0)
             {
-                Log.Info($"Found {context.UnknownReferences.Count} unknown references during import: " +
+                AasxPackageExplorer.Log.Singleton.Info(
+                    $"Found {context.UnknownReferences.Count} unknown references during import: " +
                     string.Join(", ", context.UnknownReferences));
             }
         }

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -17,7 +17,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
-using AasxGlobalLogging;
 
 namespace AasxDictionaryImport
 {
@@ -201,7 +200,7 @@ namespace AasxDictionaryImport
                 }
                 catch (Model.ImportException ex)
                 {
-                    Log.Error(ex, "Could not load the selected data source.");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "Could not load the selected data source.");
                     MessageBox.Show(
                      "Could not load the selected data source.\n" +
                      "Details: " + ex.Message,

--- a/src/AasxPackageExplorer/App.xaml.cs
+++ b/src/AasxPackageExplorer/App.xaml.cs
@@ -7,11 +7,9 @@ This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 This source code may use other Open Source software components (see LICENSE.txt).
 */
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Windows;
-using AasxGlobalLogging;
 
 namespace AasxPackageExplorer
 {
@@ -32,7 +30,7 @@ namespace AasxPackageExplorer
             if (args.Length == 1 && !args[0].StartsWith("-"))
             {
                 directAasx = args[0];
-                Log.Info("Direct request to load AASX {0} ..", directAasx);
+                AasxPackageExplorer.Log.Singleton.Info("Direct request to load AASX {0} ..", directAasx);
             }
 
             // If no command-line args given, read options via default filename
@@ -42,15 +40,17 @@ namespace AasxPackageExplorer
                     System.IO.Path.GetDirectoryName(exePath),
                     System.IO.Path.GetFileNameWithoutExtension(exePath) + ".options.json");
 
-                Log.Info("The default options are expected in the JSON file: {0}", defFn);
+                AasxPackageExplorer.Log.Singleton.Info(
+                    "The default options are expected in the JSON file: {0}", defFn);
                 if (File.Exists(defFn))
                 {
-                    Log.Info("Loading the default options from: {0}", defFn);
+                    AasxPackageExplorer.Log.Singleton.Info(
+                        "Loading the default options from: {0}", defFn);
                     OptionsInformation.ReadJson(defFn, optionsInformation);
                 }
                 else
                 {
-                    Log.Info(
+                    AasxPackageExplorer.Log.Singleton.Info(
                         "The JSON file with the default options does not exist;" +
                         "no default options were loaded: {0}", defFn);
                 }
@@ -58,17 +58,17 @@ namespace AasxPackageExplorer
                 // overrule
                 if (directAasx != null)
                 {
-                    Log.Info($"Loading the AASX from: {directAasx}");
+                    AasxPackageExplorer.Log.Singleton.Info($"Loading the AASX from: {directAasx}");
                     optionsInformation.AasxToLoad = directAasx;
                 }
             }
             else
             {
                 // 2nd parse options
-                Log.Info($"Parsing {args.Length} command-line option(s)...");
+                AasxPackageExplorer.Log.Singleton.Info($"Parsing {args.Length} command-line option(s)...");
 
                 for (var i = 0; i < args.Length; i++)
-                    Log.Info($"Command-line option: {i}: {args[i]}");
+                    AasxPackageExplorer.Log.Singleton.Info($"Command-line option: {i}: {args[i]}");
 
                 OptionsInformation.ParseArgs(args, optionsInformation);
             }
@@ -76,7 +76,8 @@ namespace AasxPackageExplorer
             // 3rd further commandline options in extra file
             if (optionsInformation.OptionsTextFn != null)
             {
-                Log.Info($"Parsing options from a non-default options file: {optionsInformation.OptionsTextFn}");
+                AasxPackageExplorer.Log.Singleton.Info(
+                    $"Parsing options from a non-default options file: {optionsInformation.OptionsTextFn}");
                 var fullFilename = System.IO.Path.GetFullPath(optionsInformation.OptionsTextFn);
                 OptionsInformation.TryReadOptionsFile(fullFilename, optionsInformation);
             }
@@ -90,7 +91,8 @@ namespace AasxPackageExplorer
             // Plugins to be loaded
             if (pluginDllInfos.Count == 0) return new Dictionary<string, Plugins.PluginInstance>();
 
-            Log.Info($"Trying to load and activate {pluginDllInfos.Count} plug-in(s)...");
+            AasxPackageExplorer.Log.Singleton.Info(
+                $"Trying to load and activate {pluginDllInfos.Count} plug-in(s)...");
             var loadedPlugins = Plugins.TryActivatePlugins(pluginDllInfos);
 
             Plugins.TrySetOptionsForPlugins(pluginDllInfos, loadedPlugins);
@@ -101,10 +103,10 @@ namespace AasxPackageExplorer
         private void Application_Startup(object sender, StartupEventArgs e)
         {
             // allow long term logging (for report box)
-            Log.LogInstance.EnableLongTermStore();
+            AasxPackageExplorer.Log.Singleton.EnableLongTermStore();
 
             // Build up of options
-            Log.Info("Application startup.");
+            AasxPackageExplorer.Log.Singleton.Info("Application startup.");
 
             var exePath = System.Reflection.Assembly.GetEntryAssembly()?.Location;
 
@@ -117,16 +119,20 @@ namespace AasxPackageExplorer
                     System.IO.Path.GetDirectoryName(exePath),
                     Options.Curr.PluginDir);
 
-                Log.Info("Searching for the plugins in the plugin directory: {0}", searchDir);
+                AasxPackageExplorer.Log.Singleton.Info(
+                    "Searching for the plugins in the plugin directory: {0}", searchDir);
 
                 var pluginDllInfos = Plugins.TrySearchPlugins(searchDir);
 
-                Log.Info($"Found {pluginDllInfos.Count} plugin(s) in the plugin directory: {searchDir}");
+                AasxPackageExplorer.Log.Singleton.Info(
+                    $"Found {pluginDllInfos.Count} plugin(s) in the plugin directory: {searchDir}");
 
                 Options.Curr.PluginDll.AddRange(pluginDllInfos);
             }
 
-            Log.Info($"Loading and activating {Options.Curr.PluginDll.Count} plugin(s)...");
+            AasxPackageExplorer.Log.Singleton.Info(
+                $"Loading and activating {Options.Curr.PluginDll.Count} plugin(s)...");
+
             Plugins.LoadedPlugins = LoadAndActivatePlugins(Options.Curr.PluginDll);
 
             // at end, write all default options to JSON?
@@ -134,7 +140,7 @@ namespace AasxPackageExplorer
             {
                 // info
                 var fullFilename = System.IO.Path.GetFullPath(Options.Curr.WriteDefaultOptionsFN);
-                Log.Info($"Writing resulting options to a JSON file: {fullFilename}");
+                AasxPackageExplorer.Log.Singleton.Info($"Writing resulting options to a JSON file: {fullFilename}");
 
                 // retrieve
                 Plugins.TryGetDefaultOptionsForPlugins(Options.Curr.PluginDll, Plugins.LoadedPlugins);

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -20,21 +20,13 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Forms;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Effects;
-using System.Windows.Media.Imaging;
-using System.Windows.Threading;
 using System.Xml.Serialization;
-using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AasxSignature;
 using AasxUANodesetImExport;
 using AdminShellNS;
 using Jose;
-using Newtonsoft;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -113,7 +105,7 @@ namespace AasxPackageExplorer
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "When creating new AASX, an error occurred");
+                        AasxPackageExplorer.Log.Singleton.Error(ex, "When creating new AASX, an error occurred");
                         return;
                     }
                 }
@@ -141,7 +133,7 @@ namespace AasxPackageExplorer
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, $"When opening {dlg.FileName}");
+                        AasxPackageExplorer.Log.Singleton.Error(ex, $"When opening {dlg.FileName}");
                     }
 
                     if (packnew != null)
@@ -195,10 +187,10 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "When saving AASX, an error occurred");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "When saving AASX, an error occurred");
                     return;
                 }
-                Log.Info("AASX saved successfully: {0}", packages.Main.Filename);
+                AasxPackageExplorer.Log.Singleton.Info("AASX saved successfully: {0}", packages.Main.Filename);
             }
 
             if (cmd == "saveas")
@@ -241,10 +233,10 @@ namespace AasxPackageExplorer
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "When saving AASX, an error occurred");
+                        AasxPackageExplorer.Log.Singleton.Error(ex, "When saving AASX, an error occurred");
                         return;
                     }
-                    Log.Info("AASX saved successfully as: {0}", dlg.FileName);
+                    AasxPackageExplorer.Log.Singleton.Info("AASX saved successfully as: {0}", dlg.FileName);
                 }
             }
 
@@ -260,7 +252,7 @@ namespace AasxPackageExplorer
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "When closing AASX, an error occurred");
+                        AasxPackageExplorer.Log.Singleton.Error(ex, "When closing AASX, an error occurred");
                     }
             }
 
@@ -392,7 +384,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "When closing auxiliary AASX, an error occurred");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "When closing auxiliary AASX, an error occurred");
                 }
 
             if (cmd == "exit")
@@ -591,7 +583,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Checking model contents");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "Checking model contents");
                 MessageBoxFlyoutShow(
                     "Error while checking model contents. Aborting.", msgBoxHeadline,
                     MessageBoxButton.OK, MessageBoxImage.Error);
@@ -630,7 +622,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Fixing model contents");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "Fixing model contents");
                     MessageBoxFlyoutShow(
                         "Error while fixing issues. Aborting.", msgBoxHeadline,
                         MessageBoxButton.OK, MessageBoxImage.Error);
@@ -719,18 +711,18 @@ namespace AasxPackageExplorer
 
                 if (packages.FileRepository == null)
                 {
-                    Log.Error("No file repository open to be saved. Aborting.");
+                    AasxPackageExplorer.Log.Singleton.Error("No file repository open to be saved. Aborting.");
                     return;
                 }
 
                 try
                 {
-                    Log.Info($"Saving AASX file repository to {fn} ..");
+                    AasxPackageExplorer.Log.Singleton.Info($"Saving AASX file repository to {fn} ..");
                     packages.FileRepository.SaveAs(fn);
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, $"When saving AASX file repository to {fn}");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, $"When saving AASX file repository to {fn}");
                 }
             }
 
@@ -761,13 +753,14 @@ namespace AasxPackageExplorer
                 // execute (is data binded)
                 try
                 {
-                    Log.Info("Make AASX file names relative to {0}", Path.GetFullPath(
+                    AasxPackageExplorer.Log.Singleton.Info("Make AASX file names relative to {0}", Path.GetFullPath(
                         Path.GetDirectoryName("" + packages.FileRepository.Filename)));
                     packages.FileRepository.MakeFilenamesRelative();
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, $"When making AASX file names in repository relative.");
+                    AasxPackageExplorer.Log.Singleton.Error(
+                        ex, $"When making AASX file names in repository relative.");
                 }
             }
 
@@ -806,13 +799,14 @@ namespace AasxPackageExplorer
                             try
                             {
                                 // load
-                                Log.Info("Switching to AASX repository file {0} ..", fn);
+                                AasxPackageExplorer.Log.Singleton.Info("Switching to AASX repository file {0} ..", fn);
                                 UiLoadPackageWithNew(
                                     packages.MainContainer, new AdminShellPackageEnv(fn), fn, onlyAuxiliary: false);
                             }
                             catch (Exception ex)
                             {
-                                Log.Error(ex, $"When switching to AASX repository file {fn}.");
+                                AasxPackageExplorer.Log.Singleton.Error(
+                                    ex, $"When switching to AASX repository file {fn}.");
                             }
                         }
 
@@ -842,7 +836,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "When printing, an error occurred");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "When printing, an error occurred");
                 }
             }
 
@@ -934,12 +928,12 @@ namespace AasxPackageExplorer
             uc2.EnableLargeScreen();
 
             // do some statistics
-            Log.Info("Start secure connect ..");
-            Log.Info("Protocol: {0}", preset.Protocol.Value);
-            Log.Info("AuthorizationServer: {0}", preset.AuthorizationServer.Value);
-            Log.Info("AasServer: {0}", preset.AasServer.Value);
-            Log.Info("CertificateFile: {0}", preset.CertificateFile.Value);
-            Log.Info("Password: {0}", preset.Password.Value);
+            AasxPackageExplorer.Log.Singleton.Info("Start secure connect ..");
+            AasxPackageExplorer.Log.Singleton.Info("Protocol: {0}", preset.Protocol.Value);
+            AasxPackageExplorer.Log.Singleton.Info("AuthorizationServer: {0}", preset.AuthorizationServer.Value);
+            AasxPackageExplorer.Log.Singleton.Info("AasServer: {0}", preset.AasServer.Value);
+            AasxPackageExplorer.Log.Singleton.Info("CertificateFile: {0}", preset.CertificateFile.Value);
+            AasxPackageExplorer.Log.Singleton.Info("Password: {0}", preset.Password.Value);
 
             logger.Info("Protocol: {0}", preset.Protocol.Value);
             logger.Info("AuthorizationServer: {0}", preset.AuthorizationServer.Value);
@@ -985,7 +979,7 @@ namespace AasxPackageExplorer
             }
 
             // done
-            Log.Info("Secure connect done.");
+            AasxPackageExplorer.Log.Singleton.Info("Secure connect done.");
         }
 
         public void CommandBinding_QueryRepo()
@@ -1000,7 +994,7 @@ namespace AasxPackageExplorer
                     var fn = uc.ResultItem?.Filename;
                     if (fn != null && fn != "")
                     {
-                        Log.Info("Switching to {0} ..", fn);
+                        AasxPackageExplorer.Log.Singleton.Info("Switching to {0} ..", fn);
                         UiLoadPackageWithNew(
                             packages.MainContainer, new AdminShellPackageEnv(fn), fn, onlyAuxiliary: false);
                     }
@@ -1056,7 +1050,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "When printing, an error occurred");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "When printing, an error occurred");
             }
         }
 
@@ -1080,7 +1074,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "When printing, an error occurred");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "When printing, an error occurred");
             }
 
             if (Options.Curr.UseFlyovers) this.CloseFlyover();
@@ -1116,7 +1110,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "When printing, an error occurred");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "When printing, an error occurred");
             }
 
             if (Options.Curr.UseFlyovers) this.CloseFlyover();
@@ -1231,7 +1225,7 @@ namespace AasxPackageExplorer
                 else
                 {
                     var url = uc.Text;
-                    Log.Info($"Connecting to REST server {url} ..");
+                    AasxPackageExplorer.Log.Singleton.Info($"Connecting to REST server {url} ..");
 
                     try
                     {
@@ -1243,7 +1237,7 @@ namespace AasxPackageExplorer
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, $"Connecting to REST server {url}");
+                        AasxPackageExplorer.Log.Singleton.Error(ex, $"Connecting to REST server {url}");
                     }
                 }
             }
@@ -1283,7 +1277,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "When importing BMEcat, an error occurred");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "When importing BMEcat, an error occurred");
                 }
 
             if (Options.Curr.UseFlyovers) this.CloseFlyover();
@@ -1322,7 +1316,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "When importing CSV, an error occurred");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "When importing CSV, an error occurred");
                 }
 
             if (Options.Curr.UseFlyovers) this.CloseFlyover();
@@ -1361,7 +1355,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "When importing, an error occurred");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "When importing, an error occurred");
                 }
 
             if (Options.Curr.UseFlyovers) this.CloseFlyover();
@@ -1606,7 +1600,7 @@ namespace AasxPackageExplorer
                 return;
             }
             PUTURL = input.Text;
-            Log.Info($"Connecting to REST server {PUTURL} ..");
+            AasxPackageExplorer.Log.Singleton.Info($"Connecting to REST server {PUTURL} ..");
 
             if (DisplayElements.SelectedItem != null && DisplayElements.SelectedItem is VisualElementSubmodelRef)
                 ve1 = DisplayElements.SelectedItem as VisualElementSubmodelRef;
@@ -1627,7 +1621,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"Connecting to REST server {PUTURL}");
+                AasxPackageExplorer.Log.Singleton.Error(ex, $"Connecting to REST server {PUTURL}");
             }
         }
 
@@ -1655,7 +1649,7 @@ namespace AasxPackageExplorer
                 return;
             }
             GETURL = input.Text;
-            Log.Info($"Connecting to REST server {GETURL} ..");
+            AasxPackageExplorer.Log.Singleton.Info($"Connecting to REST server {GETURL} ..");
 
             var obj = ve1.theSubmodel;
             var sm = "";
@@ -1666,7 +1660,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"Connecting to REST server {GETURL}");
+                AasxPackageExplorer.Log.Singleton.Error(ex, $"Connecting to REST server {GETURL}");
             }
 
             {
@@ -1814,7 +1808,7 @@ namespace AasxPackageExplorer
                             var pi = Plugins.FindPluginInstance("AasxPluginOpcUaClient");
                             if (pi == null || !pi.HasAction("create-client") || !pi.HasAction("read-sme-value"))
                             {
-                                Log.Error(
+                                AasxPackageExplorer.Log.Singleton.Error(
                                     "No plug-in 'AasxPluginOpcUaClient' with appropriate " +
                                     "actions 'create-client()', 'read-sme-value()' found.");
                                 return;
@@ -1829,7 +1823,8 @@ namespace AasxPackageExplorer
                             // ReSharper enable ConditionIsAlwaysTrueOrFalse
                             if (resClient == null || resClient.obj == null)
                             {
-                                Log.Error("Plug-in 'AasxPluginOpcUaClient' cannot create client access!");
+                                AasxPackageExplorer.Log.Singleton.Error(
+                                    "Plug-in 'AasxPluginOpcUaClient' cannot create client access!");
                                 return;
                             }
 
@@ -1867,7 +1862,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "executing OPC UA client");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "executing OPC UA client");
                 }
             }
 
@@ -1901,7 +1896,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception e)
             {
-                Log.Error(e, "An error occurred during the submodel import.");
+                AasxPackageExplorer.Log.Singleton.Error(e, "An error occurred during the submodel import.");
             }
 
             if (dataChanged)
@@ -1942,7 +1937,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception e)
             {
-                Log.Error(e, "An error occurred during the submodel element import.");
+                AasxPackageExplorer.Log.Singleton.Error(e, "An error occurred during the submodel element import.");
             }
 
             if (dataChanged)
@@ -1975,7 +1970,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "When importing AML, an error occurred");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "When importing AML, an error occurred");
             }
 
             if (Options.Curr.UseFlyovers) this.CloseFlyover();
@@ -2007,7 +2002,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "When exporting AML, an error occurred");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "When exporting AML, an error occurred");
             }
 
             if (Options.Curr.UseFlyovers) this.CloseFlyover();
@@ -2042,7 +2037,8 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "When exporting UA nodeset via plug-in, an error occurred");
+                AasxPackageExplorer.Log.Singleton.Error(
+                    ex, "When exporting UA nodeset via plug-in, an error occurred");
             }
 
             if (Options.Curr.UseFlyovers) this.CloseFlyover();
@@ -2086,11 +2082,11 @@ namespace AasxPackageExplorer
             if (jsonStr != null && jsonStr != "")
             {
                 System.Windows.Clipboard.SetText(jsonStr);
-                Log.Info("Copied selected element to clipboard.");
+                AasxPackageExplorer.Log.Singleton.Info("Copied selected element to clipboard.");
             }
             else
             {
-                Log.Info("No JSON text could be generated for selected element.");
+                AasxPackageExplorer.Log.Singleton.Info("No JSON text could be generated for selected element.");
             }
         }
 
@@ -2132,7 +2128,8 @@ namespace AasxPackageExplorer
             {
                 if (res == true)
                 {
-                    Log.Info("Exporting add-options file to GenericForm: {0}", dlg.FileName);
+                    AasxPackageExplorer.Log.Singleton.Info(
+                        "Exporting add-options file to GenericForm: {0}", dlg.FileName);
                     RememberForInitialDirectory(dlg.FileName);
                     AasxIntegrationBase.AasForms.AasFormUtils.ExportAsGenericFormsOptions(
                         ve1.theEnv, ve1.theSubmodel, dlg.FileName);
@@ -2140,7 +2137,8 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "When exporting options file for GenericForms, an error occurred");
+                AasxPackageExplorer.Log.Singleton.Error(
+                    ex, "When exporting options file for GenericForms, an error occurred");
             }
 
             if (Options.Curr.UseFlyovers) this.CloseFlyover();
@@ -2185,14 +2183,16 @@ namespace AasxPackageExplorer
                 if (res == true)
                 {
                     RememberForInitialDirectory(dlg.FileName);
-                    Log.Info("Exporting text snippets for PredefinedConcepts: {0}", dlg.FileName);
+                    AasxPackageExplorer.Log.Singleton.Info(
+                        "Exporting text snippets for PredefinedConcepts: {0}", dlg.FileName);
                     AasxPredefinedConcepts.ExportPredefinedConcepts.Export(
                         packages.Main.AasEnv, ve1.theSubmodel, dlg.FileName);
                 }
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "When exporting text snippets for PredefinedConcepts, an error occurred");
+                AasxPackageExplorer.Log.Singleton.Error(
+                    ex, "When exporting text snippets for PredefinedConcepts, an error occurred");
             }
 
             if (Options.Curr.UseFlyovers) this.CloseFlyover();
@@ -2259,7 +2259,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Executing user defined conversion");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "Executing user defined conversion");
                 }
 
             // redisplay
@@ -2453,7 +2453,8 @@ namespace AasxPackageExplorer
                             ve1.theEnv.ConceptDescriptions.Add(newCd);
                             nr++;
                         }
-                        Log.Info($"added {nr} ConceptDescritions for Submodel {smres.idShort}.");
+                        AasxPackageExplorer.Log.Singleton.Info(
+                            $"added {nr} ConceptDescritions for Submodel {smres.idShort}.");
                     }
 
                     // redisplay
@@ -2462,7 +2463,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "when adding Submodel to AAS");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "when adding Submodel to AAS");
                 }
             }
         }

--- a/src/AasxPackageExplorer/MainWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MainWindow.xaml.cs
@@ -11,7 +11,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
@@ -20,7 +19,6 @@ using System.Windows.Media;
 using System.Windows.Media.Effects;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
-using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AasxWpfControlLibrary;
 using AdminShellNS;
@@ -100,13 +98,14 @@ namespace AasxPackageExplorer
             if (theContentBrowser.CanHandleFileNameExtension(url) || preferInternal)
             {
                 // try view in browser
-                Log.Info($"Displaying {url} locally in embedded browser ..");
+                AasxPackageExplorer.Log.Singleton.Info($"Displaying {url} locally in embedded browser ..");
                 ShowContentBrowser(url);
             }
             else
             {
                 // open externally
-                Log.Info($"Displaying {this.showContentPackageUri} remotely in external viewer ..");
+                AasxPackageExplorer.Log.Singleton.Info(
+                    $"Displaying {this.showContentPackageUri} remotely in external viewer ..");
                 System.Diagnostics.Process.Start(url);
             }
         }
@@ -186,7 +185,8 @@ namespace AasxPackageExplorer
             if (packContainer == null)
                 return;
 
-            Log.Info("Loading new AASX from: {0} as auxiliary {1} ..", info, onlyAuxiliary);
+            AasxPackageExplorer.Log.Singleton.Info(
+                "Loading new AASX from: {0} as auxiliary {1} ..", info, onlyAuxiliary);
             // loading
             try
             {
@@ -196,7 +196,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"When loading {info}, an error occurred");
+                AasxPackageExplorer.Log.Singleton.Error(ex, $"When loading {info}, an error occurred");
                 return;
             }
 
@@ -207,7 +207,8 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"When displaying element tree of {info}, an error occurred");
+                AasxPackageExplorer.Log.Singleton.Error(
+                    ex, $"When displaying element tree of {info}, an error occurred");
                 return;
             }
 
@@ -219,29 +220,33 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"When performing actions after load of {info}, an error occurred");
+                AasxPackageExplorer.Log.Singleton.Error(
+                    ex, $"When performing actions after load of {info}, an error occurred");
                 return;
             }
 
             // done
-            Log.Info("AASX {0} loaded.", info);
+            AasxPackageExplorer.Log.Singleton.Info("AASX {0} loaded.", info);
         }
 
         public AasxFileRepository UiLoadFileRepository(string fn)
         {
             try
             {
-                Log.Info($"Loading aasx file repository {Options.Curr.AasxRepositoryFn} ..");
+                AasxPackageExplorer.Log.Singleton.Info(
+                    $"Loading aasx file repository {Options.Curr.AasxRepositoryFn} ..");
                 var fr = AasxFileRepository.Load(fn);
 
                 if (fr != null)
                     return fr;
                 else
-                    Log.Info($"File not found when auto-loading aasx file repository {Options.Curr.AasxRepositoryFn}");
+                    AasxPackageExplorer.Log.Singleton.Info(
+                        $"File not found when auto-loading aasx file repository {Options.Curr.AasxRepositoryFn}");
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"When auto-loading aasx file repository {Options.Curr.AasxRepositoryFn}");
+                AasxPackageExplorer.Log.Singleton.Error(
+                    ex, $"When auto-loading aasx file repository {Options.Curr.AasxRepositoryFn}");
             }
 
             return null;
@@ -624,7 +629,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, $"When auto-loading {fn}");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, $"When auto-loading {fn}");
                 }
             };
             this.RepoControl.QueryClick += () =>
@@ -636,7 +641,7 @@ namespace AasxPackageExplorer
             MenuItemFileRepoLoadWoPrompt.IsChecked = Options.Curr.LoadWithoutPrompt;
 
             // Last task here ..
-            Log.Info("Application started ..");
+            AasxPackageExplorer.Log.Singleton.Info("Application started ..");
 
             // Try to load?
             if (Options.Curr.AasxToLoad != null)
@@ -650,7 +655,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, $"When auto-loading {fn}");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, $"When auto-loading {fn}");
                 }
             }
 
@@ -690,7 +695,7 @@ namespace AasxPackageExplorer
 
             // check for Stored Prints in Log
             StoredPrint sp;
-            while ((sp = Log.LogInstance.PopLastShortTermPrint()) != null)
+            while ((sp = AasxPackageExplorer.Log.Singleton.PopLastShortTermPrint()) != null)
             {
                 // pop
                 Message.Content = "" + sp.msg;
@@ -725,7 +730,7 @@ namespace AasxPackageExplorer
             }
 
             // always tell the errors
-            var ne = Log.LogInstance.NumberErrors;
+            var ne = AasxPackageExplorer.Log.Singleton.NumberErrors;
             if (ne > 0)
             {
                 LabelNumberErrors.Content = "Errors: " + ne;
@@ -789,7 +794,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "While responding to a user interaction");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "While responding to a user interaction");
             }
         }
 
@@ -809,12 +814,12 @@ namespace AasxPackageExplorer
             AdminShellPackageEnv pkg = null;
             try
             {
-                Log.Info($"Auto-load AASX file from repository {fn}");
+                AasxPackageExplorer.Log.Singleton.Info($"Auto-load AASX file from repository {fn}");
                 pkg = LoadPackageFromFile(fn);
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"When auto-loading {fn}");
+                AasxPackageExplorer.Log.Singleton.Error(ex, $"When auto-loading {fn}");
             }
 
             // if successfull ..
@@ -918,7 +923,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "While retrieving element requested for navigate to");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "While retrieving element requested for navigate to");
             }
 
             // if successful, try to display it
@@ -944,7 +949,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "While displaying element requested for navigate to");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "While displaying element requested for navigate to");
             }
         }
 
@@ -978,7 +983,8 @@ namespace AasxPackageExplorer
                         }
                         catch (Exception ex)
                         {
-                            Log.Error(ex, $"While displaying content file {evtDispCont.fn} requested by plug-in");
+                            AasxPackageExplorer.Log.Singleton.Error(
+                                ex, $"While displaying content file {evtDispCont.fn} requested by plug-in");
                         }
 
                     #endregion
@@ -1030,7 +1036,8 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, $"While responding to a event from plug-in {"" + lpi?.name}");
+                    AasxPackageExplorer.Log.Singleton.Error(
+                        ex, $"While responding to a event from plug-in {"" + lpi?.name}");
                 }
             }
         }
@@ -1051,7 +1058,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "While displaying home element");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "While displaying home element");
             }
         }
 
@@ -1087,7 +1094,8 @@ namespace AasxPackageExplorer
                     var fi = packages.FileRepository.FindByAasId(hi.ReferableAasId.id.Trim());
                     if (fi == null)
                     {
-                        Log.Error($"Cannot lookup aas id {hi.ReferableAasId.id} in file repository.");
+                        AasxPackageExplorer.Log.Singleton.Error(
+                            $"Cannot lookup aas id {hi.ReferableAasId.id} in file repository.");
                         return;
                     }
 
@@ -1102,7 +1110,8 @@ namespace AasxPackageExplorer
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, $"While retrieving file for {hi.ReferableAasId.id} from file repository");
+                        AasxPackageExplorer.Log.Singleton.Error(
+                            ex, $"While retrieving file for {hi.ReferableAasId.id} from file repository");
                     }
 
                     // still proceed?
@@ -1113,7 +1122,8 @@ namespace AasxPackageExplorer
                             alsoDereferenceObjects: true, sri: sri);
                         if (veFocus == null)
                         {
-                            Log.Error($"Cannot lookup requested element within loaded file from repository.");
+                            AasxPackageExplorer.Log.Singleton.Error(
+                                $"Cannot lookup requested element within loaded file from repository.");
                             return;
                         }
                     }
@@ -1132,13 +1142,14 @@ namespace AasxPackageExplorer
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "While displaying element requested by back button.");
+                        AasxPackageExplorer.Log.Singleton.Error(
+                            ex, "While displaying element requested by back button.");
                     }
                 }
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "While displaying element requested by plug-in");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "While displaying element requested by plug-in");
             }
         }
 
@@ -1146,7 +1157,7 @@ namespace AasxPackageExplorer
         {
             if (sender == ButtonClear)
             {
-                Log.LogInstance.ClearNumberErrors();
+                AasxPackageExplorer.Log.Singleton.ClearNumberErrors();
                 Message.Content = "";
                 Message.Background = Brushes.White;
                 Message.Foreground = Brushes.Black;
@@ -1200,7 +1211,7 @@ namespace AasxPackageExplorer
                 // Collect all the stored log prints
                 IEnumerable<StoredPrint> Prints()
                 {
-                    var prints = Log.LogInstance.GetStoredLongTermPrints();
+                    var prints = AasxPackageExplorer.Log.Singleton.GetStoredLongTermPrints();
                     if (prints != null)
                     {
                         yield return new StoredPrint(head);
@@ -1292,7 +1303,7 @@ namespace AasxPackageExplorer
                 return;
             }
 
-            Log.Info("Closing ..");
+            AasxPackageExplorer.Log.Singleton.Info("Closing ..");
             try
             {
                 packages.Main.Close();
@@ -1321,7 +1332,7 @@ namespace AasxPackageExplorer
         {
             if (sender == ShowContent && this.showContentPackageUri != null && packages.MainAvailable)
             {
-                Log.Info("Trying display content {0} ..", this.showContentPackageUri);
+                AasxPackageExplorer.Log.Singleton.Info("Trying display content {0} ..", this.showContentPackageUri);
                 try
                 {
                     var contentUri = this.showContentPackageUri;
@@ -1338,10 +1349,11 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, $"When displaying content {this.showContentPackageUri}, an error occurred");
+                    AasxPackageExplorer.Log.Singleton.Error(
+                        ex, $"When displaying content {this.showContentPackageUri}, an error occurred");
                     return;
                 }
-                Log.Info("Content {0} displayed.", this.showContentPackageUri);
+                AasxPackageExplorer.Log.Singleton.Info("Content {0} displayed.", this.showContentPackageUri);
             }
         }
 
@@ -1624,11 +1636,12 @@ namespace AasxPackageExplorer
                     string fn = files[0];
                     try
                     {
-                        UiLoadPackageWithNew(packages.MainContainer, LoadPackageFromFile(fn), fn, onlyAuxiliary: false);
+                        UiLoadPackageWithNew(
+                            packages.MainContainer, LoadPackageFromFile(fn), fn, onlyAuxiliary: false);
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, $"while receiving file drop to window");
+                        AasxPackageExplorer.Log.Singleton.Error(ex, $"while receiving file drop to window");
                     }
                 }
             }
@@ -1671,7 +1684,8 @@ namespace AasxPackageExplorer
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, $"When dragging content {this.showContentPackageUri}, an error occurred");
+                        AasxPackageExplorer.Log.Singleton.Error(
+                            ex, $"When dragging content {this.showContentPackageUri}, an error occurred");
                         return;
                     }
 

--- a/src/AasxPackageExplorer/MessageReportWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MessageReportWindow.xaml.cs
@@ -7,20 +7,9 @@ This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 This source code may use other Open Source software components (see LICENSE.txt).
 */
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
-using AasxGlobalLogging;
 using AasxIntegrationBase;
 
 namespace AasxPackageExplorer
@@ -48,7 +37,7 @@ namespace AasxPackageExplorer
 
             // get url
             var uri = link.NavigateUri.ToString();
-            Log.Info($"Displaying {uri} remotely in external viewer ..");
+            AasxPackageExplorer.Log.Singleton.Info($"Displaying {uri} remotely in external viewer ..");
             System.Diagnostics.Process.Start(uri);
         }
 

--- a/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
+++ b/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
@@ -9,25 +9,15 @@ This source code may use other Open Source software components (see LICENSE.txt)
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using AasxGlobalLogging;
 using AasxIntegrationBase;
-using AasxPackageExplorer;
 using AasxWpfControlLibrary;
 using AdminShellNS;
 
@@ -176,7 +166,7 @@ namespace AasxPackageExplorer
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "When printing, an error occurred");
+                        AasxPackageExplorer.Log.Singleton.Error(ex, "When printing, an error occurred");
                     }
 
                     if (helper.flyoutProvider != null) helper.flyoutProvider.CloseFlyover();
@@ -495,7 +485,7 @@ namespace AasxPackageExplorer
                                         }
                                         catch (Exception ex)
                                         {
-                                            Log.Error(ex, $"copying AAS");
+                                            AasxPackageExplorer.Log.Singleton.Error(ex, $"copying AAS");
                                         }
 
                                         //
@@ -524,7 +514,8 @@ namespace AasxPackageExplorer
                                                 }
                                                 catch (Exception ex)
                                                 {
-                                                    Log.Error(ex, $"copying supplementary file {fn}");
+                                                    AasxPackageExplorer.Log.Singleton.Error(
+                                                        ex, $"copying supplementary file {fn}");
                                                 }
                                             }
                                         }
@@ -704,13 +695,13 @@ namespace AasxPackageExplorer
                                 ptd = "/";
                             packages.Main.AddSupplementaryFileToStore(
                                 PackageSourcePath, ptd, PackageTargetFn, PackageEmbedAsThumbnail);
-                            Log.Info(
+                            AasxPackageExplorer.Log.Singleton.Info(
                                 "Added {0} to pending package items. A save-operation is required.",
                                 PackageSourcePath);
                         }
                         catch (Exception ex)
                         {
-                            Log.Error(ex, "Adding file to package");
+                            AasxPackageExplorer.Log.Singleton.Error(ex, "Adding file to package");
                         }
                         PackageSourcePath = "";
                         PackageTargetFn = "";
@@ -791,13 +782,13 @@ namespace AasxPackageExplorer
                            try
                            {
                                packages.Main.DeleteSupplementaryFile(psf);
-                               Log.Info(
+                               AasxPackageExplorer.Log.Singleton.Info(
                                "Added {0} to pending package items to be deleted. " +
                                    "A save-operation might be required.", PackageSourcePath);
                            }
                            catch (Exception ex)
                            {
-                               Log.Error(ex, "Deleting file in package");
+                               AasxPackageExplorer.Log.Singleton.Error(ex, "Deleting file in package");
                            }
                            return new ModifyRepo.LambdaActionRedrawAllElements(
                            nextFocus: VisualElementEnvironmentItem.GiveDataObject(
@@ -2818,20 +2809,23 @@ namespace AasxPackageExplorer
                                         var psf = psfs?.FindByUri(fl.value);
                                         if (psf == null)
                                         {
-                                            Log.Error($"Not able to locate supplmentary file {fl.value} for removal! " +
+                                            AasxPackageExplorer.Log.Singleton.Error(
+                                                $"Not able to locate supplmentary file {fl.value} for removal! " +
                                                 $"Aborting!");
                                         }
                                         else
                                         {
-                                            Log.Info($"Removing file {fl.value} ..");
+                                            AasxPackageExplorer.Log.Singleton.Info($"Removing file {fl.value} ..");
                                             packages.Main.DeleteSupplementaryFile(psf);
-                                            Log.Info($"Added {fl.value} to pending package items to be deleted. " +
+                                            AasxPackageExplorer.Log.Singleton.Info(
+                                                $"Added {fl.value} to pending package items to be deleted. " +
                                                 "A save-operation might be required.");
                                         }
                                     }
                                     catch (Exception ex)
                                     {
-                                        Log.Error(ex, $"Removing file {fl.value} in package");
+                                        AasxPackageExplorer.Log.Singleton.Error(
+                                            ex, $"Removing file {fl.value} in package");
                                     }
 
                                     // clear value
@@ -2885,11 +2879,12 @@ namespace AasxPackageExplorer
 
                                     if (targetPath == null)
                                     {
-                                        Log.Error($"Error creating text-file {ptd + ptfn} within package");
+                                        AasxPackageExplorer.Log.Singleton.Error(
+                                            $"Error creating text-file {ptd + ptfn} within package");
                                     }
                                     else
                                     {
-                                        Log.Info(
+                                        AasxPackageExplorer.Log.Singleton.Info(
                                             $"Added empty text-file {ptd + ptfn} to pending package items. " +
                                             $"A save-operation is required.");
                                         fl.mimeType = mimeType;
@@ -2898,7 +2893,8 @@ namespace AasxPackageExplorer
                                 }
                                 catch (Exception ex)
                                 {
-                                    Log.Error(ex, $"Creating text-file {ptd + ptfn} within package");
+                                    AasxPackageExplorer.Log.Singleton.Error(
+                                        ex, $"Creating text-file {ptd + ptfn} within package");
                                 }
                                 return new ModifyRepo.LambdaActionRedrawAllElements(nextFocus: sme);
                             }
@@ -2912,13 +2908,14 @@ namespace AasxPackageExplorer
                                     var psf = psfs?.FindByUri(fl.value);
                                     if (psf == null)
                                     {
-                                        Log.Error($"Not able to locate supplmentary file {fl.value} for edit. " +
+                                        AasxPackageExplorer.Log.Singleton.Error(
+                                            $"Not able to locate supplmentary file {fl.value} for edit. " +
                                             $"Aborting!");
                                         return new ModifyRepo.LambdaActionNone();
                                     }
 
                                     // try read ..
-                                    Log.Info($"Reading text-file {fl.value} ..");
+                                    AasxPackageExplorer.Log.Singleton.Info($"Reading text-file {fl.value} ..");
                                     string contents;
                                     using (var stream = packages.Main.GetStreamFromUriOrLocalPackage(fl.value))
                                     {
@@ -2932,7 +2929,8 @@ namespace AasxPackageExplorer
                                     // test
                                     if (contents == null)
                                     {
-                                        Log.Error($"Not able to read contents from  supplmentary file {fl.value} " +
+                                        AasxPackageExplorer.Log.Singleton.Error(
+                                            $"Not able to read contents from  supplmentary file {fl.value} " +
                                             $"for edit. Aborting!");
                                         return new ModifyRepo.LambdaActionNone();
                                     }
@@ -2957,7 +2955,8 @@ namespace AasxPackageExplorer
                                 }
                                 catch (Exception ex)
                                 {
-                                    Log.Error(ex, $"Edit text-file {fl.value} in package.");
+                                    AasxPackageExplorer.Log.Singleton.Error(
+                                        ex, $"Edit text-file {fl.value} in package.");
                                 }
 
                                 // reshow
@@ -3023,11 +3022,12 @@ namespace AasxPackageExplorer
 
                                     if (targetPath == null)
                                     {
-                                        Log.Error($"Error adding file {uploadAssistance.SourcePath} to package");
+                                        AasxPackageExplorer.Log.Singleton.Error(
+                                            $"Error adding file {uploadAssistance.SourcePath} to package");
                                     }
                                     else
                                     {
-                                        Log.Info(
+                                        AasxPackageExplorer.Log.Singleton.Info(
                                             $"Added {ptfn} to pending package items. A save-operation is required.");
                                         fl.mimeType = mimeType;
                                         fl.value = targetPath;
@@ -3035,7 +3035,8 @@ namespace AasxPackageExplorer
                                 }
                                 catch (Exception ex)
                                 {
-                                    Log.Error(ex, $"Adding file {uploadAssistance.SourcePath} to package");
+                                    AasxPackageExplorer.Log.Singleton.Error(
+                                        ex, $"Adding file {uploadAssistance.SourcePath} to package");
                                 }
 
                                 // refresh dialogue

--- a/src/AasxWpfControlLibrary/DispEditHelperBasics.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperBasics.cs
@@ -12,14 +12,10 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
 using System.Windows.Media;
-using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AasxWpfControlLibrary;
 using AdminShellNS;
@@ -1218,7 +1214,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Executing refactoring");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, "Executing refactoring");
                 }
             }
 
@@ -1428,7 +1424,7 @@ namespace AasxPackageExplorer
                     {
                         var st = keys.ToString(format: 1, delimiter: "\r\n");
                         Clipboard.SetText(st);
-                        Log.Info("Keys written to clipboard.");
+                        AasxPackageExplorer.Log.Singleton.Info("Keys written to clipboard.");
                         return new ModifyRepo.LambdaActionNone();
                     });
 
@@ -1748,7 +1744,8 @@ namespace AasxPackageExplorer
                             }
                             catch (Exception ex)
                             {
-                                Log.Error(ex, $"While show qualifier presets ({Options.Curr.QualifiersFile})");
+                                AasxPackageExplorer.Log.Singleton.Error(
+                                    ex, $"While show qualifier presets ({Options.Curr.QualifiersFile})");
                             }
                         }
 

--- a/src/AasxWpfControlLibrary/DispEditHelperCopyPaste.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperCopyPaste.cs
@@ -9,19 +9,9 @@ This source code may use other Open Source software components (see LICENSE.txt)
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
-using System.Windows.Media;
-using AasxGlobalLogging;
 using AasxIntegrationBase;
-using AasxWpfControlLibrary;
 using AdminShellNS;
 
 namespace AasxPackageExplorer
@@ -180,7 +170,7 @@ namespace AasxPackageExplorer
                         cpb.item = new CopyPasteItemSME(env, parentContainer, wrapper, sme);
 
                         // user feedback
-                        Log.Info(
+                        AasxPackageExplorer.Log.Singleton.Info(
                             StoredPrint.Color.Blue,
                             "Stored SubmodelElement '{0}'({1}) to internal buffer.{2}", "" + sme.idShort,
                             "" + sme?.GetElementName(),
@@ -205,7 +195,7 @@ namespace AasxPackageExplorer
                         }
 
                         // user feedback
-                        Log.Info(
+                        AasxPackageExplorer.Log.Singleton.Info(
                             "Pasting buffer with SubmodelElement '{0}'({1}) to internal buffer.",
                             "" + item.sme.idShort, "" + item.sme.GetElementName());
 
@@ -323,7 +313,7 @@ namespace AasxPackageExplorer
                         cpb.item = new CopyPasteItemSubmodel(parentContainer, entity, smref, sm);
 
                         // user feedback
-                        Log.Info(
+                        AasxPackageExplorer.Log.Singleton.Info(
                             StoredPrint.Color.Blue,
                             "Stored Submodel '{0}' to internal buffer.{1}", "" + sm.idShort,
                             cpb.duplicate
@@ -349,7 +339,7 @@ namespace AasxPackageExplorer
                             }
 
                             // user feedback
-                            Log.Info(
+                            AasxPackageExplorer.Log.Singleton.Info(
                                 "Pasting buffer with Submodel '{0}' to internal buffer.",
                                 "" + item.sm.idShort);
 
@@ -402,7 +392,7 @@ namespace AasxPackageExplorer
                             }
 
                             // user feedback
-                            Log.Info(
+                            AasxPackageExplorer.Log.Singleton.Info(
                                 "Pasting buffer with SubmodelElement '{0}'({1}) to internal buffer.",
                                 "" + item.sme.idShort, "" + item.sme.GetElementName());
 
@@ -471,7 +461,7 @@ namespace AasxPackageExplorer
                         cpb.item = new CopyPasteItemIdentifiable(parentContainer, entity);
 
                         // user feedback
-                        Log.Info(
+                        AasxPackageExplorer.Log.Singleton.Info(
                             StoredPrint.Color.Blue,
                             "Stored {0} '{1}' to internal buffer.{1}",
                             "" + entity.GetElementName(),
@@ -499,7 +489,7 @@ namespace AasxPackageExplorer
                             }
 
                             // user feedback
-                            Log.Info(
+                            AasxPackageExplorer.Log.Singleton.Info(
                                 "Pasting buffer with {0} '{1}' to internal buffer.",
                                 "" + item.entity.GetElementName(),
                                 "" + item.entity.idShort);

--- a/src/AasxWpfControlLibrary/DispEditHelperModules.cs
+++ b/src/AasxWpfControlLibrary/DispEditHelperModules.cs
@@ -19,7 +19,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
-using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AdminShellNS;
 

--- a/src/AasxWpfControlLibrary/Log.cs
+++ b/src/AasxWpfControlLibrary/Log.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>
 Author: Michael Hoffmeister
 
@@ -7,14 +7,7 @@ This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
 This source code may use other Open Source software components (see LICENSE.txt).
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AasxIntegrationBase;
-
-namespace AasxGlobalLogging
+namespace AasxPackageExplorer
 {
     /// <summary>
     /// Static class, wrapping log instance, to have a logging via Singleton.
@@ -22,48 +15,8 @@ namespace AasxGlobalLogging
     /// </summary>
     public static class Log
     {
-        private static AasxIntegrationBase.LogInstance logInstance = new AasxIntegrationBase.LogInstance();
+        private static readonly AasxIntegrationBase.LogInstance LogInstance = new AasxIntegrationBase.LogInstance();
 
-        public static AasxIntegrationBase.LogInstance LogInstance { get { return logInstance; } }
-
-        /// <summary>
-        /// Writes the message to STDERR skipping the both the short-term and the long-term storages.
-        /// </summary>
-        public static void Silent(string msg, params object[] args)
-        {
-            logInstance?.Silent(msg, args);
-        }
-
-        /// <summary>
-        /// Display a message, which is for information only
-        /// </summary>
-        public static void Info(string msg, params object[] args)
-        {
-            logInstance?.Info(msg, args);
-        }
-
-        /// <summary>
-        /// Display a message, which is for information only
-        /// </summary>
-        public static void Info(StoredPrint.Color color, string msg, params object[] args)
-        {
-            logInstance?.Info(color, msg, args);
-        }
-
-        /// <summary>
-        /// Display a message, which is for errors
-        /// </summary>
-        public static void Error(string msg, params object[] args)
-        {
-            logInstance?.Error(msg, args);
-        }
-
-        /// <summary>
-        /// Display a message, which is for errors
-        /// </summary>
-        public static void Error(Exception ex, string where)
-        {
-            logInstance?.Error(ex, where);
-        }
+        public static AasxIntegrationBase.LogInstance Singleton => LogInstance;
     }
 }

--- a/src/AasxWpfControlLibrary/LogMessageFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/LogMessageFlyout.xaml.cs
@@ -9,23 +9,12 @@ This source code may use other Open Source software components (see LICENSE.txt)
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using AasxGlobalLogging;
 using AasxIntegrationBase;
-using Newtonsoft.Json;
 
 namespace AasxPackageExplorer
 {
@@ -137,7 +126,7 @@ namespace AasxPackageExplorer
 
             // get url
             var uri = link.NavigateUri.ToString();
-            Log.Info($"Displaying {uri} remotely in external viewer ..");
+            AasxPackageExplorer.Log.Singleton.Info($"Displaying {uri} remotely in external viewer ..");
             System.Diagnostics.Process.Start(uri);
         }
 

--- a/src/AasxWpfControlLibrary/ModifyRepo.cs
+++ b/src/AasxWpfControlLibrary/ModifyRepo.cs
@@ -9,13 +9,9 @@ This source code may use other Open Source software components (see LICENSE.txt)
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using AasxGlobalLogging;
 using AdminShellNS;
 
 namespace AasxPackageExplorer
@@ -194,7 +190,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "While in user callback (modify repo lambda)");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "While in user callback (modify repo lambda)");
             }
         }
 
@@ -218,7 +214,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "While in user callback (modify repo lambda)");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "While in user callback (modify repo lambda)");
             }
 
         }
@@ -241,7 +237,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "While in user callback (modify repo lambda)");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "While in user callback (modify repo lambda)");
             }
         }
 
@@ -264,7 +260,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "While in user callback (modify repo lambda)");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "While in user callback (modify repo lambda)");
             }
         }
 
@@ -288,7 +284,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "While in user callback (modify repo lambda)");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "While in user callback (modify repo lambda)");
             }
         }
 
@@ -315,7 +311,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "While in user callback (modify repo lambda)");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "While in user callback (modify repo lambda)");
             }
         }
     }

--- a/src/AasxWpfControlLibrary/Options.cs
+++ b/src/AasxWpfControlLibrary/Options.cs
@@ -9,17 +9,9 @@ This source code may use other Open Source software components (see LICENSE.txt)
 
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Windows.Media;
-using AasxGlobalLogging;
-using AasxIntegrationBase;
-using AdminShellNS;
 using Newtonsoft.Json;
 
 namespace AasxPackageExplorer
@@ -294,7 +286,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"When writing options to a JSON file: {filename}");
+                AasxPackageExplorer.Log.Singleton.Error(ex, $"When writing options to a JSON file: {filename}");
             }
         }
 
@@ -310,7 +302,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "When reading options JSON file");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "When reading options JSON file");
             }
         }
 
@@ -588,7 +580,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Reading options file: " + filename);
+                AasxPackageExplorer.Log.Singleton.Error(ex, "Reading options file: " + filename);
             }
         }
 

--- a/src/AasxWpfControlLibrary/Plugins.cs
+++ b/src/AasxWpfControlLibrary/Plugins.cs
@@ -10,13 +10,8 @@ This source code may use other Open Source software components (see LICENSE.txt)
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using AasxGlobalLogging;
 using AasxIntegrationBase;
-using AdminShellNS;
 using Newtonsoft.Json;
 
 namespace AasxPackageExplorer
@@ -161,7 +156,7 @@ namespace AasxPackageExplorer
             {
                 try
                 {
-                    Log.Info("Trying to load a DLL: {0}", pluginDll[index].Path);
+                    AasxPackageExplorer.Log.Singleton.Info("Trying to load a DLL: {0}", pluginDll[index].Path);
 
                     // make full path
                     var fullfn = System.IO.Path.GetFullPath(pluginDll[index].Path);
@@ -174,7 +169,8 @@ namespace AasxPackageExplorer
                     var tp = asm.GetType("AasxIntegrationBase.AasxPlugin");
                     if (tp == null)
                     {
-                        Log.Error("Cannot find class AasxIntegrationBase.AasxPlugin within .dll.");
+                        AasxPackageExplorer.Log.Singleton.Error(
+                            "Cannot find class AasxIntegrationBase.AasxPlugin within .dll.");
                         continue;
                     }
 
@@ -182,7 +178,8 @@ namespace AasxPackageExplorer
                     IAasxPluginInterface ob = (IAasxPluginInterface)Activator.CreateInstance(tp);
                     if (ob == null)
                     {
-                        Log.Error("Cannot create instance from class AasxIntegrationBase.AasxPlugin within .dll.");
+                        AasxPackageExplorer.Log.Singleton.Error(
+                            "Cannot create instance from class AasxIntegrationBase.AasxPlugin within .dll.");
                         continue;
                     }
 
@@ -190,7 +187,7 @@ namespace AasxPackageExplorer
                     var pi = PluginInstance.CreateNew(index, asm, tp, ob, pluginDll[index].Args);
                     if (pi == null)
                     {
-                        Log.Error(
+                        AasxPackageExplorer.Log.Singleton.Error(
                             "Cannot invoke methods within instance from " +
                                 "class AasxIntegrationBase.AasxPlugin within .dll.");
                         continue;
@@ -201,12 +198,12 @@ namespace AasxPackageExplorer
                     pi.BasicInvokeMethod("InitPlugin", singleArg);
 
                     // adding
-                    Log.Info(".. adding plugin {0}", pi.name);
+                    AasxPackageExplorer.Log.Singleton.Info(".. adding plugin {0}", pi.name);
                     loadedPlugins.Add(pi.name, pi);
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, $"Trying to activate the plugin at index {index}");
+                    AasxPackageExplorer.Log.Singleton.Error(ex, $"Trying to activate the plugin at index {index}");
                 }
             }
 
@@ -284,7 +281,7 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, exceptionWhere);
+                    AasxPackageExplorer.Log.Singleton.Error(ex, exceptionWhere);
                 }
             }
         }
@@ -343,7 +340,7 @@ namespace AasxPackageExplorer
                         {
                             if (duplicateLog != null)
                                 duplicateLog(new StoredPrint(xs));
-                            Log.Info("[{0}] {1}", "" + pluginInstance.name, x);
+                            AasxPackageExplorer.Log.Singleton.Info("[{0}] {1}", "" + pluginInstance.name, x);
                         }
 
                         var xsp = x as StoredPrint;
@@ -352,9 +349,9 @@ namespace AasxPackageExplorer
                             xsp.msg = $"[{"" + pluginInstance.name}] " + xsp.msg;
                             if (duplicateLog != null)
                                 duplicateLog(xsp);
-                            Log.LogInstance.Append(xsp);
+                            AasxPackageExplorer.Log.Singleton.Append(xsp);
                             if (xsp.isError)
-                                Log.LogInstance.NumberErrors++;
+                                AasxPackageExplorer.Log.Singleton.NumberErrors++;
                         }
                     }
                 }

--- a/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SecureConnectFlyout.xaml.cs
@@ -9,25 +9,11 @@ This source code may use other Open Source software components (see LICENSE.txt)
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Data;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using AasxGlobalLogging;
 using AasxIntegrationBase;
-using AdminShellNS;
 using Newtonsoft.Json;
 
 namespace AasxPackageExplorer
@@ -108,7 +94,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "When loading Sercure Conncect Presets from Options");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "When loading Sercure Conncect Presets from Options");
             }
         }
 

--- a/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/SelectQualifierPresetFlyout.xaml.cs
@@ -10,19 +10,9 @@ This source code may use other Open Source software components (see LICENSE.txt)
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using AasxGlobalLogging;
 using AasxIntegrationBase;
 using AdminShellNS;
 using Newtonsoft.Json;
@@ -62,7 +52,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"While loading qualifier preset file ({presetFn})");
+                AasxPackageExplorer.Log.Singleton.Error(ex, $"While loading qualifier preset file ({presetFn})");
             }
         }
 

--- a/src/AasxWpfControlLibrary/ToolControlFindReplace.xaml.cs
+++ b/src/AasxWpfControlLibrary/ToolControlFindReplace.xaml.cs
@@ -8,20 +8,9 @@ This source code may use other Open Source software components (see LICENSE.txt)
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using AasxGlobalLogging;
 using AdminShellNS;
 
 namespace AasxPackageExplorer
@@ -137,7 +126,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "When searching for results");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "When searching for results");
             }
 
             // try to go to 1st result

--- a/src/AasxWpfControlLibrary/VisualAasxElements.cs
+++ b/src/AasxWpfControlLibrary/VisualAasxElements.cs
@@ -11,11 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Media;
-using AasxGlobalLogging;
 using AdminShellNS;
 
 // ReSharper disable VirtualMemberCallInConstructor
@@ -1062,7 +1058,7 @@ namespace AasxPackageExplorer
                         {
                             var sm = env.FindSubmodel(smr);
                             if (sm == null)
-                                Log.Error("Cannot find some submodel!");
+                                AasxPackageExplorer.Log.Singleton.Error("Cannot find some submodel!");
                             else
                                 referencedSubmodels.Add(sm);
 
@@ -1175,7 +1171,7 @@ namespace AasxPackageExplorer
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Generating tree of visual elements");
+                AasxPackageExplorer.Log.Singleton.Error(ex, "Generating tree of visual elements");
             }
 
             // end

--- a/src/AdditionalVerbsInImperativeMood.txt
+++ b/src/AdditionalVerbsInImperativeMood.txt
@@ -19,3 +19,4 @@ dispatch
 export
 skip
 redirect
+deduplicate


### PR DESCRIPTION
Package Explorer uses `Log` singleton class to manage logging meant to
be reported to the user which instantiates a `LogInstance`. Previously,
the `Log` class forwarded all the calls to `LogInstance` which
duplicated a lot of code and made it hard to follow.

This patch deduplicates the calls and directs them directly to the
singleton instance.