### PR TITLE
Fix typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ artefacts/
 
 # Sample AASXs
 sample-aasx/
+/.vs/slnx.sqlite
+/.vs/aasx-package-explorer_fork/v16/.suo
+/.vs

--- a/src/AasxPredefinedConcepts/DefinitionsVDI2770.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsVDI2770.cs
@@ -34,7 +34,7 @@ namespace AasxPredefinedConcepts
         {
             "All",      "* - All document classes",
             "01-01",    "Identification",
-            "02-01",    "Technical specifiction",
+            "02-01",    "Technical specification",
             "02-02",    "Drawings, plans",
             "02-03",    "Assemblies",
             "02-04",    "Certificates, declarations",


### PR DESCRIPTION
"Technical specifiction" -> "Technical specification"