### PR TITLE
Whitelist verb "position" for commit messages

### DIFF
--- a/src/AdditionalVerbsInImperativeMood.txt
+++ b/src/AdditionalVerbsInImperativeMood.txt
@@ -21,3 +21,4 @@ skip
 redirect
 deduplicate
 re-order
+position


### PR DESCRIPTION
This patch adds "position" to the list of allowed verbs.