### PR TITLE
Position windows relative to parent

### DIFF
--- a/src/AasxDictionaryImport/FetchOnlineDialog.xaml
+++ b/src/AasxDictionaryImport/FetchOnlineDialog.xaml
@@ -6,7 +6,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:AasxDictionaryImport"
              mc:Ignorable="d"
-             MinWidth="300" SizeToContent="WidthAndHeight" Title="Fetch Online [Dictionary Import]">
+             MinWidth="300" SizeToContent="WidthAndHeight" Title="Fetch Online [Dictionary Import]"
+             WindowStartupLocation="CenterOwner">
     <!--
     Copyright (c) 2020 SICK AG <info@sick.de>
 

--- a/src/AasxDictionaryImport/FetchOnlineDialog.xaml.cs
+++ b/src/AasxDictionaryImport/FetchOnlineDialog.xaml.cs
@@ -25,8 +25,9 @@ namespace AasxDictionaryImport
         public Model.IDataProvider? DataProvider => ComboBoxProvider.SelectedItem as Model.IDataProvider;
         public string Query { get; set; } = string.Empty;
 
-        public FetchOnlineDialog(ICollection<Model.IDataProvider> providers)
+        public FetchOnlineDialog(Window owner, ICollection<Model.IDataProvider> providers)
         {
+            Owner = owner;
             DataContext = this;
 
             InitializeComponent();

--- a/src/AasxDictionaryImport/Import.cs
+++ b/src/AasxDictionaryImport/Import.cs
@@ -10,6 +10,7 @@ This source code may use other Open Source software components (see LICENSE.txt)
 
 using System;
 using System.Linq;
+using System.Windows;
 using System.Windows.Input;
 using AdminShellNS;
 
@@ -59,17 +60,19 @@ namespace AasxDictionaryImport
         /// converted into an AAS submodel and imported into the given admin shell.  If <paramref name="adminShell"/> is
         /// null, a new empty admin shell is created in the given environment.
         /// </summary>
+        /// <param name="window">The parent window for the import dialog</param>
         /// <param name="env">The AAS environment to import into</param>
         /// <param name="defaultSourceDir">The search path for the default data sources, e. g. the current working
         /// directory</param>
         /// <param name="adminShell">The admin shell to import into, or null if a new admin shell should be
         /// created</param>
         /// <returns>true if at least one submodel was imported</returns>
-        public static bool ImportSubmodel(AdminShellV20.AdministrationShellEnv env,
+        public static bool ImportSubmodel(Window window, AdminShellV20.AdministrationShellEnv env,
             string defaultSourceDir, AdminShellV20.AdministrationShell? adminShell = null)
         {
             adminShell ??= CreateAdminShell(env);
-            return PerformImport(ImportMode.Submodels, defaultSourceDir, e => e.ImportSubmodelInto(env, adminShell));
+            return PerformImport(window, ImportMode.Submodels, defaultSourceDir,
+                    e => e.ImportSubmodelInto(env, adminShell));
         }
 
         /// <summary>
@@ -77,21 +80,23 @@ namespace AasxDictionaryImport
         /// converted into AAS submodel elements (usually properties and collections) and imported into the given parent
         /// element (usually a submodel).
         /// </summary>
+        /// <param name="window">The parent window for the import dialog</param>
         /// <param name="env">The AAS environment to import into</param>
         /// <param name="defaultSourceDir">The search path for the default data sources, e. g. the current working
         /// directory</param>
         /// <param name="parent">The parent element to import into</param>
         /// <returns>true if at least one submodel element was imported</returns>
-        public static bool ImportSubmodelElements(AdminShell.AdministrationShellEnv env,
+        public static bool ImportSubmodelElements(Window window, AdminShell.AdministrationShellEnv env,
             string defaultSourceDir, AdminShell.IManageSubmodelElements parent)
         {
-            return PerformImport(ImportMode.SubmodelElements, defaultSourceDir,
+            return PerformImport(window, ImportMode.SubmodelElements, defaultSourceDir,
                 e => e.ImportSubmodelElementsInto(env, parent));
         }
 
-        private static bool PerformImport(ImportMode importMode, string defaultSourceDir, Func<Model.IElement, bool> f)
+        private static bool PerformImport(Window window, ImportMode importMode, string defaultSourceDir,
+                Func<Model.IElement, bool> f)
         {
-            var dialog = new ImportDialog(importMode, defaultSourceDir);
+            var dialog = new ImportDialog(window, importMode, defaultSourceDir);
             if (dialog.ShowDialog() != true || dialog.Context == null)
                 return false;
 

--- a/src/AasxDictionaryImport/ImportDialog.xaml
+++ b/src/AasxDictionaryImport/ImportDialog.xaml
@@ -6,7 +6,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:AasxDictionaryImport"
              mc:Ignorable="d" 
-             Title="Dictionary Import" Width="1000" Height="500" MinWidth="550" MinHeight="200">
+             Title="Dictionary Import" Width="1000" Height="500" MinWidth="550" MinHeight="200"
+             WindowStartupLocation="CenterOwner">
     <!--
     Copyright (c) 2020 SICK AG <info@sick.de>
 

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -65,8 +65,9 @@ namespace AasxDictionaryImport
             }
         }
 
-        public ImportDialog(ImportMode importMode, string defaultSourceDir)
+        public ImportDialog(Window owner, ImportMode importMode, string defaultSourceDir)
         {
+            Owner = owner;
             DataContext = this;
 
             ImportMode = importMode;
@@ -242,7 +243,7 @@ namespace AasxDictionaryImport
             if (fetchProviders.Count == 0)
                 return;
 
-            var dialog = new FetchOnlineDialog(fetchProviders);
+            var dialog = new FetchOnlineDialog(this, fetchProviders);
             if (dialog.ShowDialog() != true || dialog.DataProvider == null)
                 return;
 

--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -1847,7 +1847,7 @@ namespace AasxPackageExplorer
             var dataChanged = false;
             try
             {
-                dataChanged = AasxDictionaryImport.Import.ImportSubmodel(env, Options.Curr.DictImportDir, aas);
+                dataChanged = AasxDictionaryImport.Import.ImportSubmodel(this, env, Options.Curr.DictImportDir, aas);
             }
             catch (Exception e)
             {
@@ -1888,7 +1888,7 @@ namespace AasxPackageExplorer
             var dataChanged = false;
             try
             {
-                dataChanged = AasxDictionaryImport.Import.ImportSubmodelElements(env, Options.Curr.DictImportDir,
+                dataChanged = AasxDictionaryImport.Import.ImportSubmodelElements(this, env, Options.Curr.DictImportDir,
                     submodel);
             }
             catch (Exception e)


### PR DESCRIPTION
This patch updates the AasxDictionaryImport project to display new
windows relative to its parent by setting the WindowStartupLocation to
CenterOwner and by setting the Owner property.