### PR TITLE
Test against aas-package3-csharp

### DIFF
--- a/src/AasxCsharpLibrary.Tests/AasxCsharpLibrary.Tests.csproj
+++ b/src/AasxCsharpLibrary.Tests/AasxCsharpLibrary.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
@@ -18,6 +19,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AasCore.Aas3.Package" Version="1.0.0-pre6" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/AasxCsharpLibrary.Tests/TestAgainstAasCorePackage.cs
+++ b/src/AasxCsharpLibrary.Tests/TestAgainstAasCorePackage.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace AdminShellNS.Tests
+{
+    public class TestAgainstAasCorePackage
+    {
+        /**
+         * Retrieve the bytes of the valid XML file 01_Festo.aasx.xml from the
+         * test resources.
+         */
+        private static byte[] Get01FestoAasxXmlBytes()
+        {
+            string pth = Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "TestResources\\AasxCsharpLibrary.Tests\\XmlValidation\\expectedOk\\" +
+                "01_Festo.aasx.xml");
+
+            if (!File.Exists(pth))
+            {
+                throw new FileNotFoundException(
+                    $"Could not find the XML file: {pth}");
+            }
+
+            return File.ReadAllBytes(pth);
+        }
+
+        [Test]
+        public void TestThatSupplementaryMaterialIsLoaded()
+        {
+            var packaging = new AasCore.Aas3.Package.Packaging();
+            using var tmpDir = new TemporaryDirectory();
+
+            var pth = System.IO.Path.Combine(tmpDir.Path, "dummy.aasx");
+
+            var supplUri = new Uri(
+                "/aasx-suppl/some-company/some-manual.pdf",
+                UriKind.Relative);
+
+            var supplContent = Encoding.UTF8.GetBytes("some content");
+
+            // Create a package
+            {
+                using var pkg = packaging.Create(pth);
+
+                var spec = pkg.MakeSpec(
+                    pkg.PutPart(
+                        new Uri("/aasx/some-company/data.xml", UriKind.Relative),
+                        "text/xml",
+                        Get01FestoAasxXmlBytes()));
+
+                pkg.RelateSupplementaryToSpec(
+                    pkg.PutPart(
+                        supplUri,
+                        "application/pdf",
+                        supplContent),
+                    spec);
+
+                pkg.Flush();
+            }
+
+            // Load the AASX using AasxCsharpLibrary
+            {
+                using var package = new AdminShellPackageEnv(pth);
+
+                Assert.IsTrue(package.IsOpen);
+
+                var lst = package.GetListOfSupplementaryFiles();
+
+                Assert.AreEqual(1, lst.Count);
+                var suppl = lst.First();
+                Assert.AreEqual(supplUri, suppl.Uri);
+                Assert.AreEqual(
+                    Encoding.UTF8.GetString(supplContent),
+                    Encoding.UTF8.GetString(
+                        package.GetByteArrayFromUriOrLocalPackage(
+                            suppl.Uri.ToString()))
+                );
+            }
+        }
+    }
+}

--- a/src/AasxCsharpLibrary.Tests/TestValidateXml.cs
+++ b/src/AasxCsharpLibrary.Tests/TestValidateXml.cs
@@ -38,19 +38,17 @@ namespace AdminShellNS.Tests
 
             foreach (string path in paths)
             {
-                using (var fileStream = System.IO.File.OpenRead(path))
+                using var fileStream = System.IO.File.OpenRead(path);
+                var records = new AasValidationRecordList();
+                validator.Validate(records, fileStream);
+                if (records.Count != 0)
                 {
-                    var records = new AasValidationRecordList();
-                    validator.Validate(records, fileStream);
-                    if (records.Count != 0)
+                    var parts = new List<string>
                     {
-                        var parts = new List<string>
-                        {
-                            $"Failed to validate XML file {path}:"
-                        };
-                        parts.AddRange(records.Select((r) => r.Message));
-                        throw new AssertionException(string.Join(Environment.NewLine, parts));
-                    }
+                        $"Failed to validate XML file {path}:"
+                    };
+                    parts.AddRange(records.Select((r) => r.Message));
+                    throw new AssertionException(string.Join(Environment.NewLine, parts));
                 }
             }
         }


### PR DESCRIPTION
This patch adds an unit test to make sure that the parsing of the .aasx
package is compatible with aas-package3-csharp library.