### PR TITLE
Add -dict-import-dir option

### DIFF
--- a/src/AasxDictionaryImport.Tests/Cdd/TestModel.cs
+++ b/src/AasxDictionaryImport.Tests/Cdd/TestModel.cs
@@ -120,30 +120,27 @@ namespace AasxDictionaryImport.Cdd.Tests
             public void MissingDirectory()
             {
                 using var tempDir = TempDir.Create();
-                using var wd = WorkingDirectory.ChangeTo(tempDir);
                 var dataProvider = new DataProvider();
 
-                Assert.That(dataProvider.FindDefaultDataSources(), Is.Empty);
+                Assert.That(dataProvider.FindDefaultDataSources(tempDir), Is.Empty);
             }
 
             [Test]
             public void EmptyDirectory()
             {
                 using var tempDir = TempDir.Create();
-                using var wd = WorkingDirectory.ChangeTo(tempDir);
                 var dataProvider = new DataProvider();
 
                 var iecCddPath = Path.Combine(tempDir, "iec-cdd");
                 Directory.CreateDirectory(iecCddPath);
 
-                Assert.That(dataProvider.FindDefaultDataSources(), Is.Empty);
+                Assert.That(dataProvider.FindDefaultDataSources(tempDir), Is.Empty);
             }
 
             [Test]
             public void EmptySource()
             {
                 using var tempDir = TempDir.Create();
-                using var wd = WorkingDirectory.ChangeTo(tempDir);
                 var dataProvider = new DataProvider();
 
                 var iecCddPath = Path.Combine(tempDir, "iec-cdd");
@@ -151,14 +148,13 @@ namespace AasxDictionaryImport.Cdd.Tests
 
                 using var sourcePath = TempDir.Create(iecCddPath);
 
-                Assert.That(dataProvider.FindDefaultDataSources(), Is.Empty);
+                Assert.That(dataProvider.FindDefaultDataSources(tempDir), Is.Empty);
             }
 
             [Test]
             public void IncompleteSource()
             {
                 using var tempDir = TempDir.Create();
-                using var wd = WorkingDirectory.ChangeTo(tempDir);
                 var dataProvider = new DataProvider();
 
                 var iecCddPath = Path.Combine(tempDir, "iec-cdd");
@@ -167,14 +163,13 @@ namespace AasxDictionaryImport.Cdd.Tests
                 using var source = TempDir.Create(iecCddPath);
                 CreateEmptyXls(source, GetExportFileName("class", "12345"));
 
-                Assert.That(dataProvider.FindDefaultDataSources(), Is.Empty);
+                Assert.That(dataProvider.FindDefaultDataSources(tempDir), Is.Empty);
             }
 
             [Test]
             public void ValidSource()
             {
                 using var tempDir = TempDir.Create();
-                using var wd = WorkingDirectory.ChangeTo(tempDir);
                 var dataProvider = new DataProvider();
 
                 var iecCddPath = Path.Combine(tempDir, "iec-cdd");
@@ -184,7 +179,7 @@ namespace AasxDictionaryImport.Cdd.Tests
                 CreateEmptyXls(source, GetExportFileName("class", "12345"));
                 CreateEmptyXls(source, GetExportFileName("property", "12345"));
 
-                Assert.That(dataProvider.FindDefaultDataSources(), Is.EquivalentTo(new[] {
+                Assert.That(dataProvider.FindDefaultDataSources(tempDir), Is.EquivalentTo(new[] {
                     new DataSource(dataProvider, source, Model.DataSourceType.Default),
                 }));
             }
@@ -193,7 +188,6 @@ namespace AasxDictionaryImport.Cdd.Tests
             public void TwoValidSources()
             {
                 using var tempDir = TempDir.Create();
-                using var wd = WorkingDirectory.ChangeTo(tempDir);
                 var dataProvider = new DataProvider();
 
                 var iecCddPath = Path.Combine(tempDir, "iec-cdd");
@@ -207,7 +201,7 @@ namespace AasxDictionaryImport.Cdd.Tests
                 CreateEmptyXls(source2, GetExportFileName("class", "67890"));
                 CreateEmptyXls(source2, GetExportFileName("property", "67890"));
 
-                Assert.That(dataProvider.FindDefaultDataSources(), Is.EquivalentTo(new[] {
+                Assert.That(dataProvider.FindDefaultDataSources(tempDir), Is.EquivalentTo(new[] {
                     new DataSource(dataProvider, source1, Model.DataSourceType.Default),
                     new DataSource(dataProvider, source2, Model.DataSourceType.Default),
                 }));
@@ -217,7 +211,6 @@ namespace AasxDictionaryImport.Cdd.Tests
             public void OneValidOneInvalidSource()
             {
                 using var tempDir = TempDir.Create();
-                using var wd = WorkingDirectory.ChangeTo(tempDir);
                 var dataProvider = new DataProvider();
 
                 var iecCddPath = Path.Combine(tempDir, "iec-cdd");
@@ -232,7 +225,7 @@ namespace AasxDictionaryImport.Cdd.Tests
                 CreateEmptyXls(source2, GetExportFileName("property", "67890"));
                 CreateEmptyXls(source2, GetExportFileName("class", "12345"));
 
-                Assert.That(dataProvider.FindDefaultDataSources(), Is.EquivalentTo(new[] {
+                Assert.That(dataProvider.FindDefaultDataSources(tempDir), Is.EquivalentTo(new[] {
                     new DataSource(dataProvider, source1, Model.DataSourceType.Default),
                 }));
             }

--- a/src/AasxDictionaryImport.Tests/Utils.cs
+++ b/src/AasxDictionaryImport.Tests/Utils.cs
@@ -69,26 +69,4 @@ namespace AasxDictionaryImport.Tests
 
         public static implicit operator string(TempDir tempDir) => tempDir.Path;
     }
-
-    internal sealed class WorkingDirectory : IDisposable
-    {
-        public string Path;
-
-        private WorkingDirectory(string path)
-        {
-            Path = path;
-        }
-
-        public void Dispose()
-        {
-            Directory.SetCurrentDirectory(Path);
-        }
-
-        public static WorkingDirectory ChangeTo(string path)
-        {
-            var oldPath = Directory.GetCurrentDirectory();
-            Directory.SetCurrentDirectory(path);
-            return new WorkingDirectory(oldPath);
-        }
-    }
 }

--- a/src/AasxDictionaryImport/Cdd/Model.cs
+++ b/src/AasxDictionaryImport/Cdd/Model.cs
@@ -28,9 +28,9 @@ namespace AasxDictionaryImport.Cdd
         public override bool IsValidPath(string path) => Parser.IsValidDirectory(path);
 
         /// <inheritdoc/>
-        protected override IEnumerable<string> GetDefaultPaths()
+        protected override IEnumerable<string> GetDefaultPaths(string dir)
         {
-            var searchDirectory = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "iec-cdd");
+            var searchDirectory = System.IO.Path.Combine(dir, "iec-cdd");
             if (!System.IO.Directory.Exists(searchDirectory))
                 return new List<string>();
             return System.IO.Directory.GetDirectories(searchDirectory);

--- a/src/AasxDictionaryImport/Import.cs
+++ b/src/AasxDictionaryImport/Import.cs
@@ -60,14 +60,16 @@ namespace AasxDictionaryImport
         /// null, a new empty admin shell is created in the given environment.
         /// </summary>
         /// <param name="env">The AAS environment to import into</param>
+        /// <param name="defaultSourceDir">The search path for the default data sources, e. g. the current working
+        /// directory</param>
         /// <param name="adminShell">The admin shell to import into, or null if a new admin shell should be
         /// created</param>
         /// <returns>true if at least one submodel was imported</returns>
         public static bool ImportSubmodel(AdminShellV20.AdministrationShellEnv env,
-            AdminShellV20.AdministrationShell? adminShell = null)
+            string defaultSourceDir, AdminShellV20.AdministrationShell? adminShell = null)
         {
             adminShell ??= CreateAdminShell(env);
-            return PerformImport(ImportMode.Submodels, e => e.ImportSubmodelInto(env, adminShell));
+            return PerformImport(ImportMode.Submodels, defaultSourceDir, e => e.ImportSubmodelInto(env, adminShell));
         }
 
         /// <summary>
@@ -76,17 +78,20 @@ namespace AasxDictionaryImport
         /// element (usually a submodel).
         /// </summary>
         /// <param name="env">The AAS environment to import into</param>
+        /// <param name="defaultSourceDir">The search path for the default data sources, e. g. the current working
+        /// directory</param>
         /// <param name="parent">The parent element to import into</param>
         /// <returns>true if at least one submodel element was imported</returns>
         public static bool ImportSubmodelElements(AdminShell.AdministrationShellEnv env,
-            AdminShell.IManageSubmodelElements parent)
+            string defaultSourceDir, AdminShell.IManageSubmodelElements parent)
         {
-            return PerformImport(ImportMode.SubmodelElements, e => e.ImportSubmodelElementsInto(env, parent));
+            return PerformImport(ImportMode.SubmodelElements, defaultSourceDir,
+                e => e.ImportSubmodelElementsInto(env, parent));
         }
 
-        private static bool PerformImport(ImportMode importMode, Func<Model.IElement, bool> f)
+        private static bool PerformImport(ImportMode importMode, string defaultSourceDir, Func<Model.IElement, bool> f)
         {
-            var dialog = new ImportDialog(importMode);
+            var dialog = new ImportDialog(importMode, defaultSourceDir);
             if (dialog.ShowDialog() != true || dialog.Context == null)
                 return false;
 

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -64,7 +64,7 @@ namespace AasxDictionaryImport
             }
         }
 
-        public ImportDialog(ImportMode importMode)
+        public ImportDialog(ImportMode importMode, string defaultSourceDir)
         {
             DataContext = this;
 
@@ -75,7 +75,7 @@ namespace AasxDictionaryImport
             InitializeComponent();
 
             foreach (var provider in DataProviders)
-                foreach (var source in provider.FindDefaultDataSources())
+                foreach (var source in provider.FindDefaultDataSources(defaultSourceDir))
                     ComboBoxSource.Items.Add(source);
 
             DataSourceLabel.Content = String.Join(", ", DataProviders.Select(p => p.Name));

--- a/src/AasxDictionaryImport/Model.cs
+++ b/src/AasxDictionaryImport/Model.cs
@@ -45,8 +45,9 @@ namespace AasxDictionaryImport.Model
         /// Returns a list of all default data sources for this provider, i. e. all data sources that have been shipped
         /// with the AASX Package Explorer or that are freely available on the internet.
         /// </summary>
+        /// <param name="dir">The search path for the default data sources, e. g. the current working directory</param>
         /// <returns>A list of all default data sources</returns>
-        IEnumerable<IDataSource> FindDefaultDataSources();
+        IEnumerable<IDataSource> FindDefaultDataSources(string dir);
 
         /// <summary>
         /// Checks whether the given path contains valid data that can be read by this data provider.  This method
@@ -321,9 +322,9 @@ namespace AasxDictionaryImport.Model
         public abstract string Name { get; }
 
         /// <inheritdoc/>
-        public virtual IEnumerable<IDataSource> FindDefaultDataSources()
+        public virtual IEnumerable<IDataSource> FindDefaultDataSources(string dir)
         {
-            return GetDefaultPaths()
+            return GetDefaultPaths(dir)
                 .Where(IsValidPath)
                 .Select(p => OpenPath(p, Model.DataSourceType.Default))
                 .ToList();
@@ -342,8 +343,9 @@ namespace AasxDictionaryImport.Model
         /// <summary>
         /// Returns all paths that could contain a default data source.
         /// </summary>
+        /// <param name="dir">The search path for the default data sources, e. g. the current working directory</param>
         /// <returns>A list of all possible default data sources</returns>
-        protected abstract IEnumerable<string> GetDefaultPaths();
+        protected abstract IEnumerable<string> GetDefaultPaths(string dir);
 
         /// <summary>
         /// Creates a new data source that reads the data stored at the given path and sets the data source type to the

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -1834,13 +1834,15 @@ namespace AasxPackageExplorer
             }
 
 #if !DoNotUseAasxDictionaryImport
+            string defaultSourceDir = Options.Curr.DictImportDir ?? System.IO.Directory.GetCurrentDirectory();
             var dataChanged = false;
             try
             {
                 if (ve != null && ve.theEnv != null && ve.theAas != null)
-                    dataChanged = AasxDictionaryImport.Import.ImportSubmodel(ve.theEnv, ve.theAas);
+                    dataChanged = AasxDictionaryImport.Import.ImportSubmodel(ve.theEnv, defaultSourceDir, ve.theAas);
                 else
-                    dataChanged = AasxDictionaryImport.Import.ImportSubmodel(_packageCentral.Main.AasEnv);
+                    dataChanged = AasxDictionaryImport.Import.ImportSubmodel(_packageCentral.Main.AasEnv,
+                        defaultSourceDir);
             }
             catch (Exception e)
             {
@@ -1878,10 +1880,11 @@ namespace AasxPackageExplorer
             }
 
 #if !DoNotUseAasxDictionaryImport
+            string defaultSourceDir = Options.Curr.DictImportDir ?? System.IO.Directory.GetCurrentDirectory();
             var dataChanged = false;
             try
             {
-                dataChanged = AasxDictionaryImport.Import.ImportSubmodelElements(env, submodel);
+                dataChanged = AasxDictionaryImport.Import.ImportSubmodelElements(env, defaultSourceDir, submodel);
             }
             catch (Exception e)
             {

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -1834,15 +1834,15 @@ namespace AasxPackageExplorer
             }
 
 #if !DoNotUseAasxDictionaryImport
-            string defaultSourceDir = Options.Curr.DictImportDir ?? System.IO.Directory.GetCurrentDirectory();
             var dataChanged = false;
             try
             {
                 if (ve != null && ve.theEnv != null && ve.theAas != null)
-                    dataChanged = AasxDictionaryImport.Import.ImportSubmodel(ve.theEnv, defaultSourceDir, ve.theAas);
+                    dataChanged = AasxDictionaryImport.Import.ImportSubmodel(ve.theEnv, Options.Curr.DictImportDir,
+                        ve.theAas);
                 else
                     dataChanged = AasxDictionaryImport.Import.ImportSubmodel(_packageCentral.Main.AasEnv,
-                        defaultSourceDir);
+                        Options.Curr.DictImportDir);
             }
             catch (Exception e)
             {
@@ -1880,11 +1880,11 @@ namespace AasxPackageExplorer
             }
 
 #if !DoNotUseAasxDictionaryImport
-            string defaultSourceDir = Options.Curr.DictImportDir ?? System.IO.Directory.GetCurrentDirectory();
             var dataChanged = false;
             try
             {
-                dataChanged = AasxDictionaryImport.Import.ImportSubmodelElements(env, defaultSourceDir, submodel);
+                dataChanged = AasxDictionaryImport.Import.ImportSubmodelElements(env, Options.Curr.DictImportDir,
+                    submodel);
             }
             catch (Exception e)
             {

--- a/src/AasxWpfControlLibrary/Options.cs
+++ b/src/AasxWpfControlLibrary/Options.cs
@@ -137,6 +137,12 @@ namespace AasxPackageExplorer
         public string EclassDir = null;
 
         /// <summary>
+        /// Path to the directory with the default sources for the Dictionary Import feature (see
+        /// AasxDictionaryImport).  If this option is not set, the current working directory should be used.
+        /// </summary>
+        public string DictImportDir = null;
+
+        /// <summary>
         /// Path to an image to be displayed as logo
         /// </summary>
         public string LogoFile = null;
@@ -463,6 +469,12 @@ namespace AasxPackageExplorer
                 if (arg == "-eclass" && morearg > 0)
                 {
                     optionsInformation.EclassDir = args[index + 1];
+                    index++;
+                    continue;
+                }
+                if (arg == "-dict-import-dir" && morearg > 0)
+                {
+                    optionsInformation.DictImportDir = args[index + 1];
                     index++;
                     continue;
                 }

--- a/src/AasxWpfControlLibrary/Options.cs
+++ b/src/AasxWpfControlLibrary/Options.cs
@@ -138,9 +138,9 @@ namespace AasxPackageExplorer
 
         /// <summary>
         /// Path to the directory with the default sources for the Dictionary Import feature (see
-        /// AasxDictionaryImport).  If this option is not set, the current working directory should be used.
+        /// AasxDictionaryImport).  If this option is not set, the current working directory is used.
         /// </summary>
-        public string DictImportDir = null;
+        public string DictImportDir = System.IO.Directory.GetCurrentDirectory();
 
         /// <summary>
         /// Path to an image to be displayed as logo


### PR DESCRIPTION
This patch adds the -dict-import-dir option that can be used to set the
default search path for the Dictionary Import feature.  If the option is
not set, the current working directory is used instead.

As we no longer have to change the working directory in the
AasxDictionaryImport.Tests, we can also remove the WorkingDirectory
class.