### PR TITLE
Unify newline access in PowerShell

### DIFF
--- a/src/DownloadSamples.ps1
+++ b/src/DownloadSamples.ps1
@@ -84,7 +84,7 @@ function Main
                     $proxyMessage = "the script uses the default proxy: $("$proxyAddress"|ConvertTo-Json))"
                 }
 
-                $nl = [System]::Environment.NewLine
+                $nl = [Environment]::NewLine
 
                 throw (
                     "The script failed to download the sample AASX from: $url.$nl$nl" +


### PR DESCRIPTION
The script `DownloadSamples.ps1` caused an error on some powershell
versions since we accessed the newline through
`[System]::Environment.NewLine`, which was not compatible for some
reason.

The workflow build-test-inspect was intentionally skipped.
The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.