### PR TITLE
Change label for eClass import

### DIFF
--- a/src/AasxDictionaryImport/Eclass/Model.cs
+++ b/src/AasxDictionaryImport/Eclass/Model.cs
@@ -55,7 +55,7 @@ namespace AasxDictionaryImport.Eclass
         public override bool IsFetchSupported => true;
 
         /// <inheritdoc/>
-        public override string FetchPrompt => "IRDI";
+        public override string FetchPrompt => "IRDI / Code";
 
         /// <summary>
         /// Checks whether the given path contains valid eCl@ss data that can be read by this data provider.  If this


### PR DESCRIPTION
This patch changes the label from "IRDI" to "IRDI / Code"