### PR TITLE
Fix idShort and semanticId in DocumentShelf plugin

### DIFF
--- a/src/AasxPluginDocumentShelf/DocuShelfSemanticConfig.cs
+++ b/src/AasxPluginDocumentShelf/DocuShelfSemanticConfig.cs
@@ -269,7 +269,7 @@ namespace AasxPluginDocumentShelf
                 "Identification of the Domain, e.g. the providing organisation."));
 
             descDocIdDom.Add(new FormDescProperty(
-                "DocumentId", FormMultiplicity.One, defs.CD_DocumentId?.GetSingleKey(),
+                "DocumentId", FormMultiplicity.One, defs.CD_DocumentIdValue?.GetSingleKey(),
                 "DocumentId",
                 "Identification of the Document within a given domain, e.g. the providing organisation."));
 

--- a/src/AasxPluginDocumentShelf/DocuShelfSemanticConfig.cs
+++ b/src/AasxPluginDocumentShelf/DocuShelfSemanticConfig.cs
@@ -178,7 +178,7 @@ namespace AasxPluginDocumentShelf
             // DocumentVersion
 
             var descDocVer = new FormDescSubmodelElementCollection(
-                "DocumentVersion", FormMultiplicity.OneToMany, semConfig.SemIdDocumentVersion, "DocumentVersion",
+                "DocumentVersion", FormMultiplicity.OneToMany, semConfig.SemIdDocumentVersion, "DocumentVersion{0:00}",
                 "VDI2770 allows for multiple DocumentVersions for a document to be delivered.");
             descDoc.Add(descDocVer);
 
@@ -342,7 +342,7 @@ namespace AasxPluginDocumentShelf
 
             var descDocVer = new FormDescSubmodelElementCollection(
                 "DocumentVersion", FormMultiplicity.OneToMany, defs.CD_DocumentVersion?.GetSingleKey(),
-                "DocumentVersion",
+                "DocumentVersion{0:00}",
                 "VDI2770 allows for multiple DocumentVersions for a document to be delivered.");
             descDoc.Add(descDocVer);
 


### PR DESCRIPTION
This PR fixes two bugs in the DocumentShelf plugin.

The first is what I assume to be an incorrect semanticId on the 
*ManufacturerDocumentation* > *Document##* > *DocumentIdDomain##* > 
*DocumentId* property. As it is, it shares the same semanticId as its
parent SMC. At the same time, there is a predefined CD named 
`CD_DocumentIdValue` which is supposed to be used here, judging by its
description.
This PR makes it so this CD is assigned to `DocumentId`.

Secondly, *ManufacturerDocumentation* > *Document##* > 
*DocumentVersion* didn't use to have an index, even though a single 
Document can have many DocumentVersions. This element is now indexed.