### PR TITLE
Show busy cursor when fetching dictionary data

### DIFF
--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -248,6 +248,7 @@ namespace AasxDictionaryImport
 
             try
             {
+                Mouse.OverrideCursor = Cursors.Wait;
                 var source = dialog.DataProvider.Fetch(dialog.Query);
                 ComboBoxSource.Items.Add(source);
                 ComboBoxSource.SelectedItem = source;
@@ -260,6 +261,10 @@ namespace AasxDictionaryImport
                         "Could not fetch the requested data.\n" +
                         "Details: " + ex.Message,
                         "Fetch Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                        Mouse.OverrideCursor = null;
             }
         }
 

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -264,7 +264,7 @@ namespace AasxDictionaryImport
             }
             finally
             {
-                        Mouse.OverrideCursor = null;
+                Mouse.OverrideCursor = null;
             }
         }
 


### PR DESCRIPTION
This patch changes the ImportDialog to show a waiting cursor while we
are fetching the data for a class from a data provider, e. g. the ECLASS
webservice.