### PR TITLE
Display repository in build-test-inspect

### DIFF
--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Display repository name
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          Write-Host "The repository is: ${env:REPOSITORY}"
+
       - name: Install .NET core
         uses: actions/setup-dotnet@v1
         with:


### PR DESCRIPTION
This patch shows the repository to the user so that we can debug fork
problems a bit faster (*e.g.*, we don't have to wait for dependencies to
be installed if there are problems with the repository name).

The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.