### PR TITLE
Add Fetch Online option for the import dialog

### DIFF
--- a/src/AasxDictionaryImport/FetchOnlineDialog.xaml
+++ b/src/AasxDictionaryImport/FetchOnlineDialog.xaml
@@ -1,0 +1,44 @@
+﻿<Window x:Class="AasxDictionaryImport.FetchOnlineDialog"
+             x:ClassModifier="internal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:AasxDictionaryImport"
+             mc:Ignorable="d"
+             MinWidth="300" SizeToContent="WidthAndHeight" Title="Fetch Online [Dictionary Import]">
+    <!--
+    Copyright (c) 2020 SICK AG <info@sick.de>
+
+    This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+    This source code may use other Open Source software components (see LICENSE.txt).
+    -->
+
+    <DockPanel Margin="5" LastChildFill="False">
+        <Grid DockPanel.Dock="Top" VerticalAlignment="Stretch">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*"/>
+                <ColumnDefinition Width="7*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+
+            <Label Grid.Row="0" Grid.Column="0" Content="Provider" Margin="0,0,10,0" VerticalAlignment="Center"/>
+            <ComboBox Grid.Row="0" Grid.Column="1" x:Name="ComboBoxProvider" MinWidth="50"
+                SelectionChanged="ComboBoxProvider_SelectionChanged" VerticalAlignment="Center"
+                HorizontalAlignment="Stretch"/>
+
+            <Label Grid.Row="1" Grid.Column="0" x:Name="LabelQuery" MinWidth="50" Margin="0,0,10,0" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="1" Grid.Column="1" x:Name="TextBoxQuery" Text="{Binding Query}" MinWidth="150"
+                VerticalAlignment="Center" HorizontalAlignment="Stretch"/>
+        </Grid>
+
+        <WrapPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Cancel" HorizontalAlignment="Right" Padding="5,0" MinWidth="75" IsCancel="True" Margin="5"/>
+            <Button Content="OK" HorizontalAlignment="Right" MinWidth="75" IsDefault="True" Margin="5" Click="ButtonOk_Click"/>
+        </WrapPanel>
+    </DockPanel>
+</Window>

--- a/src/AasxDictionaryImport/FetchOnlineDialog.xaml.cs
+++ b/src/AasxDictionaryImport/FetchOnlineDialog.xaml.cs
@@ -1,0 +1,56 @@
+﻿/*
+Copyright (c) 2020 SICK AG <info@sick.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace AasxDictionaryImport
+{
+    /// <summary>
+    /// Query a data provider and a query string from the user that will be used to retrieve data from the network
+    /// (see <see cref="Model.IDataProvider.Fetch"/>).
+    /// </summary>
+    internal partial class FetchOnlineDialog : Window
+    {
+        public Model.IDataProvider? DataProvider => ComboBoxProvider.SelectedItem as Model.IDataProvider;
+        public string Query { get; set; } = string.Empty;
+
+        public FetchOnlineDialog(ICollection<Model.IDataProvider> providers)
+        {
+            DataContext = this;
+
+            InitializeComponent();
+
+            foreach (var provider in providers)
+                ComboBoxProvider.Items.Add(provider);
+            if (providers.Count > 0)
+                ComboBoxProvider.SelectedItem = providers.First();
+        }
+
+        private void ComboBoxProvider_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+
+            if (!(ComboBoxProvider.SelectedItem is Model.IDataProvider provider))
+                return;
+            if (!provider.IsFetchSupported)
+                return;
+
+            LabelQuery.Content = provider.FetchPrompt;
+        }
+
+        private void ButtonOk_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+        }
+    }
+}

--- a/src/AasxDictionaryImport/ImportDialog.xaml
+++ b/src/AasxDictionaryImport/ImportDialog.xaml
@@ -39,6 +39,7 @@
                 <Label Content="Source:" Margin="0,0,10,0" VerticalAlignment="Center"/>
                 <ComboBox x:Name="ComboBoxSource" Width="250" Margin="0,0,10,0" SelectionChanged="ComboBoxSource_SelectionChanged" VerticalAlignment="Center"/>
                 <Button Content="Open Local File" Padding="5,0" Click="ButtonOpenFile_Click" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <Button x:Name="ButtonFetchOnline" Content="Fetch Online" Padding="5,0" Click="ButtonFetchOnline_Click" VerticalAlignment="Center" Margin="0,0,10,0"/>
             </WrapPanel>
             <WrapPanel HorizontalAlignment="Right">
                 <Label Content="Filter elements: " VerticalAlignment="Center" Margin="0,0,10,0"/>

--- a/src/AasxDictionaryImport/Model.cs
+++ b/src/AasxDictionaryImport/Model.cs
@@ -42,6 +42,18 @@ namespace AasxDictionaryImport.Model
         string Name { get; }
 
         /// <summary>
+        /// The prompt to use in the user interface when asking the user for the query string for fetching online data
+        /// using the <see cref="Fetch"/> method.
+        /// </summary>
+        string FetchPrompt { get; }
+
+        /// <summary>
+        /// Whether this data provider supports fetching data from the network based on a search string provided by the
+        /// user.
+        /// </summary>
+        bool IsFetchSupported { get; }
+
+        /// <summary>
         /// Returns a list of all default data sources for this provider, i. e. all data sources that have been shipped
         /// with the AASX Package Explorer or that are freely available on the internet.
         /// </summary>
@@ -67,6 +79,17 @@ namespace AasxDictionaryImport.Model
         /// <exception cref="ImportException">If the path could not be accessed or does not contain valid data for this
         /// data provider</exception>
         IDataSource OpenPath(string path);
+
+        /// <summary>
+        /// Fetch data from this data provider from the network using the given query string provided by the user.
+        /// This method will only work if <see cref="IsFetchSupported"/> is true.  Otherwise it will throw an
+        /// ImportException.
+        /// </summary>
+        /// <param name="query">The query string provided by the user</param>
+        /// <returns>A data source loaded from the network using the given query string</returns>
+        /// <exception cref="ImportException">If the data cannot be retrieved from the network or if this data provider
+        /// does not support fetching data from the network</exception>
+        IDataSource Fetch(string query);
     }
 
     /// <summary>
@@ -327,6 +350,12 @@ namespace AasxDictionaryImport.Model
         public abstract string Name { get; }
 
         /// <inheritdoc/>
+        public virtual string FetchPrompt { get; } = string.Empty;
+
+        /// <inheritdoc/>
+        public virtual bool IsFetchSupported { get; } = false;
+
+        /// <inheritdoc/>
         public virtual IEnumerable<IDataSource> FindDefaultDataSources(string dir)
         {
             return GetDefaultPaths(dir)
@@ -344,6 +373,10 @@ namespace AasxDictionaryImport.Model
         /// <inheritdoc/>
         public virtual IDataSource OpenPath(string path)
             => OpenPath(path, DataSourceType.Custom);
+
+        /// <inheritdoc/>
+        public virtual IDataSource Fetch(string query) =>
+            throw new ImportException("Fetch not supported by this data provider");
 
         /// <summary>
         /// Returns all paths that could contain a default data source.


### PR DESCRIPTION
This patch adds a "Fetch Online" button to the import dialog that allows
the user to retrieve data from the network, for example from the eCl@ss
REST web service.  If clicked, a FetchOnlineDialog is opened.  In this
dialog, the user can select the data provider to use and provide a query
string for the fetch.

The patch also adds support for fetching data from the network to the
DataProvider class:
- The IsFetchSupported attribute designates whether the data provider
  supports fetching data from the network.
- The FetchPrompt attribute contains a label for the query prompt to be
  used in the user interface.
- The Fetch method creates a new IDataSource instance using the data
  fetched from the network for a query string provided by the user.

This patch also contains a default implementation of these methods in
the DataProviderBase class and a simple (and incomplete) implementation
in the Eclass data provider.