### PR TITLE
Add escape hatch for custom InspectCode

### DIFF
--- a/src/InspectCode.ps1
+++ b/src/InspectCode.ps1
@@ -29,11 +29,35 @@ function Main
     Write-Host "* The working directory is: $(Get-Location)"
     Write-Host "* The path to solution is: $pathToSolution"
 
-    & dotnet.exe jb inspectcode `
+    # We need to allow for a custom path to InspectCode since dotnet jb command fails on systems
+    # where there are spaces in the paths.
+    if (Test-Path env:INSPECT_CODE_PATH)
+    {
+        Write-Host ( `
+            "* The environment variable INSPECT_CODE_PATH has been defined, " + `
+            "inspecting with it: $($env:INSPECT_CODE_PATH)")
+
+        if ($null -eq (Test-Path $env:INSPECT_CODE_PATH -ErrorAction SilentlyContinue))
+        {
+            throw "Unable to find the specified INSPECT_CODE_PATH: $( $env:INSPECT_CODE_PATH )"
+        }
+
+        & $env:INSPECT_CODE_PATH `
         "-o=$codeInspectionPath" `
         "--caches-home=$cachesHome" `
         '--exclude=*\obj\*;packages\*;*\bin\*;*\*.json' `
         "$pathToSolution"
+    }
+    else
+    {
+        Write-Host "* Inspecting the code with dodtnet jb inspectcode"
+
+        & dotnet.exe jb inspectcode `
+            "-o=$codeInspectionPath" `
+            "--caches-home=$cachesHome" `
+            '--exclude=*\obj\*;packages\*;*\bin\*;*\*.json' `
+            "$pathToSolution"
+    }
 
     [xml]$inspection = Get-Content $codeInspectionPath
 


### PR DESCRIPTION
We need to allow for a custom path to InspectCode since dotnet jb
command fails on systems where there are spaces in the paths.