### PR TITLE
Fix internally logged errors on a sample AASX

### DIFF
--- a/src/AasxCsharpLibrary/LogInternally.cs
+++ b/src/AasxCsharpLibrary/LogInternally.cs
@@ -15,11 +15,11 @@ namespace AdminShellNS
     {
         public static string FormatError(Exception ex, string where)
         {
-            return string.Format("Error {0}: {1} {2} at {3}.",
+            return string.Format("Error: {0}: {1} {2} at {3}.",
                 where,
                 ex.Message,
-                ((ex.InnerException != null) ? ex.InnerException.Message : ""),
-                AdminShellUtil.ShortLocation(ex));
+                (ex.InnerException != null) ? ex.InnerException.Message : "",
+                ex.StackTrace);
         }
     }
 
@@ -30,7 +30,7 @@ namespace AdminShellNS
         /// </summary>
         public void Error(Exception ex, string where)
         {
-            System.Console.WriteLine(Logging.FormatError(ex, where));
+            System.Console.Error.WriteLine(Logging.FormatError(ex, where));
         }
 
         /// <summary>
@@ -38,7 +38,10 @@ namespace AdminShellNS
         /// </summary>
         public void SilentlyIgnoredError(Exception ex)
         {
-            Error(ex, "The exception is silently ignored.");
+            System.Console.Error.WriteLine("The exception is silently ignored: {0} {1} at {2}.",
+                ex.Message,
+                ((ex.InnerException != null) ? ex.InnerException.Message : ""),
+                ex.StackTrace);
         }
     }
 

--- a/src/AasxPackageExplorer.GuiTests/Test.cs
+++ b/src/AasxPackageExplorer.GuiTests/Test.cs
@@ -34,7 +34,7 @@ namespace AasxPackageExplorer.GuiTests
                 Retry.WhileNull(() =>
                         // ReSharper disable once AccessToDisposedClosure
                         application.GetAllTopLevelWindows(automation)
-                            .FirstOrDefault((w) => w.Title == "AASX Package Explorer Splash Screen"),
+                            .FirstOrDefault((w) => w.AutomationId == "splashScreen"),
                     throwOnTimeout: true, timeout: TimeSpan.FromSeconds(5),
                     timeoutMessage: "Could not find the splash screen"
                 );

--- a/src/AasxPackageExplorer.GuiTests/TestResources/AasxPackageExplorer.GuiTests/ExpectedTrees/01_Festo.aasx.tree.txt
+++ b/src/AasxPackageExplorer.GuiTests/TestResources/AasxPackageExplorer.GuiTests/ExpectedTrees/01_Festo.aasx.tree.txt
@@ -1,5 +1,6 @@
 *["AAS", " ", "\"Festo_3S7PM0CP4BD\" ", " ", "[IRI, smart.festo.com/demo/aas/1/1/454576463545648365874] of [IRI, HTTP://PK.FESTO.COM/3S7PM0CP4BD, Instance]"]
 **["SM", " ", "\"Nameplate\" ", " ", "[IRI, www.company.com/ids/sm/4343_5072_7091_3242]"]
+***["HSU", " ", "Nameplate Submodel of the HSU", " ", "ready"]
 ***["Prop", " ", "\"ManufacturerName\" ", " ", "= Festo AG & Co. KG"]
 ***["Prop", " ", "\"ManufacturerProductDesignation\" ", " ", "= OVEL Vacuum generator"]
 ***["SMC", " ", "\"PhysicalAddress\" ", " ", "(5 elements)"]

--- a/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
+++ b/src/AasxPackageExplorer/CustomSplashScreenNew.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:AasxPackageExplorer"
         mc:Ignorable="d"
+        x:Name="splashScreen"
         Title="AASX Package Explorer Splash Screen" Width="650" Height="350" Background="White" WindowStyle="None"
         WindowStartupLocation="CenterScreen" Topmost="True" MouseDown="Window_MouseDown">
     <!--

--- a/src/AasxPluginUaNetServer/AasxPluginUaNetServer.csproj
+++ b/src/AasxPluginUaNetServer/AasxPluginUaNetServer.csproj
@@ -4,6 +4,32 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+
+  <!--
+      (mristin, 2020-11-25)
+      We have to skip publishing this plugin in Debug configuration as it breaks the tests
+      and does not load properly.
+
+      The reported error is:
+      Error: Failed to load the license from the plugin: Net46AasxServerPlugin
+      from artefacts\build\Debug\AasxPluginUaNetServer.dll:
+      Ein Aufrufziel hat einen Ausnahmefehler verursacht. Die Datei oder Assembly "Opc.Ua.Configuration,
+      Version=1.4.360.0, Culture=neutral, PublicKeyToken=bfa7a73c5cf4b6e8" oder eine Abhõngigkeit davon wurde
+      nicht gefunden. Die gefundene Manifestdefinition der Assembly stimmt nicht mit dem Assemblyverweis überein.
+      (Ausnahme von HRESULT: 0x80131040) at    bei System.RuntimeMethodHandle.InvokeMethod(Object target,
+      Object[] arguments, Signature sig, Boolean constructor)
+        bei System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
+        bei System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder,
+            Object[] parameters, CultureInfo culture)
+        bei System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
+        bei AasxPackageExplorer.Plugins.PluginInstance.BasicInvokeMethod(String mname, Object[] args)
+        bei AasxPackageExplorer.Plugins.PluginInstance.InvokeAction(String name, Object[] args)
+        bei AasxPackageExplorer.Plugins.CompileAllLicenses()
+  -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />

--- a/src/AasxWpfControlLibrary/Plugins.cs
+++ b/src/AasxWpfControlLibrary/Plugins.cs
@@ -237,7 +237,8 @@ namespace AasxPackageExplorer
                 }
                 catch (Exception ex)
                 {
-                    AdminShellNS.LogInternally.That.SilentlyIgnoredError(ex);
+                    AdminShellNS.LogInternally.That.Error(
+                        ex, $"Failed to load the license from the plugin: {pi.name} from {pi.asm.Location}");
                 }
             }
 


### PR DESCRIPTION
This patch fixes the errors which were previously silently ignored upon
loading a sample AASX.