### PR TITLE
Change type of SMEs in technical data

### DIFF
--- a/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData.add-options.json
+++ b/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData.add-options.json
@@ -79,7 +79,7 @@
                 "presetMimeType": ""
               },
               {
-                "$type": "FormProperty",
+                "$type": "FormMultiLangProp",
                 "FormTitle": "ManufacturerProductDesignation",
                 "FormEditIdShort": false,
                 "FormEditDescription": false,
@@ -93,11 +93,7 @@
                   "idType": "IRI"
                 },
                 "Multiplicity": "One",
-                "IsReadOnly": false,
-                "allowedValueTypes": [
-                  "string"
-                ],
-                "presetValue": ""
+                "IsReadOnly": false
               },
               {
                 "$type": "FormProperty",
@@ -400,7 +396,7 @@
             "IsReadOnly": false,
             "value": [
               {
-                "$type": "FormProperty",
+                "$type": "FormMultiLangProp",
                 "FormTitle": "TextStatement",
                 "FormEditIdShort": false,
                 "FormEditDescription": false,
@@ -414,11 +410,7 @@
                   "idType": "IRI"
                 },
                 "Multiplicity": "ZeroToMany",
-                "IsReadOnly": false,
-                "allowedValueTypes": [
-                  "string"
-                ],
-                "presetValue": ""
+                "IsReadOnly": false
               },
               {
                 "$type": "FormProperty",

--- a/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData_v11.add-options.json
+++ b/src/AasxPluginGenericForms/AasxPluginGenericForms_SG2_TechnicalData_v11.add-options.json
@@ -79,7 +79,7 @@
                 "presetMimeType": ""
               },
               {
-                "$type": "FormProperty",
+                "$type": "FormMultiLangProp",
                 "FormTitle": "ManufacturerProductDesignation",
                 "FormEditIdShort": false,
                 "FormEditDescription": false,
@@ -93,11 +93,7 @@
                   "idType": "IRI"
                 },
                 "Multiplicity": "One",
-                "IsReadOnly": false,
-                "allowedValueTypes": [
-                  "string"
-                ],
-                "presetValue": ""
+                "IsReadOnly": false
               },
               {
                 "$type": "FormProperty",
@@ -400,7 +396,7 @@
             "IsReadOnly": false,
             "value": [
               {
-                "$type": "FormProperty",
+                "$type": "FormMultiLangProp",
                 "FormTitle": "TextStatement",
                 "FormEditIdShort": false,
                 "FormEditDescription": false,
@@ -414,11 +410,7 @@
                   "idType": "IRI"
                 },
                 "Multiplicity": "ZeroToMany",
-                "IsReadOnly": false,
-                "allowedValueTypes": [
-                  "string"
-                ],
-                "presetValue": ""
+                "IsReadOnly": false
               },
               {
                 "$type": "FormProperty",


### PR DESCRIPTION
There were two submodel elements in the technical data submodel which
were properties even though the specification defines them as MLPs.

This has been fixed.