### PR TITLE
Implement reload of cached online imports

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-    "sdk": {
-      "version": "3.1.0",
-      "rollForward": "latestFeature"
-    }
-  }
-  

--- a/src/AasxDictionaryImport/Cdd/Model.cs
+++ b/src/AasxDictionaryImport/Cdd/Model.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using AasxDictionaryImport.Model;
 using AdminShellNS;
 
 namespace AasxDictionaryImport.Cdd
@@ -42,7 +43,7 @@ namespace AasxDictionaryImport.Cdd
         }
 
         /// <inheritdoc/>
-        protected override Model.IDataSource OpenPath(string path, Model.DataSourceType type)
+        public override Model.IDataSource OpenPath(string path, Model.DataSourceType type = Model.DataSourceType.Custom)
         {
             string dir = File.Exists(path) ? Path.GetDirectoryName(path) : path;
             return new DataSource(this, dir, type);

--- a/src/AasxDictionaryImport/Eclass/Model.cs
+++ b/src/AasxDictionaryImport/Eclass/Model.cs
@@ -198,7 +198,7 @@ namespace AasxDictionaryImport.Eclass
                 throw new ImportException($"ECLASS query failed with status code: {response.ReasonPhrase}");
             }
 
-            var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var tempDir = Path.Combine(Path.Combine(Path.GetTempPath(), $"aasx.import"), Path.GetRandomFileName());
             Directory.CreateDirectory(tempDir);
             var tempFile = Path.Combine(tempDir, irdi + ".xml");
 
@@ -218,7 +218,7 @@ namespace AasxDictionaryImport.Eclass
         }
 
         /// <inheritdoc/>
-        protected override Model.IDataSource OpenPath(string path, Model.DataSourceType type)
+        public override Model.IDataSource OpenPath(string path, Model.DataSourceType type = DataSourceType.Custom)
             => new DataSource(this, path, type);
     }
 

--- a/src/AasxDictionaryImport/ImportDialog.xaml
+++ b/src/AasxDictionaryImport/ImportDialog.xaml
@@ -39,6 +39,7 @@
             <WrapPanel>
                 <Label Content="Source:" Margin="0,0,10,0" VerticalAlignment="Center"/>
                 <ComboBox x:Name="ComboBoxSource" Width="250" Margin="0,0,10,0" SelectionChanged="ComboBoxSource_SelectionChanged" VerticalAlignment="Center"/>
+                <Button Content="Clear" Margin="0,0,10,0" Padding="5,0" VerticalAlignment="Center" Click="ButtonClear_Click"/>
                 <Button Content="Open Local File" Padding="5,0" Click="ButtonOpenFile_Click" VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <Button x:Name="ButtonFetchOnline" Content="Fetch Online" Padding="5,0" Click="ButtonFetchOnline_Click" VerticalAlignment="Center" Margin="0,0,10,0"/>
             </WrapPanel>
@@ -86,7 +87,7 @@
                   Click="CheckBoxAllIecCddAttributes_Click"/>
 
         <WrapPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,10,0,0" HorizontalAlignment="Right">
-            <Button Content="Cancel" Width="75" Margin="0,0,10,0" IsCancel="True"/>
+            <Button Content="Cancel" Width="75" Margin="0,0,10,0" IsCancel="True" Click="ButtonCancel_Click"/>
             <Button x:Name="ButtonImport" Content="Import" Width="75" IsDefault="True" IsEnabled="False" Click="ButtonImport_Click"/>
         </WrapPanel>
 

--- a/src/AasxDictionaryImport/ImportDialog.xaml.cs
+++ b/src/AasxDictionaryImport/ImportDialog.xaml.cs
@@ -12,12 +12,15 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
+using System.Xml.Linq;
 using AasxPackageLogic;
+using AasxDictionaryImport.Model;
 
 namespace AasxDictionaryImport
 {
@@ -83,6 +86,65 @@ namespace AasxDictionaryImport
 
             DataSourceLabel.Content = String.Join(", ", DataProviders.Select(p => p.Name));
             ButtonFetchOnline.IsEnabled = DataProviders.Any(p => p.IsFetchSupported);
+
+
+            LoadCachedImports();
+        }
+
+        private void LoadCachedImports()
+        {
+            var indexFile = Path.Combine(Path.Combine(Path.GetTempPath(), $"aasx.import"), $"cache.index.xml");
+            try
+            {
+                if (File.Exists(indexFile))
+                {
+                    XDocument doc = XDocument.Load(indexFile);
+                    foreach (var cacheEl in doc.Root.Elements("CachedElement"))
+                    {
+                        var fileName = cacheEl.Attribute("FileName").Value;
+                        if (File.Exists(fileName) && cacheEl.Attribute("Source").Value.Equals("Online"))
+                        {
+                            ICollection<Model.IDataProvider> providers =
+                                DataProviders.Where(p => p.IsFetchSupported).ToList();
+                            foreach (var provider in providers)
+                            {
+                                if (cacheEl.Attribute("Provider").Value.Equals(provider.Name))
+                                {
+                                    var source = provider.OpenPath(fileName, Model.DataSourceType.Online);
+                                    ComboBoxSource.Items.Add(source);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (ArgumentNullException e)
+            {
+                /* Nothing to do */
+            }
+
+        }
+        
+        private void SaveCachedIndex()
+        {
+            var indexFile = Path.Combine(Path.Combine(Path.GetTempPath(), $"aasx.import"), $"cache.index.xml");
+            XDocument doc = new XDocument(
+                new XElement("Cache")
+                );
+            var rootEl = doc.Root;
+            foreach (var listItem in ComboBoxSource.Items)
+            {
+                if (listItem is Model.FileSystemDataSource source)
+                {
+                    var el = new XElement("CachedElement");
+                    el.SetAttributeValue("FileName", source.Path);
+                    el.SetAttributeValue("Source", source.Type.ToString());
+                    el.SetAttributeValue("Provider", source.DataProvider.ToString());
+                    rootEl.Add(el);
+                }
+            }
+            doc.Save(indexFile);
         }
 
         public IEnumerable<Model.IElement> GetResult()
@@ -141,6 +203,14 @@ namespace AasxDictionaryImport
         private void ButtonImport_Click(object sender, RoutedEventArgs e)
         {
             DialogResult = true;
+            SaveCachedIndex();
+            Close();
+        }
+        
+        private void ButtonCancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            SaveCachedIndex();
             Close();
         }
 
@@ -307,6 +377,13 @@ namespace AasxDictionaryImport
                     System.Diagnostics.Process.Start("https://cdd.iec.ch/CDD/iec61360/iec61360.nsf/License?openPage");
                 }
             }
+        }
+
+        private void ButtonClear_Click(object sender, RoutedEventArgs e)
+        {
+            ComboBoxSource.Items.Clear();
+            _topLevelElements.Clear();
+            _detailsElements.Clear();
         }
     }
 

--- a/src/AasxDictionaryImport/Model.cs
+++ b/src/AasxDictionaryImport/Model.cs
@@ -78,7 +78,7 @@ namespace AasxDictionaryImport.Model
         /// <returns>A data source that reads from the given path</returns>
         /// <exception cref="ImportException">If the path could not be accessed or does not contain valid data for this
         /// data provider</exception>
-        IDataSource OpenPath(string path);
+        IDataSource OpenPath(string path, Model.DataSourceType type = Model.DataSourceType.Custom);
 
         /// <summary>
         /// Fetch data from this data provider from the network using the given query string provided by the user.
@@ -119,7 +119,7 @@ namespace AasxDictionaryImport.Model
         /// <returns>The data stored in this data source</returns>
         /// <exception cref="ImportException">If the data source could not be accessed or does not contain valid
         /// data</exception>
-        IDataContext Load();
+        IDataContext Load(); // cache this
     }
 
     /// <summary>
@@ -371,10 +371,6 @@ namespace AasxDictionaryImport.Model
         public abstract bool IsValidPath(string path);
 
         /// <inheritdoc/>
-        public virtual IDataSource OpenPath(string path)
-            => OpenPath(path, DataSourceType.Custom);
-
-        /// <inheritdoc/>
         public virtual IDataSource Fetch(string query) =>
             throw new ImportException("Fetch not supported by this data provider");
 
@@ -395,7 +391,7 @@ namespace AasxDictionaryImport.Model
         /// <returns>A data source that reads from the given path</returns>
         /// <exception cref="ImportException">If the path could not be accessed or does not contain valid data for this
         /// data provider</exception>
-        protected abstract IDataSource OpenPath(string path, DataSourceType type);
+        public abstract IDataSource OpenPath(string path, DataSourceType type = Model.DataSourceType.Custom);
     }
 
     /// <summary>

--- a/src/AasxDictionaryImport/Model.cs
+++ b/src/AasxDictionaryImport/Model.cs
@@ -75,6 +75,7 @@ namespace AasxDictionaryImport.Model
         /// returns true for this path, this method will always succeed.  Otherwise it will throw an exception.
         /// </summary>
         /// <param name="path">The path of the data set to open</param>
+        /// <param name="type">Type</param>
         /// <returns>A data source that reads from the given path</returns>
         /// <exception cref="ImportException">If the path could not be accessed or does not contain valid data for this
         /// data provider</exception>


### PR DESCRIPTION
Taking over PR #367 

Original branch: heidese-sick:heidepriem/import-reload-cached

For online imports the cached files are reloaded to the
import dialog during construction