### PR TITLE
Fix reference to building the solution in devdoc

### DIFF
--- a/docdev/docfx_project/getting-started/toc.yml
+++ b/docdev/docfx_project/getting-started/toc.yml
@@ -7,9 +7,6 @@
 - name: Installing the Dependencies
   href: installing-the-dependencies.md
 
-- name: Building the Solution
-  href: building-the-solution.md
-
 - name: Continuous Integration
   href: continuous-integration.md
 


### PR DESCRIPTION
Fixes #332.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.