### PR TITLE
Rename package which uses Blazor UI

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -58,5 +58,5 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
-          name: BlazorUI.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/BlazorUI.zip
+          name: aasx-package-explorer-blazorui.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/aasx-package-explorer-blazorui.zip

--- a/src/AasxCsharpLibrary.Tests/AasxCsharpLibrary.Tests.csproj
+++ b/src/AasxCsharpLibrary.Tests/AasxCsharpLibrary.Tests.csproj
@@ -19,7 +19,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AasCore.Aas3.Package" Version="1.0.0-pre6" />
+    <PackageReference Include="AasCore.Aas3.Package" Version="1.0.0-pre7" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/PackageRelease.ps1
+++ b/src/PackageRelease.ps1
@@ -148,7 +148,7 @@ function PackageRelease($outputDir)
 
     MakePackage -identifier "aasx-package-explorer-small" -plugins $smallPlugins
 
-    MakePackageBlazor -identifier "BlazorUI"
+    MakePackageBlazor -identifier "aasx-package-explorer-blazorui"
 
     # Do not copy the source code in the releases.
     # The source code will be distributed automatically through Github releases.


### PR DESCRIPTION
This changes how the package is identified on the disk as well as on the
release page on GitHub. Now it follows the convention
`aasx-package-explorer-*`.