### PR TITLE
Pin dependencies of AasxPluginSmdExporter

### DIFF
--- a/src/AasxPluginSmdExporter/AasxPluginSmdExporter.csproj
+++ b/src/AasxPluginSmdExporter/AasxPluginSmdExporter.csproj
@@ -56,10 +56,10 @@
         <PackageReference Include="CsvHelper" Version="27.1.1" />
         <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="System.Buffers" Version="4.5.1" />
         <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-        <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
+        <PackageReference Include="System.IO.Packaging" Version="4.7.0" />
         <PackageReference Include="System.Memory" Version="4.5.4" />
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />


### PR DESCRIPTION
The dependencies of AasxPluginSmdExporter were simply set to latest
(following dependabot warnings from GitHub). This breaks the build as
the different DLLs are all lumped together in the same directory. Newer
versions of System.IO.Packaging and Newtonsoft.Json hence overwrite the
older ones. The executables fail at runtime as a consequence as they can
not find the older dependencies.

In the future, we should equalize all the dependencies across the
solution to avoid such conflicts.