### PR TITLE
Fix dictionary import on an empty AAS environment

### DIFF
--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -1970,9 +1970,17 @@ namespace AasxPackageExplorer
             try
             {
                 if (ve != null && ve.theEnv != null && ve.theAas != null)
+                {
                     dataChanged = AasxDictionaryImport.Import.ImportSubmodel(ve.theEnv, ve.theAas);
+                }
                 else
+                {
+                    if (packages.Main == null)
+                    {
+                        packages.Main = new AdminShellPackageEnv();
+                    }
                     dataChanged = AasxDictionaryImport.Import.ImportSubmodel(packages.Main.AasEnv);
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Commit 9ce14cb436487dc7aa65cebec76dc3f58c7a19b7 introduced a null
reference error when opening the dictionary import dialog if no AASX
file has been opened, see issue #334.  This patch fixes the issue by
creating a new AAS package environment if the current environment is
null.