### PR TITLE
Fix to incorrect language codes in langString menu

### DIFF
--- a/src/AasxIntegrationBase/AasxLanguageHelper.cs
+++ b/src/AasxIntegrationBase/AasxLanguageHelper.cs
@@ -17,10 +17,10 @@ namespace AasxIntegrationBase
 {
     public static class AasxLanguageHelper
     {
-        public enum LangEnum { Any = 0, EN, DE, ZH, JP, KR, FR, ES };
+        public enum LangEnum { Any = 0, EN, DE, ZH, JA, KO, FR, ES };
 
         public static string[] LangEnumToISO639String = {
-                "All", "en", "de", "zh", "jp", "kr", "fr", "es" }; // ISO 639 -> List of languages
+                "All", "en", "de", "zh", "ja", "ko", "fr", "es" }; // ISO 639 -> List of languages
 
         public static string[] LangEnumToISO3166String = {
                 "All", "GB", "DE", "CN", "JP", "KR", "FR", "ES" }; // ISO 3166 -> List of countries

--- a/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
+++ b/src/AasxIntegrationBaseWpf/AasForms/FormDescription.cs
@@ -494,7 +494,7 @@ namespace AasxIntegrationBase.AasForms
     [DisplayName("FormMultiLangProp")]
     public class FormDescMultiLangProp : FormDescSubmodelElement
     {
-        public static string[] DefaultLanguages = new string[] { "de", "en", "fr", "es", "it", "zh", "kr" };
+        public static string[] DefaultLanguages = new string[] { "de", "en", "fr", "es", "it", "zh", "ko", "ja" };
 
         public FormDescMultiLangProp() { }
 

--- a/src/AasxPackageLogic/DispEditHelperBasics.cs
+++ b/src/AasxPackageLogic/DispEditHelperBasics.cs
@@ -127,7 +127,7 @@ namespace AasxPackageLogic
         // Members
         //
 
-        private string[] defaultLanguages = new[] { "en", "de", "fr", "es", "it", "zh", "kr", "jp" };
+        private string[] defaultLanguages = new[] { "en", "de", "fr", "es", "it", "zh", "ko", "ja" };
 
         public PackageCentral.PackageCentral packages = null;
         public IPushApplicationEvent appEventsProvider = null;

--- a/src/AasxPluginDocumentShelf/ShelfControl.xaml
+++ b/src/AasxPluginDocumentShelf/ShelfControl.xaml
@@ -122,18 +122,18 @@
                                 <Label Content="ZH"/>
                             </WrapPanel>
                         </RadioButton>
-                        <RadioButton x:Name="RadioLangJP" VerticalContentAlignment="Center" Margin="3"
-                                 IsChecked="{Binding Path=TheSelectedLanguage, Converter={StaticResource enumBooleanConverter}, ConverterParameter=JP}">
+                        <RadioButton x:Name="RadioLangJA" VerticalContentAlignment="Center" Margin="3"
+                                 IsChecked="{Binding Path=TheSelectedLanguage, Converter={StaticResource enumBooleanConverter}, ConverterParameter=JA}">
                             <WrapPanel Width="30">
                                 <!--<cf:CountryFlag Code="JP" Width="30"/> -->
-                                <Label Content="JP"/>
+                                <Label Content="JA"/>
                             </WrapPanel>
                         </RadioButton>
-                        <RadioButton x:Name="RadioLangKR" VerticalContentAlignment="Center" Margin="3"
-                                 IsChecked="{Binding Path=TheSelectedLanguage, Converter={StaticResource enumBooleanConverter}, ConverterParameter=KR}">
+                        <RadioButton x:Name="RadioLangKO" VerticalContentAlignment="Center" Margin="3"
+                                 IsChecked="{Binding Path=TheSelectedLanguage, Converter={StaticResource enumBooleanConverter}, ConverterParameter=KO}">
                             <WrapPanel Width="30">
                                 <!--<cf:CountryFlag Code="KR" Width="30"/> -->
-                                <Label Content="KR"/>
+                                <Label Content="KO"/>
                             </WrapPanel>
                         </RadioButton>
                         <RadioButton x:Name="RadioLangFR" VerticalContentAlignment="Center" Margin="3"

--- a/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
+++ b/src/AasxPluginDocumentShelf/ShelfControl.xaml.cs
@@ -157,8 +157,8 @@ namespace AasxPluginDocumentShelf
             ResetCountryRadioButton(RadioLangEN, CountryFlag.CountryCode.GB);
             ResetCountryRadioButton(RadioLangDE, CountryFlag.CountryCode.DE);
             ResetCountryRadioButton(RadioLangZH, CountryFlag.CountryCode.CN);
-            ResetCountryRadioButton(RadioLangJP, CountryFlag.CountryCode.JP);
-            ResetCountryRadioButton(RadioLangKR, CountryFlag.CountryCode.KR);
+            ResetCountryRadioButton(RadioLangJA, CountryFlag.CountryCode.JP);
+            ResetCountryRadioButton(RadioLangKO, CountryFlag.CountryCode.KR);
             ResetCountryRadioButton(RadioLangFR, CountryFlag.CountryCode.FR);
             ResetCountryRadioButton(RadioLangES, CountryFlag.CountryCode.ES);
 #endif

--- a/src/AasxPredefinedConcepts/DefinitionsLanguages.cs
+++ b/src/AasxPredefinedConcepts/DefinitionsLanguages.cs
@@ -17,6 +17,6 @@ namespace AasxPredefinedConcepts
 {
     public static class DefinitionsLanguages
     {
-        public static string[] DefaultLanguages = new string[] { "en", "de", "fr", "es", "it", "zh", "kr", "jp" };
+        public static string[] DefaultLanguages = new string[] { "en", "de", "fr", "es", "it", "zh", "ko", "ja" };
     }
 }


### PR DESCRIPTION
The language codes "kr" and "jp" do not exist. They should be "ko" and
"ja", respectively.