### PR TITLE
Improve dictionary import without an AASX file

### DIFF
--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -1818,15 +1818,25 @@ namespace AasxPackageExplorer
 
         public void CommandBinding_ImportSubmodel()
         {
-            VisualElementAdminShell ve = null;
+            AdminShell.AdministrationShellEnv env = _packageCentral.Main.AasEnv;
+            AdminShell.AdministrationShell aas = null;
             if (DisplayElements.SelectedItem != null)
             {
-                if (DisplayElements.SelectedItem is VisualElementAdminShell)
+                if (DisplayElements.SelectedItem is VisualElementAdminShell aasItem)
                 {
-                    ve = DisplayElements.SelectedItem as VisualElementAdminShell;
+                    // AAS is selected --> import into AAS
+                    env = aasItem.theEnv;
+                    aas = aasItem.theAas;
+                }
+                else if (DisplayElements.SelectedItem is VisualElementEnvironmentItem envItem &&
+                        envItem.theItemType == VisualElementEnvironmentItem.ItemType.EmptySet)
+                {
+                    // Empty environment is selected --> create new AAS
+                    env = envItem.theEnv;
                 }
                 else
                 {
+                    // Other element is selected --> error
                     MessageBoxFlyoutShow("Please select the administration shell for the submodel import.",
                         "Submodel Import", MessageBoxButton.OK, MessageBoxImage.Error);
                     return;
@@ -1837,12 +1847,7 @@ namespace AasxPackageExplorer
             var dataChanged = false;
             try
             {
-                if (ve != null && ve.theEnv != null && ve.theAas != null)
-                    dataChanged = AasxDictionaryImport.Import.ImportSubmodel(ve.theEnv, Options.Curr.DictImportDir,
-                        ve.theAas);
-                else
-                    dataChanged = AasxDictionaryImport.Import.ImportSubmodel(_packageCentral.Main.AasEnv,
-                        Options.Curr.DictImportDir);
+                dataChanged = AasxDictionaryImport.Import.ImportSubmodel(env, Options.Curr.DictImportDir, aas);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
In older Package Explorer versions, the main window would start with an
empty AAS tree.  In this case, the Dictionary Import function would
create a new AAS when performing the import.  In newer Package Explorer
versions, the tree always contains a "No information available"
pseudo-element.

With this patch, the Dictionary Import function creates a new AAS if is
selected while the "No information" element is selected.