### PR TITLE
Send to coveralls only on pushes to master

### DIFF
--- a/.github/workflows/build-test-inspect.yml
+++ b/.github/workflows/build-test-inspect.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Display repository name
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          Write-Host "The repository is: ${env:REPOSITORY}"
+
       - name: Install .NET core
         uses: actions/setup-dotnet@v1
         with:
@@ -80,16 +86,18 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        if: github.repository == 'admin-shell-io/aasx-package-explorer'
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |
-          $headRef = ${env:HEAD_REF}
+          # At the moment we only run coveralls on master.
+          # However, we leave this legacy logic here in case we introduce
+          # new branching policy or new coverage publishing rules.
           if (${env:GITHUB_REF}.StartsWith("refs/pull/"))
           {
-            $branch = $headRef -Replace 'refs/heads/', ''
+            $branch = ${env:HEAD_REF} -Replace 'refs/heads/', ''
           }
           else
           {
-            $branch = ${env:GITHUB_REF} -replace 'refs/heads/', ''
+            $branch = ${env:GITHUB_REF} -Replace 'refs/heads/', ''
           }
 
           $commit = $env:GITHUB_SHA


### PR DESCRIPTION
The workflow build-test-inspect can not run on forked repositories since
the secrets are not shared (*i.e.*, only available in the main
repository and not in the fork) so that sending to coveralls fails
without the token.

This patch skips the send-to-coveralls step in all the workflows except
when we push to master.

The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.