### PR TITLE
Add support for ECLASS imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ artefacts/
 
 # Sample AASXs
 sample-aasx/
-
-# ecl@ss with restricted license
-eclass/

--- a/src/AasxDictionaryImport/Cdd/Model.cs
+++ b/src/AasxDictionaryImport/Cdd/Model.cs
@@ -10,6 +10,7 @@ This source code may use other Open Source software components (see LICENSE.txt)
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using AdminShellNS;
 
@@ -25,20 +26,27 @@ namespace AasxDictionaryImport.Cdd
         public override string Name => "IEC CDD";
 
         /// <inheritdoc/>
-        public override bool IsValidPath(string path) => Parser.IsValidDirectory(path);
+        public override bool IsValidPath(string path)
+        {
+            string dir = File.Exists(path) ? Path.GetDirectoryName(path) : path;
+            return Parser.IsValidDirectory(dir);
+        }
 
         /// <inheritdoc/>
         protected override IEnumerable<string> GetDefaultPaths(string dir)
         {
-            var searchDirectory = System.IO.Path.Combine(dir, "iec-cdd");
-            if (!System.IO.Directory.Exists(searchDirectory))
+            var searchDirectory = Path.Combine(dir, "iec-cdd");
+            if (!Directory.Exists(searchDirectory))
                 return new List<string>();
-            return System.IO.Directory.GetDirectories(searchDirectory);
+            return Directory.GetDirectories(searchDirectory);
         }
 
         /// <inheritdoc/>
         protected override Model.IDataSource OpenPath(string path, Model.DataSourceType type)
-            => new DataSource(this, path, type);
+        {
+            string dir = File.Exists(path) ? Path.GetDirectoryName(path) : path;
+            return new DataSource(this, dir, type);
+        }
     }
 
     /// <summary>
@@ -65,7 +73,7 @@ namespace AasxDictionaryImport.Cdd
         public DataSource(Model.IDataProvider dataProvider, string directory, Model.DataSourceType type)
             : base(dataProvider, directory, type)
         {
-            if (!System.IO.Directory.Exists(directory))
+            if (!Directory.Exists(directory))
                 throw new Model.ImportException($"Directory '{directory}' does not exist");
         }
 

--- a/src/AasxDictionaryImport/Eclass/Model.cs
+++ b/src/AasxDictionaryImport/Eclass/Model.cs
@@ -236,7 +236,10 @@ namespace AasxDictionaryImport.Eclass
             AssignApplicationClasses();
             AssignAspects(document.Descendants(Namespaces.OntoML + "a_posteriori_semantic_relationship"));
 
-            var properties = document.Descendants(Namespaces.OntoML + "property").Select(e => new Property(this, e)).ToList();
+            var properties = document
+                .Descendants(Namespaces.OntoML + "property")
+                .Select(e => new Property(this, e))
+                .ToList();
             AddElements(properties);
             if (units != null)
                 AssignUnits(properties, units);
@@ -290,7 +293,7 @@ namespace AasxDictionaryImport.Eclass
                 if (data.TryGetValue("IRDI", out string irdi) && data.TryGetValue("SI code", out string siCode))
                 {
                     if (!units.ContainsKey(irdi))
-                        // TODO: HTML-decode SI code
+                        // TODO (krahlro-sick, 2021-02-03): HTML-decode SI code
                         units.Add(irdi, siCode);
                 }
             }
@@ -336,7 +339,6 @@ namespace AasxDictionaryImport.Eclass
                 }
                 else
                 {
-                    // TODO: possible duplicates
                     if (!_elements.ContainsKey(element.Id))
                         _elements.Add(element.Id, element);
                 }
@@ -489,8 +491,6 @@ namespace AasxDictionaryImport.Eclass
                 { "Hierarchical Position", HierarchicalPosition },
             };
         }
-
-        // TODO: check -- do we have a public URI?
     }
 
     /// <summary>
@@ -701,7 +701,6 @@ namespace AasxDictionaryImport.Eclass
 
         protected override Iec61360Data GetIec61360Data()
         {
-            // TODO: unit
             var data = base.GetIec61360Data();
             data.DataType = GetDataType(Type);
             data.ShortName = ShortName;
@@ -719,8 +718,8 @@ namespace AasxDictionaryImport.Eclass
 
         private static string GetDataType(string type)
         {
-            // TODO: This logic is copied from EclassUtils.GenerateConceptDescription -- does it handle all possible
-            // values?
+            // TODO (krahlro-sick, 2021-02-23): This logic is copied from EclassUtils.GenerateConceptDescription -- does
+            // it handle all possible values?
             var lowerType = type.ToLower();
             foreach (var aasType in AdminShell.DataSpecificationIEC61360.DataTypeNames)
             {
@@ -740,7 +739,7 @@ namespace AasxDictionaryImport.Eclass
                 case "REAL_MEASURE":
                 case "REAL_COUNT":
                 case "REAL_CURRENCY":
-                    return "double"; // TODO: float?
+                    return "double";
                 case "INTEGER_MEASURE":
                 case "INTEGER_COUNT":
                 case "INTEGER_CURRENCY":

--- a/src/AasxDictionaryImport/Eclass/Model.cs
+++ b/src/AasxDictionaryImport/Eclass/Model.cs
@@ -526,6 +526,23 @@ namespace AasxDictionaryImport.Eclass
         /// </summary>
         public ICollection<Class> Aspects { get; } = new List<Class>();
 
+        /// <inheritdoc/>
+        public override string DisplayName
+        {
+            get
+            {
+                var name = PreferredName.GetDefault();
+                if (Id.Contains("BASIC"))
+                {
+                    return $"{name} (ECLASS Basic)";
+                }
+                else
+                {
+                    return name;
+                }
+            }
+        }
+
         /// <summary>
         /// Creates a new Class object within the given context, backed by the given XML element.
         /// </summary>

--- a/src/AasxDictionaryImport/Eclass/Model.cs
+++ b/src/AasxDictionaryImport/Eclass/Model.cs
@@ -25,6 +25,17 @@ namespace AasxDictionaryImport.Eclass
     /// <see cref="Context"/> for more information.  The complete eCl@ss exports use one file per language and domain.
     /// In this implementation, a data source is always backed by an English export file.  If present, export files in
     /// other languages and unit files are loaded additionally.
+    /// <para>
+    /// This data provider assumes that the eCl@ss XML files follow this naming convention:
+    /// <list type="bullet">
+    /// <item><description><code>&lt;Prefix&gt;_&lt;Version&gt;_&lt;Lang&gt;_*.xml</code> for class
+    /// exports, and</description></item>
+    /// <item><description><code>&lt;Prefix&gt;_UnitsML_*.xml</code> for unit data,</description></item>
+    /// </list>
+    /// where <code>&lt;Prefix&gt;</code> is a constant prefix per eCl@ss release, <code>&lt;Version&gt;</code> is
+    /// either <code>BASIC</code> or <code>ADVANCED</code> and <code>&lt;Lang&gt;</code> is an uppercase two-character
+    /// language code (e. g. <code>EN</code> for the English export).
+    /// </para>
     /// </summary>
     /// <seealso href="https://wiki.eclass.eu/wiki/ISO_13584-32_ontoML"/>
     public class DataProvider : Model.DataProviderBase

--- a/src/AasxDictionaryImport/Eclass/Model.cs
+++ b/src/AasxDictionaryImport/Eclass/Model.cs
@@ -1,0 +1,468 @@
+﻿/*
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using AasxPackageExplorer;
+using AdminShellNS;
+
+namespace AasxDictionaryImport.Eclass
+{
+    /// <summary>
+    /// Data provider for eCl@ss Basic data.  The data is read from XML files using the OntoML scheme, see
+    /// <see cref="Context"/> for more information.  The complete eCl@ss exports use one file per language and domain.
+    /// Currently, we only parse one file at a time, i. e. we can only read data for one language at a time.  Also,
+    /// units are stored in a separate file and are currently not parsed.
+    /// </summary>
+    /// <seealso href="https://wiki.eclass.eu/wiki/ISO_13584-32_ontoML"/>
+    public class DataProvider : Model.DataProviderBase
+    {
+        /// <inheritdoc/>
+        public override string Name => "ECLASS";
+
+        /// <inheritdoc/>
+        public override bool IsValidPath(string path)
+            => EclassUtils.TryGetDataFileType(path) == EclassUtils.DataFileType.Dictionary;
+
+        /// <inheritdoc/>
+        protected override IEnumerable<string> GetDefaultPaths(string dir)
+        {
+            var searchDirectory = System.IO.Path.Combine(dir, "eclass");
+            if (!System.IO.Directory.Exists(searchDirectory))
+                return new List<string>();
+            return System.IO.Directory.GetFiles(searchDirectory);
+        }
+
+        /// <inheritdoc/>
+        protected override Model.IDataSource OpenPath(string path, Model.DataSourceType type)
+            => new DataSource(this, path, type);
+    }
+
+    /// <summary>
+    /// Data source for eCl@ss data.  The eCl@ss data is read from XML files, and a data source represents one eCl@ss
+    /// XML file.  For more information on the XML parser, see the <see cref="Context"/> and <see cref="Element"/>
+    /// classes.
+    /// </summary>
+    public class DataSource : Model.FileSystemDataSource
+    {
+        /// <summary>
+        /// Creates a new DataSource object with the given data.
+        /// </summary>
+        /// <param name="dataProvider">The data provider for this data source</param>
+        /// <param name="path">The path of the eCl@ss XML file</param>
+        /// <param name="type">The type of the data source</param>
+        public DataSource(Model.IDataProvider dataProvider, string path, Model.DataSourceType type)
+           : base(dataProvider, path, type)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override Model.IDataContext Load()
+        {
+            try
+            {
+                var xml = XDocument.Load(Path);
+                return new Context(this, xml);
+            }
+            catch (XmlException e)
+            {
+                throw new Model.ImportException($"Could not load the XML document at '{Path}'", e);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Data context for eCl@ss data.  The context loads the classes and properties from an XML document.  It
+    /// removes all deprecated elements because they are no longer part of the eCl@ss release.  It also computes a
+    /// mapping from classification classes to application classes.  For more information on the class types, see
+    /// <see cref="Class"/>.
+    /// </summary>
+    public class Context : Model.IDataContext
+    {
+        private static XNamespace OntoML { get; } = "urn:iso:std:iso:is:13584:-32:ed-1:tech:xml-schema:ontoml";
+
+        private readonly IDictionary<string, Element> _elements = new Dictionary<string, Element>();
+
+        private readonly ICollection<string> _deprecatedElements = new List<string>();
+
+        /// <summary>
+        /// The data source this data has been read from.
+        /// </summary>
+        public DataSource DataSource { get; }
+
+        /// <summary>
+        /// The top-level classes in this data context.
+        /// </summary>
+        public ICollection<Class> Classes { get; }
+
+        /// <inheritdoc/>
+        public ICollection<Model.UnknownReference> UnknownReferences { get; } = new List<Model.UnknownReference>();
+
+        /// <summary>
+        /// Creates a new eCl@ss Context and loads the data from the given XML document.
+        /// </summary>
+        /// <param name="dataSource">The data source for this context</param>
+        /// <param name="document">The XML document to read the data from</param>
+        public Context(DataSource dataSource, XDocument document)
+        {
+            DataSource = dataSource;
+
+            var classes = document.Descendants(OntoML + "class").Select(e => new Class(this, e)).ToList();
+            AddElements(classes);
+            Classes = classes.Where(c => !c.IsDeprecated).ToList();
+            AssignApplicationClasses();
+
+            AddElements(document.Descendants(OntoML + "property").Select(e => new Property(this, e)));
+        }
+
+        private void AssignApplicationClasses()
+        {
+            foreach (var cls in Classes)
+            {
+                foreach (var cclsId in cls.ClassificationClassIds)
+                {
+                    var ccls = GetElement<Class>(cclsId);
+                    if (ccls != null)
+                        ccls.ApplicationClasses.Add(cls);
+                }
+            }
+        }
+
+        private void AddElements<T>(IEnumerable<T> elements) where T : Element
+        {
+            foreach (var element in elements)
+            {
+                if (element.IsDeprecated)
+                {
+                    _deprecatedElements.Add(element.Id);
+                }
+                else
+                {
+                    // TODO: possible duplicates
+                    if (!_elements.ContainsKey(element.Id))
+                        _elements.Add(element.Id, element);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public ICollection<Model.IElement> LoadSubmodels() => Classes.Cast<Model.IElement>().ToList();
+
+        /// <inheritdoc/>
+        public ICollection<Model.IElement> LoadSubmodelElements() => _elements.Values.Cast<Model.IElement>().ToList();
+
+        public Property? GetProperty(Class parent, string id)
+        {
+            var property = GetElement<Property>(id);
+            if (property != null)
+                return new Property(property, parent);
+            return null;
+        }
+
+        private T? GetElement<T>(string id) where T : Element
+        {
+            if (_elements.TryGetValue(id, out Element e))
+                if (e is T t)
+                    return t;
+
+            // We don't have to record deprecated elements as unknown references because we don't add them to _elements
+            // in the first place
+            if (!_deprecatedElements.Contains(id))
+                UnknownReferences.Add(Model.UnknownReference.Create<Property>(id));
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// An element in the eCl@ss data set, backed by an XML element from the exported XML document.  Currently, we
+    /// support <see cref="Class"/> and <see cref="Property"/> elements.
+    /// </summary>
+    public abstract class Element : Model.LazyElementBase
+    {
+        protected XElement XElement;
+
+        /// <summary>
+        /// The current data context.
+        /// </summary>
+        public Context Context { get; }
+
+        /// <inheritdoc/>
+        public override string Id => XElement.Attributes("id").FirstValue();
+
+        /// <inheritdoc/>
+        public override string Name => PreferredName.GetDefault();
+
+        public string Revision => XElement.Elements("revision").FirstValue();
+
+        public MultiString PreferredName => GetMultiString("preferred_name", "label");
+
+        public MultiString Definition => GetMultiString("definition", "text");
+
+        public string HierarchicalPosition => XElement.Elements("hierarchical_position").FirstValue();
+
+        /// <summary>
+        /// Whether this element is deprecated.  If this property is true, this element
+        /// should be ignored as it is no longer part of the official eCl@ss release.
+        /// </summary>
+        public bool IsDeprecated => XElement.Elements("is_deprecated").FirstValue() == "true";
+
+        protected Element(Context context, XElement element, Model.IElement? parent = null)
+            : base(context.DataSource, parent)
+        {
+            XElement = element;
+            Context = context;
+        }
+
+        protected virtual Iec61360Data GetIec61360Data()
+        {
+            return new Iec61360Data(Id)
+            {
+                Definition = Definition,
+                PreferredName = PreferredName,
+            };
+        }
+
+        protected MultiString GetMultiString(string name, string childElement)
+        {
+            var ms = new MultiString();
+            foreach (var label in XElement.Elements(name).Elements(childElement))
+            {
+                var lang = label.Attribute("language_code");
+                if (lang != null && lang.Value.Length > 0)
+                    ms.Add(lang.Value, label.Value);
+            }
+            return ms;
+        }
+
+        /// <inheritdoc/>
+        protected override bool Match(string query)
+        {
+            // The eCl@ss hierarchical position is typically displayed as groups of two digits, separated by a hyphen,
+            // but is stored without hyphens in the XML file.  Therefore we remove the hyphens from the query string.
+            // To keep the hierarchical character of the field, we only search at the beginning of the string.
+            return base.Match(query) || HierarchicalPosition.StartsWith(query.Replace("-", ""));
+        }
+
+        /// <inheritdoc/>
+        public override Dictionary<string, string> GetDetails()
+        {
+            return new Dictionary<string, string>
+            {
+                { "ID", Id },
+                { "Revision", Revision },
+                { "Preferred Name", PreferredName.GetDefault() },
+                { "Definition", Definition.GetDefault() },
+                { "Hierarchical Position", HierarchicalPosition },
+            };
+        }
+
+        // TODO: check -- do we have a public URI?
+    }
+
+    /// <summary>
+    /// An eCl@ss class.  eCl@ss has two types of classes:  application classes and classification classes.
+    /// Classification classes are part of the classification hierarchy while an application class defines the
+    /// properties for a classification class.  Unfortunately, the classification classes do not store references to
+    /// their application classes.  Therefore we manually compute this mapping in <see cref="Context"/> when loading
+    /// the data from the XML file.
+    /// <para>
+    /// In eCl@ss Basic, there is a 1:1 relation between classification and application classes.  In eCl@ss Advanced,
+    /// there may be several application classes per classification class (typically one for the basic attributes and
+    /// one for the advanced attributes).  As this implementation only supports eCl@ss Basic, we assume that there is
+    /// at most one application class per classification class and just transfer the application class's properties to
+    /// the classification class.
+    /// </para>
+    /// </summary>
+    public class Class : Element
+    {
+        /// <summary>
+        /// The IDs of the classification classes that this application class describes, or an empty list if this is a
+        /// classification class.
+        /// </summary>
+        public ICollection<string> ClassificationClassIds
+            => XElement.Elements("is_case_of").Elements("class").Attributes("class_ref").Values().ToList();
+
+        /// <summary>
+        /// The application classes for this classification class, or an empty list if this is an application class.
+        /// </summary>
+        public ICollection<Class> ApplicationClasses { get; } = new List<Class>();
+
+        /// <summary>
+        /// Creates a new Class object within the given context, backed by the given XML element.
+        /// </summary>
+        /// <param name="context">The context for this element</param>
+        /// <param name="element">The XML element with the data for this element</param>
+        public Class(Context context, XElement element) : base(context, element)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool ImportSubmodelInto(AdminShellV20.AdministrationShellEnv env,
+            AdminShellV20.AdministrationShell adminShell)
+        {
+            if (!IsSelected)
+                return false;
+
+            var submodel = Iec61360Utils.CreateSubmodel(env, adminShell, GetIec61360Data());
+            ImportSubmodelElementsInto(env, submodel);
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override bool ImportSubmodelElementsInto(AdminShellV20.AdministrationShellEnv env,
+            AdminShellV20.IManageSubmodelElements parent)
+        {
+            return Children.Count(c => c.ImportSubmodelElementsInto(env, parent)) > 0;
+        }
+
+        /// <inheritdoc/>
+        protected override ICollection<Model.IElement> LoadChildren()
+        {
+            if (ApplicationClasses.Count > 0)
+                // We assume that there is at most one application class per classification class, so we just transfer
+                // the children
+                return ApplicationClasses.First().LoadChildren(this);
+            return LoadChildren(this);
+        }
+
+        private ICollection<Model.IElement> LoadChildren(Class parent)
+        {
+            return XElement
+                .Elements("described_by")
+                .Elements("property")
+                .Attributes("property_ref")
+                .Select(a => Context.GetProperty(parent, a.Value))
+                .Where(p => p != null)
+                .Cast<Model.IElement>()
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// An eCl@ss property.  eCl@ss properties are assigned to application classes, see <see cref="Class"/>.
+    /// </summary>
+    public class Property : Element
+    {
+        private static XNamespace Xsi = "http://www.w3.org/2001/XMLSchema-instance";
+
+        public MultiString ShortName => GetMultiString("short_name", "label");
+
+        public string Type => XElement.Elements("domain").Attributes(Xsi + "type").FirstValue();
+
+        public string UnitIrdi => XElement.Elements("domain").Elements("unit").Attributes("unit_ref").FirstValue();
+
+        /// <summary>
+        /// Creates a new Property object within the given context, backed by the given XML element.
+        /// </summary>
+        /// <param name="context">The context for this element</param>
+        /// <param name="element">The XML element with the data for this element</param>
+        /// <param name="parent">The parent element</param>
+        public Property(Context context, XElement element, Model.IElement? parent = null)
+            : base(context, element, parent)
+        {
+        }
+
+        public Property(Property property, Model.IElement? parent)
+            : this(property.Context, property.XElement, parent)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool ImportSubmodelElementsInto(AdminShellV20.AdministrationShellEnv env,
+            AdminShellV20.IManageSubmodelElements parent)
+        {
+            if (!IsSelected)
+                return false;
+
+            var data = GetIec61360Data();
+            var property = Iec61360Utils.CreateProperty(env, data, GetValueType(data.DataType));
+            parent.Add(property);
+            return true;
+        }
+
+        protected override Iec61360Data GetIec61360Data()
+        {
+            // TODO: unit
+            var data = base.GetIec61360Data();
+            data.DataType = GetDataType(Type);
+            data.ShortName = ShortName;
+            data.UnitIrdi = UnitIrdi;
+            return data;
+        }
+
+        public override Dictionary<string, string> GetDetails()
+        {
+            var details = base.GetDetails();
+            details.Add("Short Name", ShortName.GetDefault());
+            return details;
+        }
+
+        private static string GetDataType(string type)
+        {
+            // TODO: This logic is copied from EclassUtils.GenerateConceptDescription -- does it handle all possible
+            // values?
+            var lowerType = type.ToLower();
+            foreach (var aasType in AdminShell.DataSpecificationIEC61360.DataTypeNames)
+            {
+                if (lowerType.Contains(aasType.ToLower()))
+                    return aasType;
+            }
+            return string.Empty;
+        }
+
+        private static string GetValueType(string dataType)
+        {
+            switch (dataType)
+            {
+                case "STRING":
+                case "STRING_TRANSLATABLE":
+                    return "string";
+                case "REAL_MEASURE":
+                case "REAL_COUNT":
+                case "REAL_CURRENCY":
+                    return "double"; // TODO: float?
+                case "INTEGER_MEASURE":
+                case "INTEGER_COUNT":
+                case "INTEGER_CURRENCY":
+                    return "int";
+                case "BOOLEAN":
+                    return "boolean";
+                case "URL":
+                case "RATIONAL":
+                case "RATIONAL_MEASURE":
+                    return "string";
+                case "TIME":
+                case "TIMESTAMP":
+                    return "time";
+                case "DATE":
+                    return "date";
+            }
+            return string.Empty;
+        }
+    }
+
+    internal static class Extensions
+    {
+        public static string FirstValue(this IEnumerable<XElement> elements)
+            => elements.Values().DefaultIfEmpty("").First();
+
+        public static string FirstValue(this IEnumerable<XAttribute> attributes)
+            => attributes.Values().DefaultIfEmpty("").First();
+
+        public static IEnumerable<string> Values(this IEnumerable<XElement> elements)
+            => elements.Select(e => e.Value);
+
+        public static IEnumerable<string> Values(this IEnumerable<XAttribute> attributes)
+            => attributes.Select(a => a.Value);
+    }
+}

--- a/src/AasxDictionaryImport/ElementDetailsDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ElementDetailsDialog.xaml.cs
@@ -34,7 +34,7 @@ namespace AasxDictionaryImport
             foreach (var field in details.Keys)
                 AddString(field, details[field]);
 
-            Title = $"{Element} [{Element.DataSource}]";
+            Title = $"{Element.DisplayName} [{Element.DataSource}]";
         }
 
         private void AddString(string label, string value)

--- a/src/AasxDictionaryImport/Iec61360Utils.cs
+++ b/src/AasxDictionaryImport/Iec61360Utils.cs
@@ -44,7 +44,8 @@ namespace AasxDictionaryImport
             AdminShellV20.AdministrationShellEnv env,
             AdminShellV20.AdministrationShell adminShell, Iec61360Data data)
         {
-            // TODO: fix
+            // We need this to ensure that we don't use the same AAS ID twice when importing multiple submodels (as
+            // GenerateIdAccordingTemplate uses the timestamp as part of the ID).
             Thread.Sleep(1000);
             var submodel = new AdminShellV20.Submodel()
             {

--- a/src/AasxDictionaryImport/Iec61360Utils.cs
+++ b/src/AasxDictionaryImport/Iec61360Utils.cs
@@ -11,6 +11,7 @@ This source code may use other Open Source software components (see LICENSE.txt)
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using AdminShellNS;
 
 namespace AasxDictionaryImport
@@ -43,6 +44,8 @@ namespace AasxDictionaryImport
             AdminShellV20.AdministrationShellEnv env,
             AdminShellV20.AdministrationShell adminShell, Iec61360Data data)
         {
+            // TODO: fix
+            Thread.Sleep(1000);
             var submodel = new AdminShellV20.Submodel()
             {
                 identification = new AdminShellV20.Identification(

--- a/src/AasxDictionaryImport/Import.cs
+++ b/src/AasxDictionaryImport/Import.cs
@@ -17,8 +17,8 @@ namespace AasxDictionaryImport
 {
     /// <summary>
     /// A generic import dialog for submodels and submodel elements.  For the data model, see the Model namespace.  For
-    /// implementations of this data model, see the Cdd namespace.  For the actual dialog, see the ImportDialog.xaml
-    /// file.
+    /// implementations of this data model, see the Cdd and Eclass namespaces.  For the actual dialog, see the
+    /// ImportDialog.xaml file.
     /// <para>
     /// This project uses nullable types.  Methods may only throw exceptions if they are mentioned in the doc comment.
     /// </para>
@@ -30,7 +30,7 @@ namespace AasxDictionaryImport
     /// ElementDetailsDialog)</description>
     /// </item>
     /// <item>
-    /// <description>supporting other data providers, especially eCl@ss</description>
+    /// <description>adding support for eCl@ss Advanced</description>
     /// </item>
     /// <item>
     /// <description>fetching data from the network (IEC CDD HTML web service, eCl@ss REST API)</description>

--- a/src/AasxDictionaryImport/ImportDialog.xaml
+++ b/src/AasxDictionaryImport/ImportDialog.xaml
@@ -38,7 +38,7 @@
             <WrapPanel>
                 <Label Content="Source:" Margin="0,0,10,0" VerticalAlignment="Center"/>
                 <ComboBox x:Name="ComboBoxSource" Width="250" Margin="0,0,10,0" SelectionChanged="ComboBoxSource_SelectionChanged" VerticalAlignment="Center"/>
-                <Button Content="Open Directory" Padding="5,0" Click="ButtonOpenDirectory_Click" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <Button Content="Open Local File" Padding="5,0" Click="ButtonOpenFile_Click" VerticalAlignment="Center" Margin="0,0,10,0"/>
             </WrapPanel>
             <WrapPanel HorizontalAlignment="Right">
                 <Label Content="Filter elements: " VerticalAlignment="Center" Margin="0,0,10,0"/>

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -322,7 +322,7 @@ namespace AasxDictionaryImport
             Element = element;
             Children = element.Children.Select(e => new ElementWrapper(e, this)).ToList();
 
-            Element.IsSelected = _isChecked != false;
+            _isChecked = Element.IsSelected;
         }
 
         protected void PropagateIsChecked(bool up, bool down)

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -36,6 +36,7 @@ namespace AasxDictionaryImport
     {
         public ISet<Model.IDataProvider> DataProviders = new HashSet<Model.IDataProvider> {
             new Cdd.DataProvider(),
+            new Eclass.DataProvider(),
         };
         public Model.IDataContext? Context;
         private readonly ObservableCollection<Model.IElement> _topLevelElements
@@ -169,7 +170,7 @@ namespace AasxDictionaryImport
 
         private void ComboBoxSource_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            Title = "IEC CDD Import";
+            Title = "Dictionary Import";
             _topLevelElements.Clear();
             _detailsElements.Clear();
 
@@ -191,7 +192,7 @@ namespace AasxDictionaryImport
                     {
                         _topLevelElements.Add(element);
                     }
-                    Title = $"IEC CDD Import [{source}]";
+                    Title = $"Dictionary Import [{source}]";
 
                     if (ClassViewControl.Items.Count > 0)
                         ClassViewControl.SelectedItem = ClassViewControl.Items[0];

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -304,7 +304,7 @@ namespace AasxDictionaryImport
 
         public string Id => Element.Id;
 
-        public string Name => Element.Name;
+        public string Name => Element.DisplayName;
 
         public bool IsExpanded => Parent == null;
 

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -92,15 +92,15 @@ namespace AasxDictionaryImport
             ButtonImport.IsEnabled = _detailsElements.Any(w => w.IsChecked != false);
         }
 
-        private string? GetImportDirectory()
+        private string? GetImportPath()
         {
-            using var dialog = new System.Windows.Forms.FolderBrowserDialog
+            using var dialog = new System.Windows.Forms.OpenFileDialog
             {
-                Description = "Select the import directory."
+                Title = "Select a local file for the Dictionary Import"
             };
 
             return dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK
-                ? dialog.SelectedPath : null;
+                ? dialog.FileName : null;
         }
 
         private void ApplyFilter()
@@ -210,9 +210,9 @@ namespace AasxDictionaryImport
             }
         }
 
-        private void ButtonOpenDirectory_Click(object sender, RoutedEventArgs e)
+        private void ButtonOpenFile_Click(object sender, RoutedEventArgs e)
         {
-            var path = GetImportDirectory();
+            var path = GetImportPath();
             if (path == null)
                 return;
 

--- a/src/AasxDictionaryImport/Model.cs
+++ b/src/AasxDictionaryImport/Model.cs
@@ -381,7 +381,7 @@ namespace AasxDictionaryImport.Model
         public abstract ICollection<IElement> Children { get; }
 
         /// <inheritdoc/>
-        public virtual bool IsSelected { get; set; }
+        public bool IsSelected { get; set; } = true;
 
         protected ElementBase(IDataSource dataSource, IElement? parent = null)
         {

--- a/src/AasxDictionaryImport/Model.cs
+++ b/src/AasxDictionaryImport/Model.cs
@@ -173,6 +173,11 @@ namespace AasxDictionaryImport.Model
         string Name { get; }
 
         /// <summary>
+        /// The display name of this element, usually in English.
+        /// </summary>
+        string DisplayName { get; }
+
+        /// <summary>
         /// The parent of this element or null if the element is a root element of the element tree.
         /// </summary>
         IElement? Parent { get; }
@@ -373,6 +378,9 @@ namespace AasxDictionaryImport.Model
 
         /// <inheritdoc/>
         public abstract string Name { get; }
+
+        /// <inheritdoc/>
+        public virtual string DisplayName => Name;
 
         /// <inheritdoc/>
         public virtual IElement? Parent { get; }


### PR DESCRIPTION
This patch series adds support for imports from ECLASS Basic and
Advanced to the AasxDictionaryImport project.  The ECLASS data is read
from OntoML XML files and can be used to create submodels or submodel
elements.

(This PR only adds support for reading XML files from the file system.
Support for the ECLASS web interface will be added with the next PR.)

@aorzelskiGH Do you want to review this PR?