### PR TITLE
Add mimeType guessing to forms

### DIFF
--- a/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormInstance.cs
@@ -998,6 +998,7 @@ namespace AasxIntegrationBase.AasForms
 
                             // save
                             file.value = targetPath + targetFn;
+                            file.mimeType = AdminShellPackageEnv.GuessMimeType(targetFn);
 
                             if (addFilesToPackage)
                             {
@@ -1019,6 +1020,7 @@ namespace AasxIntegrationBase.AasForms
             if (file != null && Touched && fileSource != null && editSource)
             {
                 fileSource.value = file.value;
+                fileSource.mimeType = file.mimeType;
                 return false;
             }
             return true;


### PR DESCRIPTION
When adding a file to an SM through a form, the file's MIME type is now
guessed the same way as if the file was added to the file element.