### PR TITLE
Enhance buildForDebug to build a single project

### DIFF
--- a/docdev/docfx_project/getting-started/continuous-integration.md
+++ b/docdev/docfx_project/getting-started/continuous-integration.md
@@ -14,6 +14,14 @@ To build the solution for debugging and testing, invoke:
 .\src\BuildForDebug.ps1
 ```
 
+You can also build a single project. 
+This is practical when you want to manually test something and do not want to
+waste time on MSBuild inspecting which projects need to be rebuilt:
+
+```powershell
+.\src\BuildForDebug.ps1 -Project AasxToolkit
+```
+
 To clean the build, call:
 ```powershell
 .\src\BuildForDebug.ps1 -clean

--- a/src/BuildForDebug.ps1
+++ b/src/BuildForDebug.ps1
@@ -1,7 +1,10 @@
 ﻿param(
     [Parameter(HelpMessage = "If set, cleans up the previous build instead of performing a new one")]
     [switch]
-    $clean = $false
+    $clean = $false,
+    [Parameter(HelpMessage = "If set, builds and publishes only the given project")]
+    [string]
+    $project = $null
 )
 
 <#
@@ -35,16 +38,24 @@ function Main
 
         New-Item -ItemType Directory -Force -Path $outputPath|Out-Null
 
-        & dotnet.exe publish `
-            --configuration $configuration `
-            --runtime win-x64 `
-            --output $outputPath
+        $dotnetArgs = @(
+            "publish",
+            "--configuration", $configuration,
+            "--runtime", "win-x64",
+            "--output", $outputPath
+        )
+
+        if($null -ne $project)
+        {
+            $dotnetArgs += $project
+        }
+
+        & dotnet $dotnetArgs
 
         $exitCode = $LASTEXITCODE
-        Write-Host "dotnet publish exit code: $exitCode"
         if ($exitCode -ne 0)
         {
-            throw "dotnet publish failed."
+            throw "dotnet publish failed with the exit code: $exitCode"
         }
     }
     else
@@ -56,10 +67,9 @@ function Main
             --runtime win-x64
 
         $exitCode = $LASTEXITCODE
-        Write-Host "dotnet clean exit code: $exitCode"
         if ($exitCode -ne 0)
         {
-            throw "dotnet clean failed."
+            throw "dotnet clean failed with the exit code: $exitCode"
         }
 
         if (Test-Path $outputPath)


### PR DESCRIPTION
This patch introduces the parameter `-Project` which allows the
developer to build only a single project.

This is practical when you debug the functional tests. This way the
rebuild does not have to sourt out which projects need to be rebuilt,
and that saves you time.

The workflow check-style was intentionally skipped.
The workflow check-release was intentionally skipped.