### PR TITLE
Fix idShort generation in forms

### DIFF
--- a/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
@@ -65,7 +65,7 @@ namespace AasxIntegrationBase.AasForms
             // access
             if (sme == null)
                 return;
-            
+
             collection = collection ?? new AdminShell.SubmodelElementWrapperCollection();
 
             // check, if to make idShort unique?

--- a/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
@@ -63,8 +63,10 @@ namespace AasxIntegrationBase.AasForms
             AdminShell.SubmodelElementWrapperCollection collection, AdminShell.SubmodelElement sme)
         {
             // access
-            if (collection == null || sme == null)
+            if (sme == null)
                 return;
+            
+            collection = collection ?? new AdminShell.SubmodelElementWrapperCollection();
 
             // check, if to make idShort unique?
             if (sme.idShort.Contains("{0"))


### PR DESCRIPTION
IdShort templates used for automatic generation in form
plugins sometimes carry the {0:00} format specifier.
These templates weren't correctly evaluated when the element
was added to a new `SubmodelElementWrapperCollection`
which doesn't exist, yet. 
This was the case, for example, in the document shelf plugin
when adding the very first document to a newly created submodel.
The final idShort of the SMC was `Document{0:00}`. 