### PR TITLE
Fix incorrect Chinese language code

### DIFF
--- a/src/AasxIntegrationBase/AasxLanguageHelper.cs
+++ b/src/AasxIntegrationBase/AasxLanguageHelper.cs
@@ -17,10 +17,10 @@ namespace AasxIntegrationBase
 {
     public static class AasxLanguageHelper
     {
-        public enum LangEnum { Any = 0, EN, DE, CN, JP, KR, FR, ES };
+        public enum LangEnum { Any = 0, EN, DE, ZH, JP, KR, FR, ES };
 
         public static string[] LangEnumToISO639String = {
-                "All", "en", "de", "cn", "jp", "kr", "fr", "es" }; // ISO 639 -> List of languages
+                "All", "en", "de", "zh", "jp", "kr", "fr", "es" }; // ISO 639 -> List of languages
 
         public static string[] LangEnumToISO3166String = {
                 "All", "GB", "DE", "CN", "JP", "KR", "FR", "ES" }; // ISO 3166 -> List of countries

--- a/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
@@ -490,7 +490,7 @@ namespace AasxIntegrationBase.AasForms
     [DisplayName("FormMultiLangProp")]
     public class FormDescMultiLangProp : FormDescSubmodelElement
     {
-        public static string[] DefaultLanguages = new string[] { "de", "en", "fr", "es", "it", "cn", "kr" };
+        public static string[] DefaultLanguages = new string[] { "de", "en", "fr", "es", "it", "zh", "kr" };
 
         public FormDescMultiLangProp() { }
 

--- a/src/AasxPackageLogic/DispEditHelperBasics.cs
+++ b/src/AasxPackageLogic/DispEditHelperBasics.cs
@@ -127,7 +127,7 @@ namespace AasxPackageLogic
         // Members
         //
 
-        private string[] defaultLanguages = new[] { "en", "de", "fr", "es", "it", "cn", "kr", "jp" };
+        private string[] defaultLanguages = new[] { "en", "de", "fr", "es", "it", "zh", "kr", "jp" };
 
         public PackageCentral.PackageCentral packages = null;
         public IPushApplicationEvent appEventsProvider = null;

--- a/src/AasxPluginDocumentShelf/ShelfControl.xaml
+++ b/src/AasxPluginDocumentShelf/ShelfControl.xaml
@@ -115,11 +115,11 @@
                                 <Label Content="DE"/>
                             </WrapPanel>
                         </RadioButton>
-                        <RadioButton x:Name="RadioLangCN" VerticalContentAlignment="Center" Margin="3"
-                                 IsChecked="{Binding Path=TheSelectedLanguage, Converter={StaticResource enumBooleanConverter}, ConverterParameter=CN}">
+                        <RadioButton x:Name="RadioLangZH" VerticalContentAlignment="Center" Margin="3"
+                                 IsChecked="{Binding Path=TheSelectedLanguage, Converter={StaticResource enumBooleanConverter}, ConverterParameter=ZH}">
                             <WrapPanel Width="30">
                                 <!-- <cf:CountryFlag Code="CN" Width="30"/> -->
-                                <Label Content="CN"/>
+                                <Label Content="ZH"/>
                             </WrapPanel>
                         </RadioButton>
                         <RadioButton x:Name="RadioLangJP" VerticalContentAlignment="Center" Margin="3"

--- a/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
+++ b/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
@@ -156,7 +156,7 @@ namespace AasxPluginDocumentShelf
             // CountryFlag does not work in XAML (at least not in Release binary)
             ResetCountryRadioButton(RadioLangEN, CountryFlag.CountryCode.GB);
             ResetCountryRadioButton(RadioLangDE, CountryFlag.CountryCode.DE);
-            ResetCountryRadioButton(RadioLangCN, CountryFlag.CountryCode.CN);
+            ResetCountryRadioButton(RadioLangZH, CountryFlag.CountryCode.CN);
             ResetCountryRadioButton(RadioLangJP, CountryFlag.CountryCode.JP);
             ResetCountryRadioButton(RadioLangKR, CountryFlag.CountryCode.KR);
             ResetCountryRadioButton(RadioLangFR, CountryFlag.CountryCode.FR);

--- a/src/AasxPredefinedConcepts/DefinitionsLanguages.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsLanguages.cs
@@ -17,6 +17,6 @@ namespace AasxPredefinedConcepts
 {
     public static class DefinitionsLanguages
     {
-        public static string[] DefaultLanguages = new string[] { "en", "de", "fr", "es", "it", "cn", "kr", "jp" };
+        public static string[] DefaultLanguages = new string[] { "en", "de", "fr", "es", "it", "zh", "kr", "jp" };
     }
 }


### PR DESCRIPTION
Attempts to fix #473 by changing all instances of the string `cn` which
are likely to be related to a language to `zh`.

Other mentions of `cn` (including X.509 certificates and two uses of
it as a country code as opposed to language code) where left unchanged.

The changes compile and the application runs and the fix seems to have
the intended effect. I can't say for sure that there aren't any
unintended side-effects or bugs which is why I'd like a thorough
review.