### PR TITLE
Improve error messages in AasxToolkit.Tests

### DIFF
--- a/src/AasxToolkit.Tests/TestProgram.cs
+++ b/src/AasxToolkit.Tests/TestProgram.cs
@@ -61,7 +61,7 @@ namespace AasxToolkit.Tests
                         if (consoleCap.Error() != "")
                         {
                             throw new AssertionException(
-                                $"Expected no stderr, but got:{System.Environment.NewLine}" +
+                                $"Expected no stderr, but got:{System.Environment.NewLine} " +
                                 consoleCap.Error());
                         }
 
@@ -81,20 +81,26 @@ namespace AasxToolkit.Tests
             {
                 using (var tmpDir = new TemporaryDirectory())
                 {
+                    string targetPth = Path.Combine(tmpDir.Path, "exported.template");
+
                     using (var consoleCap = new ConsoleCapture())
                     {
                         int code = AasxToolkit.Program.MainWithExitCode(
                             new[]
                             {
                                 "load", pth,
-                                "export-template", Path.Combine(tmpDir.Path, "exported.template")
+                                "export-template", targetPth
                             });
 
                         if (consoleCap.Error() != "")
                         {
                             throw new AssertionException(
                                 $"Expected no stderr, but got:{System.Environment.NewLine}" +
-                                consoleCap.Error());
+                                consoleCap.Error() +
+                                System.Environment.NewLine +
+                                System.Environment.NewLine +
+                                "The original command was:" + System.Environment.NewLine +
+                                $"AasxToolkit load {pth} export-template {targetPth}");
                         }
 
                         Assert.AreEqual(0, code);
@@ -115,19 +121,25 @@ namespace AasxToolkit.Tests
                 {
                     using (var consoleCap = new ConsoleCapture())
                     {
+                        string targetPth = Path.Combine(tmpDir.Path, "saved.xml");
+
                         int code = AasxToolkit.Program.MainWithExitCode(
                             new[]
                             {
                                 "load", pth,
                                 "check",
-                                "save", Path.Combine(tmpDir.Path, "saved.xml")
+                                "save", targetPth
                             });
 
                         if (consoleCap.Error() != "")
                         {
                             throw new AssertionException(
                                 $"Expected no stderr, but got:{System.Environment.NewLine}" +
-                                consoleCap.Error());
+                                consoleCap.Error() +
+                                System.Environment.NewLine +
+                                System.Environment.NewLine +
+                                $"The executed command was: " +
+                                $"AasxToolkit load {pth} check save {targetPth}");
                         }
 
                         Assert.AreEqual(0, code);


### PR DESCRIPTION
The current message is not informative enough as it only explains which
sample file caused the failure, but lacks information about the command
which was executed. This patch adds verbatim command to the error
message so that the developer can reproduce the failure manually.