### PR TITLE
Add default valueTypes in forms

### DIFF
--- a/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
@@ -483,7 +483,8 @@ namespace AasxIntegrationBase.AasForms
             this.InitSme(res);
             if (this.presetValue != null)
                 res.value = this.presetValue;
-            if (this.allowedValueTypes.Length == 1) {
+            if (this.allowedValueTypes.Length == 1)
+            {
                 res.valueType = this.allowedValueTypes[0];
             }
             return res;

--- a/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
@@ -483,6 +483,9 @@ namespace AasxIntegrationBase.AasForms
             this.InitSme(res);
             if (this.presetValue != null)
                 res.value = this.presetValue;
+            if (this.allowedValueTypes.Length == 1) {
+                res.valueType = this.allowedValueTypes[0];
+            }
             return res;
         }
     }

--- a/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
@@ -793,18 +793,24 @@ namespace AasxIntegrationBase.AasForms
 
             // If the source element has a value, keep it. Otherwise, look for
             // a default value and apply that.
-            if (!String.IsNullOrEmpty(pSource?.value)) {
+            if (!String.IsNullOrEmpty(pSource?.value))
+            {
                 p.value = pSource.value;
-            } else if (!String.IsNullOrWhiteSpace(parentDesc.presetValue)) {
+            }
+            else if (!String.IsNullOrWhiteSpace(parentDesc.presetValue))
+            {
                 p.value = parentDesc.presetValue;
                 this.Touch();
             }
 
             // If the source element has a valueType, keep it. Otherwise, look for
             // a default valueType and apply that.
-            if (!String.IsNullOrWhiteSpace(pSource?.valueType)) {
+            if (!String.IsNullOrWhiteSpace(pSource?.valueType))
+            {
                 p.valueType = pSource.valueType;
-            } else if (parentDesc.allowedValueTypes.Length == 1) {
+            }
+            else if (parentDesc.allowedValueTypes.Length == 1)
+            {
                 p.valueType = parentDesc.allowedValueTypes[0];
                 this.Touch();
             }

--- a/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
@@ -790,24 +790,23 @@ namespace AasxIntegrationBase.AasForms
             // check, if a source is present
             this.sourceSme = source;
             var pSource = this.sourceSme as AdminShell.Property;
-            if (pSource != null)
-            {
-                // take over
-                p.valueType = pSource.valueType;
-                p.value = pSource.value;
-            }
-            else
-            {
-                // some more preferences
-                if (parentDesc.allowedValueTypes != null && parentDesc.allowedValueTypes.Length >= 1)
-                    p.valueType = parentDesc.allowedValueTypes[0];
 
-                if (parentDesc.presetValue != null && parentDesc.presetValue.Length > 0)
-                {
-                    p.value = parentDesc.presetValue;
-                    // immediately set touched in order to have this value saved
-                    this.Touch();
-                }
+            // If the source element has a value, keep it. Otherwise, look for
+            // a default value and apply that.
+            if (!String.IsNullOrEmpty(pSource?.value)) {
+                p.value = pSource.value;
+            } else if (!String.IsNullOrWhiteSpace(parentDesc.presetValue)) {
+                p.value = parentDesc.presetValue;
+                this.Touch();
+            }
+
+            // If the source element has a valueType, keep it. Otherwise, look for
+            // a default valueType and apply that.
+            if (!String.IsNullOrWhiteSpace(pSource?.valueType)) {
+                p.valueType = pSource.valueType;
+            } else if (parentDesc.allowedValueTypes.Length == 1) {
+                p.valueType = parentDesc.allowedValueTypes[0];
+                this.Touch();
             }
 
             // create user control

--- a/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData.add-options.json
+++ b/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData.add-options.json
@@ -56,7 +56,7 @@
                 "Multiplicity": "One",
                 "IsReadOnly": false,
                 "allowedValueTypes": [
-                  ""
+                  "string"
                 ],
                 "presetValue": ""
               },

--- a/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData_v11.add-options.json
+++ b/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData_v11.add-options.json
@@ -56,7 +56,7 @@
                 "Multiplicity": "One",
                 "IsReadOnly": false,
                 "allowedValueTypes": [
-                  ""
+                  "string"
                 ],
                 "presetValue": ""
               },
@@ -212,7 +212,7 @@
                     "Multiplicity": "One",
                     "IsReadOnly": false,
                     "allowedValueTypes": [
-                      ""
+                      "string"
                     ],
                     "presetValue": ""
                   },
@@ -233,7 +233,7 @@
                     "Multiplicity": "ZeroToOne",
                     "IsReadOnly": false,
                     "allowedValueTypes": [
-                      ""
+                      "string"
                     ],
                     "presetValue": ""
                   },
@@ -254,7 +254,7 @@
                     "Multiplicity": "One",
                     "IsReadOnly": false,
                     "allowedValueTypes": [
-                      ""
+                      "string"
                     ],
                     "presetValue": ""
                   }


### PR DESCRIPTION
Forms didn't used to apply the allowedValueType defined in forms JSON to
properties in most cases.

This has been changed. Whenever a plugin is used to create a new
submodel, properties inside that submodel are assigned a default
valueType. When
Whenever a new submodel is created or updated through a forms plugin,
default valueTypes are applied if defined in the JSON.