### PR TITLE
Upgrade to bite-sized 1.0.1

### DIFF
--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "bitesized": {
-      "version": "1.0.0-beta3",
+      "version": "1.0.1",
       "commands": [
         "bite-sized"
       ]

--- a/src/CheckBiteSized.ps1
+++ b/src/CheckBiteSized.ps1
@@ -8,7 +8,7 @@ Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
     AssertDotnetToolVersion
 
 function Main {
-    AssertDotnetToolVersion -PackageID "BiteSized" -ExpectedVersion "1.0.0-beta3"
+    AssertDotnetToolVersion -PackageID "BiteSized" -ExpectedVersion "1.0.1"
 
     Set-Location $PSScriptRoot
 


### PR DESCRIPTION
Bite-sized 1.0.1 introduces `--verbose` flag and hides output otherwise
if all files are OK. This helps reduce the noise for the developer when
there is actually an error.

Fixes #346.