### PR TITLE
Fix naming & improve code in AdminShellPackageEnv

### DIFF
--- a/src/AasxPackageExplorer.sln.DotSettings
+++ b/src/AasxPackageExplorer.sln.DotSettings
@@ -161,6 +161,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBaseQualifier/@EntryIndexedValue">HINT</s:String>
 
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Aasx/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=aasxes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=aasxs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=doctest/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dsiec/@EntryIndexedValue">True</s:Boolean>

--- a/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
+++ b/src/AasxWpfControlLibrary/DispEditAasxEntity.xaml.cs
@@ -2778,7 +2778,7 @@ namespace AasxPackageExplorer
                                 var sf = (ve.GetMainDataObject()) as AdminShellPackageSupplementaryFile;
                                 if (sf != null)
                                 {
-                                    fl.value = sf.uri.ToString();
+                                    fl.value = sf.Uri.ToString();
                                     return new ModifyRepo.LambdaActionRedrawEntity();
                                 }
                             }

--- a/src/AasxWpfControlLibrary/VisualAasxElements.cs
+++ b/src/AasxWpfControlLibrary/VisualAasxElements.cs
@@ -832,17 +832,17 @@ namespace AasxPackageExplorer
         {
             if (theFile != null)
             {
-                this.Caption = "" + theFile.uri.ToString();
+                this.Caption = "" + theFile.Uri.ToString();
                 this.Info = "";
 
-                if (theFile.location == AdminShellPackageSupplementaryFile.LocationType.AddPending)
+                if (theFile.Location == AdminShellPackageSupplementaryFile.LocationType.AddPending)
                     this.Info += "(add pending) ";
-                if (theFile.location == AdminShellPackageSupplementaryFile.LocationType.DeletePending)
+                if (theFile.Location == AdminShellPackageSupplementaryFile.LocationType.DeletePending)
                     this.Info += "(delete pending) ";
-                if (theFile.sourceLocalPath != null)
-                    this.Info += "\u2b60 " + theFile.sourceLocalPath;
+                if (theFile.SourceLocalPath != null)
+                    this.Info += "\u2b60 " + theFile.SourceLocalPath;
 
-                if (theFile.specialHandling == AdminShellPackageSupplementaryFile.SpecialHandlingType.EmbedAsThumbnail)
+                if (theFile.SpecialHandling == AdminShellPackageSupplementaryFile.SpecialHandlingType.EmbedAsThumbnail)
                     this.Info += " [Thumbnail]";
             }
         }


### PR DESCRIPTION
This patch fixes the naming in `AdminShellPackageEnv` to comply with the
underscore prefix for private members and capitalize the public members.
This makes the code more succinct and easier to track (no need to
explicitly write `this.*`).

Additionally, minor code improvements are undertaken such as case
distinction with `switch` instead of `if` *etc.*