### PR TITLE
Update sourcesEnhance for working with BaSys models no2

### DIFF
--- a/src/AasxAmlImExport/AasxAmlImExport.csproj
+++ b/src/AasxAmlImExport/AasxAmlImExport.csproj
@@ -4,6 +4,9 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />

--- a/src/AasxBammRdfImExport/AasxBammRdfImExport.csproj
+++ b/src/AasxBammRdfImExport/AasxBammRdfImExport.csproj
@@ -4,7 +4,10 @@
 		<OutputType>Library</OutputType>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	</PropertyGroup>
-	<ItemGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+  <ItemGroup>
 		<ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
 		<ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />
 	</ItemGroup>

--- a/src/AasxCsharpLibrary.Tests/AasxCsharpLibrary.Tests.csproj
+++ b/src/AasxCsharpLibrary.Tests/AasxCsharpLibrary.Tests.csproj
@@ -5,6 +5,11 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
   </ItemGroup>

--- a/src/AasxCsharpLibrary/AasxCsharpLibrary.csproj
+++ b/src/AasxCsharpLibrary/AasxCsharpLibrary.csproj
@@ -5,7 +5,14 @@
     <RootNamespace>AdminShellNS</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+
+  <PropertyGroup>
+    <!-- MIHO on 30.0.2022
+    see: https://stackoverflow.com/questions/69919664/publish-error-found-multiple-publish-output-files-with-the-same-relative-path -->
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DefineConstants>TRACE;UseAasxCompatibilityModels</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/AasxCsharpLibrary/AdminShell.cs
+++ b/src/AasxCsharpLibrary/AdminShell.cs
@@ -23,6 +23,7 @@ using System.Xml;
 using System.Xml.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using static AdminShellNS.AdminShellV20.Key;
 
 namespace AdminShellNS
 {
@@ -1956,6 +1957,29 @@ namespace AdminShellNS
             IEnumerable<SubmodelElementWrapper> EnumerateChildren();
             EnumerationPlacmentBase GetChildrenPlacement(SubmodelElement child);
             object AddChild(SubmodelElementWrapper smw, EnumerationPlacmentBase placement = null);
+        }
+
+        public static class IEnumerateChildrenHelper
+        {
+            public static IEnumerable<SubmodelElementWrapper> RecurseOnChildren(IEnumerateChildren root)
+            {
+                // access 
+                if (root == null)
+                    yield break;
+
+                foreach (var smw in root.EnumerateChildren())
+                {
+                    var ch = smw?.submodelElement;
+                    if (ch == null)
+                        continue;
+
+                    yield return smw;
+
+                    if (ch is IEnumerateChildren chiec)
+                        foreach (var x in RecurseOnChildren(chiec))
+                            yield return x;
+                }
+            }
         }
 
         public interface IValidateEntity
@@ -4149,7 +4173,7 @@ namespace AdminShellNS
                 return this.GetSelfDescription()?.ElementName;
             }
 
-            // sorting
+            // creating
 
 
         }
@@ -4701,34 +4725,39 @@ namespace AdminShellNS
             // Handling of CDs
             //
 
-            public ConceptDescription FindConceptDescription(ConceptDescriptionRef cdr)
+            public ConceptDescription FindConceptDescription(
+                ConceptDescriptionRef cdr, MatchMode matchMode = MatchMode.Strict)
             {
                 if (cdr == null)
                     return null;
-                return FindConceptDescription(cdr.Keys);
+                return FindConceptDescription(cdr.Keys, matchMode);
             }
 
-            public ConceptDescription FindConceptDescription(SemanticId semId)
+            public ConceptDescription FindConceptDescription(
+                SemanticId semId, MatchMode matchMode = MatchMode.Strict)
             {
                 if (semId == null)
                     return null;
-                return FindConceptDescription(semId.Keys);
+                return FindConceptDescription(semId.Keys, matchMode);
             }
 
-            public ConceptDescription FindConceptDescription(Reference rf)
+            public ConceptDescription FindConceptDescription(
+                Reference rf, MatchMode matchMode = MatchMode.Strict)
             {
                 if (rf == null)
                     return null;
-                return FindConceptDescription(rf.Keys);
+                return FindConceptDescription(rf.Keys, matchMode);
             }
 
-            public ConceptDescription FindConceptDescription(Identification id)
+            public ConceptDescription FindConceptDescription(
+                Identification id, MatchMode matchMode = MatchMode.Strict)
             {
                 var cdr = ConceptDescriptionRef.CreateNew("Conceptdescription", true, id.idType, id.id);
-                return FindConceptDescription(cdr);
+                return FindConceptDescription(cdr, matchMode);
             }
 
-            public ConceptDescription FindConceptDescription(List<Key> keys)
+            public ConceptDescription FindConceptDescription(
+                List<Key> keys, MatchMode matchMode = MatchMode.Strict)
             {
                 // trivial
                 if (keys == null)
@@ -4738,8 +4767,13 @@ namespace AdminShellNS
                     return null;
                 // and we're picky
                 var key = keys[0];
-                if (!key.local || key.type.ToLower().Trim() != "conceptdescription")
+
+                if (matchMode == MatchMode.Strict && !key.local)
                     return null;
+
+                if (matchMode != MatchMode.Identification && key.type.ToLower().Trim() != "conceptdescription")
+                    return null;
+
                 // brute force
                 foreach (var cd in conceptDescriptions)
                     if (cd.identification.idType.ToLower().Trim() == key.idType.ToLower().Trim()
@@ -4775,12 +4809,13 @@ namespace AdminShellNS
                 }
             }
 
-            public ConceptDescription FindConceptDescription(Key key)
+            public ConceptDescription FindConceptDescription(
+                Key key, MatchMode matchMode = MatchMode.Strict)
             {
                 if (key == null)
                     return null;
                 var l = new List<Key> { key };
-                return (FindConceptDescription(l));
+                return (FindConceptDescription(l, matchMode));
             }
 
             public IEnumerable<LocatedReference> FindAllReferences()
@@ -4944,7 +4979,7 @@ namespace AdminShellNS
                     // seems fine
                     return res;
                 }
-
+                else
                 if (typeof(T) == typeof(Submodel))
                 {
                     // check, if exist or not exist
@@ -4974,7 +5009,7 @@ namespace AdminShellNS
                     // seems fine
                     return res;
                 }
-
+                else
                 if (typeof(T) == typeof(Asset))
                 {
                     // check, if exist or not exist
@@ -4998,8 +5033,24 @@ namespace AdminShellNS
                                 }
                     }
 
-                    // rename old Submodel
+                    // rename old Asset
                     assetOld.identification = newId;
+
+                    // seems fine
+                    return res;
+                }
+                else
+                if (typeof(T) == typeof(AdministrationShell))
+                {
+                    // check, if exist or not exist
+                    var aasOld = FindAAS(oldId);
+                    if (aasOld == null || FindAAS(newId) != null)
+                        return null;
+
+                    // recurse? -> no?
+
+                    // rename old Asset
+                    aasOld.identification = newId;
 
                     // seems fine
                     return res;

--- a/src/AasxDictionaryImport.Tests/AasxDictionaryImport.Tests.csproj
+++ b/src/AasxDictionaryImport.Tests/AasxDictionaryImport.Tests.csproj
@@ -6,6 +6,9 @@
     <Nullable>Enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>UseAasxCompatibilityModels</DefineConstants>
   </PropertyGroup>

--- a/src/AasxDictionaryImport/AasxDictionaryImport.csproj
+++ b/src/AasxDictionaryImport/AasxDictionaryImport.csproj
@@ -9,6 +9,9 @@
     <UseWPF>true</UseWPF>
     <Platform>x64</Platform>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />

--- a/src/AasxFileServerRestLibrary/AasxFileServerRestLibrary.csproj
+++ b/src/AasxFileServerRestLibrary/AasxFileServerRestLibrary.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>IO.Swagger</AssemblyName>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/src/AasxFormatCst/AasxFormatCst.csproj
+++ b/src/AasxFormatCst/AasxFormatCst.csproj
@@ -4,6 +4,9 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />

--- a/src/AasxIntegrationBase/AasxIntegrationBase.csproj
+++ b/src/AasxIntegrationBase/AasxIntegrationBase.csproj
@@ -4,6 +4,9 @@
     <OutputType>library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AnyUi\AnyUi.csproj" />

--- a/src/AasxIntegrationBaseGdi/AasxIntegrationBaseGdi.csproj
+++ b/src/AasxIntegrationBaseGdi/AasxIntegrationBaseGdi.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="11.1.2" />

--- a/src/AasxIntegrationBaseWpf/AasxIntegrationBaseWpf.csproj
+++ b/src/AasxIntegrationBaseWpf/AasxIntegrationBaseWpf.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />

--- a/src/AasxIntegrationEmptySample/AasxIntegrationEmptySample.csproj
+++ b/src/AasxIntegrationEmptySample/AasxIntegrationEmptySample.csproj
@@ -4,6 +4,9 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />
   </ItemGroup>

--- a/src/AasxMqtt/AasxMqtt.csproj
+++ b/src/AasxMqtt/AasxMqtt.csproj
@@ -6,6 +6,9 @@
     <AssemblyName>AasxMqttServer</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />
   </ItemGroup>

--- a/src/AasxMqttClient/AasxMqttClient.csproj
+++ b/src/AasxMqttClient/AasxMqttClient.csproj
@@ -4,6 +4,9 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />

--- a/src/AasxOpenidClient/AasxOpenidClient.csproj
+++ b/src/AasxOpenidClient/AasxOpenidClient.csproj
@@ -6,6 +6,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Security" />
   </ItemGroup>

--- a/src/AasxPackageExplorer.GuiTests/AasxPackageExplorer.GuiTests.csproj
+++ b/src/AasxPackageExplorer.GuiTests/AasxPackageExplorer.GuiTests.csproj
@@ -8,6 +8,9 @@
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FlaUI.UIA3" Version="3.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/src/AasxPackageExplorer.Tests/AasxPackageExplorer.Tests.csproj
+++ b/src/AasxPackageExplorer.Tests/AasxPackageExplorer.Tests.csproj
@@ -6,6 +6,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxPackageExplorer\AasxPackageExplorer.csproj" />
     <ProjectReference Include="..\AasxPackageLogic\AasxPackageLogic.csproj" />

--- a/src/AasxPackageExplorer/AasxPackageExplorer.csproj
+++ b/src/AasxPackageExplorer/AasxPackageExplorer.csproj
@@ -15,6 +15,9 @@
 	<Platform>x64</Platform>
   </PropertyGroup>
   <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+  <PropertyGroup>
     <ApplicationIcon>aasx.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>

--- a/src/AasxPackageExplorer/options-debug.MIHO.json
+++ b/src/AasxPackageExplorer/options-debug.MIHO.json
@@ -1,74 +1,76 @@
 {
-    /* "AasxToLoad" :  "sample-techdata.aasx", */
-    /* "AasxToLoad": "..\\..\\..\\..\\AasxToolkit\\bin\\Debug\\sample.aasx", */
-    /* "AasxToLoad": "sample-hsu.aasx", */
-    /* "AasxToLoad": "MTPsample.aasx", */
-    /* "AasxToLoad": "sample-generated-modified.aasx", */
-    /* "AasxToLoad": "..\\..\\..\\..\\..\\..\\aasx-sample-data\\Develop_AAS\\Sample-Fluiddraw.aasx", */
-    /* "AasxRepositoryFn": "..\\..\\..\\..\\..\\Sample_AAS\\aasxrepo-new.json", */
-    /* "AasxRepositoryFn": "C:\\Users\\miho\\Desktop\\201112_Festo_AAS_Demo_Koffer\\repo\\FestoDemoBox-RepositoryViaHTTP.json", */
-    "AasxRepositoryFn": "C:\\Users\\miho\\Desktop\\201112_Festo_AAS_Demo_Koffer\\repo3\\Festo-DemoBox-repo-local.json",
-    /* "AasxRepositoryFn": "C:\\Users\\miho\\Desktop\\201112_Festo_AAS_Demo_Koffer\\Festo_Demo_Box\\Festo-DemoBox-repo-CPX_E.json", */
-    /* "AasxRepositoryFn": "C:\\Users\\miho\\Desktop\\new-aasx-repo.json", */
-    /* "AasxToLoad": "C:\\Users\\miho\\Desktop\\200806_Sample_Repo_with_Fluidic_Plan\\MTPsample.aasx", */
-    /* "AasxToLoad": "http://localhost:51310/server/getaasx/0", */
-    /* "AasxToLoad": "C:\\MIHO\\Develop\\Aasx\\AasxFesto\\AasxFesto\\AasxFctTool\\bin\\Debug\\net472\\test.aasx", */
-    /* "AasxToLoad": "C:\\Users\\miho\\Desktop\\Festo_SPAU_VR3_UA.aasx", */
-    "AasxToLoad": "C:\\MIHO\\Develop\\Aasx\\repo\\Festo_SPAU_VR3.aasx",
-    "WindowLeft": -1,
-    "WindowTop": -1,
-    "WindowWidth": 900,
-    "WindowHeight": 600,
-    "WindowMaximized": false,
-    "TemplateIdAas": "www.example.com/ids/aas/DDDD_DDDD_DDDD_DDDD",
-    "TemplateIdAsset": "www.example.com/ids/asset/DDDD_DDDD_DDDD_DDDD",
-    "TemplateIdSubmodelInstance": "www.example.com/ids/sm/DDDD_DDDD_DDDD_DDDD",
-    "TemplateIdSubmodelTemplate": "www.example.com/ids/sm/DDDD_DDDD_DDDD_DDDD",
-    "TemplateIdConceptDescription": "www.example.com/ids/cd/DDDD_DDDD_DDDD_DDDD",
-    "EclassDir": ".\\eclass\\",
-    /* "LogoFile": "SpecPI40_t.png", */
-    "LogoFile": "SpecPI40_t.png",
-    "QualifiersFile": "qualifier-presets.json",
-    "ContentHome": "https://github.com/admin-shell/io/blob/master/README.md",
-    "UseFlyovers": true,
-    "SplashTime": 1000,
-    "InternalBrowser": false,
-    "EclassTwoPass": true,
-    "BackupDir": ".\\backup",
-    "BackupFiles": 10,
-    "RestServerHost": "localhost",
-    "RestServerPort": "1111",
-    "WriteDefaultOptionsFN": null /* "options-written.json" */,
-    "IndirectLoadSave": true,
-    "AccentColors": {},
-    "LoadWithoutPrompt": true,
-    "ShowIdAsIri": false,
-    "VerboseConnect": true,
-    "DefaultStayConnected": true,
-    "DefaultUpdatePeriod": 1000,
-    "StayConnectOptions": "REST-QUEUE", // SIM
-    /* "DefaultConnectRepositoryLocation": "http://localhost:51310", */
-    /* "DefaultConnectRepositoryLocation": "http://admin-shell-io.com:51510", */
-    /* "DefaultConnectRepositoryLocation": "https://admin-shell-io.com:51711", */
-    "DefaultConnectRepositoryLocation": "https://admin-shell-io.com/51711",
-    "MqttPublisherOptions": {
-        "BrokerUrl": "192.168.178.97:1883",
-        "MqttRetain": false,
-        "EnableFirstPublish": true,
-        "FirstTopicAAS": "AAS",
-        "FirstTopicSubmodel": "{aas}/Submodel_{sm}",
-        "EnableEventPublish": true,
-        "EventTopic": "Events/aas/{aas}/sm/{sm}/{path}",
-        "SingleValuePublish": true,
-        "SingleValueFirstTime": true,
-        "SingleValueTopic": "Values/aas/{aas}/sm/{sm}/{path}"
-    },
-    "Remarks": [
-        "This JSON file might contain special settings for debugging purposes of Michael Hoffmeisters setup."
-    ],
-    "PluginPrefer" : "ANYUI",
-    "PluginDll": [
-        /*
+  /* "AasxToLoad" :  "sample-techdata.aasx", */
+  /* "AasxToLoad": "..\\..\\..\\..\\AasxToolkit\\bin\\Debug\\sample.aasx", */
+  /* "AasxToLoad": "sample-hsu.aasx", */
+  /* "AasxToLoad": "MTPsample.aasx", */
+  /* "AasxToLoad": "sample-generated-modified.aasx", */
+  /* "AasxToLoad": "..\\..\\..\\..\\..\\..\\aasx-sample-data\\Develop_AAS\\Sample-Fluiddraw.aasx", */
+  /* "AasxRepositoryFn": "..\\..\\..\\..\\..\\Sample_AAS\\aasxrepo-new.json", */
+  /* "AasxRepositoryFn": "C:\\Users\\miho\\Desktop\\201112_Festo_AAS_Demo_Koffer\\repo\\FestoDemoBox-RepositoryViaHTTP.json", */
+  "AasxRepositoryFn": "C:\\Users\\miho\\Desktop\\201112_Festo_AAS_Demo_Koffer\\repo3\\Festo-DemoBox-repo-local.json",
+  /* "AasxRepositoryFn": "C:\\Users\\miho\\Desktop\\201112_Festo_AAS_Demo_Koffer\\Festo_Demo_Box\\Festo-DemoBox-repo-CPX_E.json", */
+  /* "AasxRepositoryFn": "C:\\Users\\miho\\Desktop\\new-aasx-repo.json", */
+  /* "AasxToLoad": "C:\\Users\\miho\\Desktop\\200806_Sample_Repo_with_Fluidic_Plan\\MTPsample.aasx", */
+  /* "AasxToLoad": "http://localhost:51310/server/getaasx/0", */
+  /* "AasxToLoad": "C:\\MIHO\\Develop\\Aasx\\AasxFesto\\AasxFesto\\AasxFctTool\\bin\\Debug\\net472\\test.aasx", */
+  /* "AasxToLoad": "C:\\Users\\miho\\Desktop\\Festo_SPAU_VR3_UA.aasx", */
+  /* "AasxToLoad": "C:\\MIHO\\Develop\\Aasx\\repo\\Festo_SPAU_VR3.aasx", */
+  // "AasxToLoad": "C:\\HOMI\\Develop\\Aasx\\repo\\01_Festo_SPAU_VR3.aasx",
+  "AasxToLoad": "C:\\HOMI\\Develop\\Aasx\\basys-cap\\repo\\BasysCapaModelV14.aasx",
+  "WindowLeft": -1,
+  "WindowTop": -1,
+  "WindowWidth": 900,
+  "WindowHeight": 600,
+  "WindowMaximized": false,
+  "TemplateIdAas": "www.example.com/ids/aas/DDDD_DDDD_DDDD_DDDD",
+  "TemplateIdAsset": "www.example.com/ids/asset/DDDD_DDDD_DDDD_DDDD",
+  "TemplateIdSubmodelInstance": "www.example.com/ids/sm/DDDD_DDDD_DDDD_DDDD",
+  "TemplateIdSubmodelTemplate": "www.example.com/ids/sm/DDDD_DDDD_DDDD_DDDD",
+  "TemplateIdConceptDescription": "www.example.com/ids/cd/DDDD_DDDD_DDDD_DDDD",
+  "EclassDir": ".\\eclass\\",
+  /* "LogoFile": "SpecPI40_t.png", */
+  "LogoFile": "SpecPI40_t.png",
+  "QualifiersFile": "qualifier-presets.json",
+  "ContentHome": "https://github.com/admin-shell/io/blob/master/README.md",
+  "UseFlyovers": true,
+  "SplashTime": 1000,
+  "InternalBrowser": false,
+  "EclassTwoPass": true,
+  "BackupDir": ".\\backup",
+  "BackupFiles": 10,
+  "RestServerHost": "localhost",
+  "RestServerPort": "1111",
+  "WriteDefaultOptionsFN": null /* "options-written.json" */,
+  "IndirectLoadSave": true,
+  "AccentColors": {},
+  "LoadWithoutPrompt": true,
+  "ShowIdAsIri": false,
+  "VerboseConnect": true,
+  "DefaultStayConnected": true,
+  "DefaultUpdatePeriod": 1000,
+  "StayConnectOptions": "REST-QUEUE", // SIM
+  /* "DefaultConnectRepositoryLocation": "http://localhost:51310", */
+  /* "DefaultConnectRepositoryLocation": "http://admin-shell-io.com:51510", */
+  /* "DefaultConnectRepositoryLocation": "https://admin-shell-io.com:51711", */
+  "DefaultConnectRepositoryLocation": "https://admin-shell-io.com/51711",
+  "MqttPublisherOptions": {
+    "BrokerUrl": "192.168.178.97:1883",
+    "MqttRetain": false,
+    "EnableFirstPublish": true,
+    "FirstTopicAAS": "AAS",
+    "FirstTopicSubmodel": "{aas}/Submodel_{sm}",
+    "EnableEventPublish": true,
+    "EventTopic": "Events/aas/{aas}/sm/{sm}/{path}",
+    "SingleValuePublish": true,
+    "SingleValueFirstTime": true,
+    "SingleValueTopic": "Values/aas/{aas}/sm/{sm}/{path}"
+  },
+  "Remarks": [
+    "This JSON file might contain special settings for debugging purposes of Michael Hoffmeisters setup."
+  ],
+  "PluginPrefer": "ANYUI",
+  "PluginDll": [
+    /*
     {
       "Path": "..\\..\\..\\..\\..\\AasxPluginUaNetServer\\bin\\Debug\\net472\\AasxPluginUaNetServer.dll",
       "Args": [
@@ -86,50 +88,50 @@
       "Args": [],
       "Options": null
     }, */
-        {
-            "Path": "..\\..\\..\\..\\..\\AasxPluginBomStructure\\bin\\Debug\\net472\\AasxPluginBomStructure.dll",
-            "Args": []
-        },
-        {
-            "Path": "..\\..\\..\\..\\..\\AasxPluginExportTable\\bin\\Debug\\net472\\AasxPluginExportTable.dll",
-            "Args": []
-        },
-        {
-            "Path": "..\\..\\..\\..\\..\\AasxPluginWebBrowser\\bin\\x64\\Debug\\net472\\AasxPluginWebBrowser.dll",
-            "Args": []
-        },
-        {
-            "Path": "..\\..\\..\\..\\..\\AasxPluginTechnicalData\\bin\\Debug\\net472\\AasxPluginTechnicalData.dll",
-            "Args": []
-        },
-        {
-            "Path": "..\\..\\..\\..\\..\\AasxPluginMtpViewer\\bin\\Debug\\net472\\AasxPluginMtpViewer.dll",
-            "Args": []
-        },
-        {
-            "Path": "..\\..\\..\\..\\..\\AasxPluginDocumentShelf\\bin\\Debug\\net472\\AasxPluginDocumentShelf.dll",
-            "Args": []
-        },
-        {
-            "Path": "..\\..\\..\\..\\..\\AasxPluginGenericForms\\bin\\Debug\\net472\\AasxPluginGenericForms.dll",
-            "Args": []
-        },
-        {
-            "Path": "..\\..\\..\\..\\..\\AasxPluginImageMap\\bin\\Debug\\net472\\AasxPluginImageMap.dll",
-            "Args": []
-        },
-        {
-            "Path": "..\\..\\..\\..\\..\\AasxPluginKnownSubmodels\\bin\\Debug\\net472\\AasxPluginKnownSubmodels.dll",
-            "Args": []
-        },
-        {
-            "Path": "..\\..\\..\\..\\..\\AasxPluginPlotting\\bin\\Debug\\net472\\AasxPluginPlotting.dll",
-            "Args": []
-        },
-        {
-            "Path": "..\\..\\..\\..\\..\\AasxPluginAdvancedTextEditor\\bin\\Debug\\net472\\AasxPluginAdvancedTextEditor.dll",
-            "Args": []
-        } /*,
+    {
+      "Path": "..\\..\\..\\..\\..\\AasxPluginBomStructure\\bin\\Debug\\net472\\AasxPluginBomStructure.dll",
+      "Args": []
+    },
+    {
+      "Path": "..\\..\\..\\..\\..\\AasxPluginExportTable\\bin\\Debug\\net472\\AasxPluginExportTable.dll",
+      "Args": []
+    },
+    {
+      "Path": "..\\..\\..\\..\\..\\AasxPluginWebBrowser\\bin\\x64\\Debug\\net472\\AasxPluginWebBrowser.dll",
+      "Args": []
+    },
+    {
+      "Path": "..\\..\\..\\..\\..\\AasxPluginTechnicalData\\bin\\Debug\\net472\\AasxPluginTechnicalData.dll",
+      "Args": []
+    },
+    {
+      "Path": "..\\..\\..\\..\\..\\AasxPluginMtpViewer\\bin\\Debug\\net472\\AasxPluginMtpViewer.dll",
+      "Args": []
+    },
+    {
+      "Path": "..\\..\\..\\..\\..\\AasxPluginDocumentShelf\\bin\\Debug\\net472\\AasxPluginDocumentShelf.dll",
+      "Args": []
+    },
+    {
+      "Path": "..\\..\\..\\..\\..\\AasxPluginGenericForms\\bin\\Debug\\net472\\AasxPluginGenericForms.dll",
+      "Args": []
+    },
+    {
+      "Path": "..\\..\\..\\..\\..\\AasxPluginImageMap\\bin\\Debug\\net472\\AasxPluginImageMap.dll",
+      "Args": []
+    },
+    {
+      "Path": "..\\..\\..\\..\\..\\AasxPluginKnownSubmodels\\bin\\Debug\\net472\\AasxPluginKnownSubmodels.dll",
+      "Args": []
+    },
+    {
+      "Path": "..\\..\\..\\..\\..\\AasxPluginPlotting\\bin\\Debug\\net472\\AasxPluginPlotting.dll",
+      "Args": []
+    },
+    {
+      "Path": "..\\..\\..\\..\\..\\AasxPluginAdvancedTextEditor\\bin\\Debug\\net472\\AasxPluginAdvancedTextEditor.dll",
+      "Args": []
+    } /*,
     // Festo specific from here on
     {
       "Path": "..\\..\\..\\..\\..\\..\\..\\AasxFesto\\AasxFesto\\AasxPluginFluiddrawViewer\\bin\\Debug\\AasxPluginFluiddrawViewer.dll",
@@ -140,123 +142,123 @@
       "Args": [] 
     }
     */
-    ],
-    "SecureConnectPresets": [
-        {
-            "Name": "Internet Demo",
-            "Protocol": {
-                "Value": "Azure",
-                "Choices": [
-                    "Unprotected",
-                    "OpenID Connect",
-                    "Azure"
-                ]
-            },
-            "AuthorizationServer": {
-                "Value": "http://auth1.phoenix.com",
-                "Choices": [
-                    "http://auth2.phoenix.com",
-                    "http://auth1.phoenix.com",
-                    "http://auth3.phoenix.com"
-                ]
-            },
-            "AasServer": {
-                "Value": "http://aas2.phoenix.com",
-                "Choices": [
-                    "http://aas3.phoenix.com",
-                    "http://aas2.phoenix.com",
-                    "http://aas1.phoenix.com"
-                ]
-            },
-            "CertificateFile": {
-                "Value": "wieso.txt",
-                "Choices": [
-                    "C:\\FILE1.TXT",
-                    "C:\\FILE2.TXT",
-                    "C:\\FILE3_dsnchdsbcjbdsjhcbdsjhcbjdsbcjhdsbhjcbdshjcjdshjhcbjhdsbcjhcdsjhbcdsbhjcshjdbcjhdsbjcbdshjcbhsjdbcdsbchjdscbhjdsbhcjhdsb.TXT"
-                ]
-            },
-            "Password": {
-                "Value": "sescret",
-                "Choices": [
-                    "geheim",
-                    "hidden",
-                    "Pand0ra"
-                ]
-            }
-        },
-        {
-            "Name": "Only Intranet",
-            "Protocol": {
-                "Value": "Unprotected",
-                "Choices": [
-                    "Unprotected",
-                    "OpenID Connect",
-                    "Azure"
-                ]
-            },
-            "AuthorizationServer": {
-                "Value": "http://auth3.phoenix.com",
-                "Choices": [
-                    "http://auth2.phoenix.com",
-                    "http://auth1.phoenix.com",
-                    "http://auth3.phoenix.com"
-                ]
-            },
-            "AasServer": {
-                "Value": "http://aas1.phoenix.com",
-                "Choices": [
-                    "http://aas3.phoenix.com",
-                    "http://aas2.phoenix.com",
-                    "http://aas1.phoenix.com"
-                ]
-            },
-            "CertificateFile": {
-                "Value": "wieso22.txt",
-                "Choices": [
-                    "C:\\FILE1.TXT",
-                    "C:\\FILE2.TXT",
-                    "C:\\FILE3_dsnchdsbcjbdsjhcbdsjhcbjdsbcjhdsbhjcbdshjcjdshjhcbjhdsbcjhcdsjhbcdsbhjcshjdbcjhdsbjcbdshjcbhsjdbcdsbchjdscbhjdsbhcjhdsb.TXT"
-                ]
-            }
-        }
-    ],
-    "IntegratedConnectPresets": [
-        {
-            "Name": "Empty",
-            "Location": "",
-            "Username": "",
-            "Password": ""
-        },
-        {
-            "Name": "First of admin-shell-io.com",
-            "Location": "http://admin-shell-io.com:51310/server/getaasx/0",
-            "Username": "",
-            "Password": "",
-            "StayConnected": true
-        },
-        {
-            "Name": "DEMO",
-            "Location": "http://demo/",
-            "Username": "Foo",
-            "Password": "Bar",
-            "AutoClose": false
-        },
-        {
-            "Name": "Long loading of admin-shell-io.com",
-            "Location": "http://admin-shell-io.com:51410/server/getaasx/3",
-            "Username": "",
-            "Password": "",
-            "StayConnected": true,
-            "AutoClose": false
-        },
-        {
-            "Name": "Latest testing",
-            "Location": "http://admin-shell-io.com:52001/server/getaasx/0",
-            "Username": "",
-            "Password": "",
-            "StayConnected": true,
-            "AutoClose": false
-        }
-    ]
+  ],
+  "SecureConnectPresets": [
+    {
+      "Name": "Internet Demo",
+      "Protocol": {
+        "Value": "Azure",
+        "Choices": [
+          "Unprotected",
+          "OpenID Connect",
+          "Azure"
+        ]
+      },
+      "AuthorizationServer": {
+        "Value": "http://auth1.phoenix.com",
+        "Choices": [
+          "http://auth2.phoenix.com",
+          "http://auth1.phoenix.com",
+          "http://auth3.phoenix.com"
+        ]
+      },
+      "AasServer": {
+        "Value": "http://aas2.phoenix.com",
+        "Choices": [
+          "http://aas3.phoenix.com",
+          "http://aas2.phoenix.com",
+          "http://aas1.phoenix.com"
+        ]
+      },
+      "CertificateFile": {
+        "Value": "wieso.txt",
+        "Choices": [
+          "C:\\FILE1.TXT",
+          "C:\\FILE2.TXT",
+          "C:\\FILE3_dsnchdsbcjbdsjhcbdsjhcbjdsbcjhdsbhjcbdshjcjdshjhcbjhdsbcjhcdsjhbcdsbhjcshjdbcjhdsbjcbdshjcbhsjdbcdsbchjdscbhjdsbhcjhdsb.TXT"
+        ]
+      },
+      "Password": {
+        "Value": "sescret",
+        "Choices": [
+          "geheim",
+          "hidden",
+          "Pand0ra"
+        ]
+      }
+    },
+    {
+      "Name": "Only Intranet",
+      "Protocol": {
+        "Value": "Unprotected",
+        "Choices": [
+          "Unprotected",
+          "OpenID Connect",
+          "Azure"
+        ]
+      },
+      "AuthorizationServer": {
+        "Value": "http://auth3.phoenix.com",
+        "Choices": [
+          "http://auth2.phoenix.com",
+          "http://auth1.phoenix.com",
+          "http://auth3.phoenix.com"
+        ]
+      },
+      "AasServer": {
+        "Value": "http://aas1.phoenix.com",
+        "Choices": [
+          "http://aas3.phoenix.com",
+          "http://aas2.phoenix.com",
+          "http://aas1.phoenix.com"
+        ]
+      },
+      "CertificateFile": {
+        "Value": "wieso22.txt",
+        "Choices": [
+          "C:\\FILE1.TXT",
+          "C:\\FILE2.TXT",
+          "C:\\FILE3_dsnchdsbcjbdsjhcbdsjhcbjdsbcjhdsbhjcbdshjcjdshjhcbjhdsbcjhcdsjhbcdsbhjcshjdbcjhdsbjcbdshjcbhsjdbcdsbchjdscbhjdsbhcjhdsb.TXT"
+        ]
+      }
+    }
+  ],
+  "IntegratedConnectPresets": [
+    {
+      "Name": "Empty",
+      "Location": "",
+      "Username": "",
+      "Password": ""
+    },
+    {
+      "Name": "First of admin-shell-io.com",
+      "Location": "http://admin-shell-io.com:51310/server/getaasx/0",
+      "Username": "",
+      "Password": "",
+      "StayConnected": true
+    },
+    {
+      "Name": "DEMO",
+      "Location": "http://demo/",
+      "Username": "Foo",
+      "Password": "Bar",
+      "AutoClose": false
+    },
+    {
+      "Name": "Long loading of admin-shell-io.com",
+      "Location": "http://admin-shell-io.com:51410/server/getaasx/3",
+      "Username": "",
+      "Password": "",
+      "StayConnected": true,
+      "AutoClose": false
+    },
+    {
+      "Name": "Latest testing",
+      "Location": "http://admin-shell-io.com:52001/server/getaasx/0",
+      "Username": "",
+      "Password": "",
+      "StayConnected": true,
+      "AutoClose": false
+    }
+  ]
 }

--- a/src/AasxPackageLogic/AasxPackageLogic.csproj
+++ b/src/AasxPackageLogic/AasxPackageLogic.csproj
@@ -7,6 +7,9 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+  <PropertyGroup>
     <!-- Used to access the XML summary for Options.cs -->
     <!-- <GenerateDocumentationFile>true</GenerateDocumentationFile> -->
   </PropertyGroup>

--- a/src/AasxPackageLogic/DispEditHelperCopyPaste.cs
+++ b/src/AasxPackageLogic/DispEditHelperCopyPaste.cs
@@ -540,9 +540,8 @@ namespace AasxPackageLogic
                             nextBusObj = smw2.submodelElement;
                             var createAtIndex = -1;
 
-                            // make this unique (e.g. for event following)
-                            if (cpb.Duplicate || cpb.ExternalSource)
-                                this.MakeNewReferableUnique(smw2.submodelElement);
+                            // make this unique later (e.g. for event following)
+                            var makeUnique = (cpb.Duplicate || cpb.ExternalSource);
 
                             // insertation depends on parent container
                             if (buttonNdx == 2)
@@ -551,23 +550,23 @@ namespace AasxPackageLogic
                                 smw2.submodelElement.parent = parentContainer;
 
                                 if (parentContainer is AdminShell.Submodel pcsm && wrapper != null)
-                                    createAtIndex = this.AddElementInListBefore<AdminShell.SubmodelElementWrapper>(
-                                        pcsm.submodelElements, smw2, wrapper);
+                                    createAtIndex = this.AddElementInSmwListBefore<AdminShell.SubmodelElement>(
+                                        pcsm.submodelElements, smw2, wrapper, makeUnique);
 
                                 if (parentContainer is AdminShell.SubmodelElementCollection pcsmc &&
                                         wrapper != null)
-                                    createAtIndex = this.AddElementInListBefore<AdminShell.SubmodelElementWrapper>(
-                                        pcsmc.value, smw2, wrapper);
+                                    createAtIndex = this.AddElementInSmwListBefore<AdminShell.SubmodelElement>(
+                                        pcsmc.value, smw2, wrapper, makeUnique);
 
                                 if (parentContainer is AdminShell.Entity pcent &&
                                         wrapper != null)
-                                    createAtIndex = this.AddElementInListBefore<AdminShell.SubmodelElementWrapper>(
-                                        pcent.statements, smw2, wrapper);
+                                    createAtIndex = this.AddElementInSmwListBefore<AdminShell.SubmodelElement>(
+                                        pcent.statements, smw2, wrapper, makeUnique);
 
                                 if (parentContainer is AdminShell.AnnotatedRelationshipElement pcarel &&
                                         wrapper != null)
-                                    createAtIndex = this.AddElementInListBefore<AdminShell.SubmodelElementWrapper>(
-                                        pcarel.annotations, smw2, wrapper);
+                                    createAtIndex = this.AddElementInSmwListBefore<AdminShell.DataElement>(
+                                        pcarel.annotations, smw2, wrapper, makeUnique);
 
                                 // TODO (Michael Hoffmeister, 2020-08-01): Operation complete?
                                 if (parentContainer is AdminShell.Operation pcop && wrapper?.submodelElement != null)
@@ -591,22 +590,22 @@ namespace AasxPackageLogic
                                 smw2.submodelElement.parent = parentContainer;
 
                                 if (parentContainer is AdminShell.Submodel pcsm && wrapper != null)
-                                    createAtIndex = this.AddElementInListAfter<AdminShell.SubmodelElementWrapper>(
-                                        pcsm.submodelElements, smw2, wrapper);
+                                    createAtIndex = this.AddElementInSmwListAfter<AdminShell.SubmodelElement>(
+                                        pcsm.submodelElements, smw2, wrapper, makeUnique);
 
                                 if (parentContainer is AdminShell.SubmodelElementCollection pcsmc &&
                                         wrapper != null)
-                                    createAtIndex = this.AddElementInListAfter<AdminShell.SubmodelElementWrapper>(
-                                        pcsmc.value, smw2, wrapper);
+                                    createAtIndex = this.AddElementInSmwListAfter<AdminShell.SubmodelElement>(
+                                        pcsmc.value, smw2, wrapper, makeUnique);
 
                                 if (parentContainer is AdminShell.Entity pcent && wrapper != null)
-                                    createAtIndex = this.AddElementInListAfter<AdminShell.SubmodelElementWrapper>(
-                                        pcent.statements, smw2, wrapper);
+                                    createAtIndex = this.AddElementInSmwListAfter<AdminShell.SubmodelElement>(
+                                        pcent.statements, smw2, wrapper, makeUnique);
 
                                 if (parentContainer is AdminShell.AnnotatedRelationshipElement pcarel &&
                                         wrapper != null)
-                                    createAtIndex = this.AddElementInListAfter<AdminShell.SubmodelElementWrapper>(
-                                        pcarel.annotations, smw2, wrapper);
+                                    createAtIndex = this.AddElementInSmwListAfter<AdminShell.DataElement>(
+                                        pcarel.annotations, smw2, wrapper, makeUnique);
 
                                 // TODO (Michael Hoffmeister, 2020-08-01): Operation complete?
                                 if (parentContainer is AdminShell.Operation pcop && wrapper?.submodelElement != null)
@@ -629,7 +628,19 @@ namespace AasxPackageLogic
                                 // aprent set automatically
                                 // TODO (MIHO, 2021-08-18): createAtIndex missing here
                                 if (sme is AdminShell.IEnumerateChildren smeec)
+                                {
+                                    if (makeUnique)
+                                    {
+                                        var found = false;
+                                        foreach (var ch in smeec.EnumerateChildren())
+                                            if (ch?.submodelElement?.idShort?.Trim() == smw2?.submodelElement?.idShort?.Trim())
+                                                found = true;
+                                        if (found)
+                                            this.MakeNewReferableUnique(smw2?.submodelElement);
+                                    }
+
                                     smeec.AddChild(smw2, item.Placement);
+                                }
                             }
 
                             // emit event

--- a/src/AasxPackageLogic/DispEditHelperEntities.cs
+++ b/src/AasxPackageLogic/DispEditHelperEntities.cs
@@ -1514,7 +1514,7 @@ namespace AasxPackageLogic
                         return new AnyUiLambdaActionNone();
                     });
 
-                // create ConceptDescriptions for ECLASS
+                // create ConceptDescriptions 
                 var targets = new List<AdminShell.SubmodelElement>();
                 this.IdentifyTargetsForEclassImportOfCDs(
                     env, AdminShell.SubmodelElementWrapper.ListOfWrappersToListOfElems(submodel.submodelElements),
@@ -1528,21 +1528,34 @@ namespace AasxPackageLogic
                                 return submodel.submodelElements != null && submodel.submodelElements.Count > 0  &&
                                     targets.Count > 0;
                             },
-                            "Consider importing ConceptDescriptions from ECLASS for existing SubmodelElements.",
+                            "Consider creating ConceptDescriptions from ECLASS or from existing SubmodelElements.",
                             severityLevel: HintCheck.Severity.Notice)
                 });
                 this.AddAction(
-                    stack, "ConceptDescriptions from ECLASS:",
-                    new[] { "Import missing" },
-                    repo,
-                    (buttonNdx) =>
+                    stack, "ConceptDescriptions (missing):",
+                    new[] { "Create \U0001f844 ECLASS", "Create \U0001f844 SMEs" },
+                    toolTips: new[] { "Create missing CDs searching from ECLASS", "Create missing CDs from semanticId of used SMEs" },
+                    repo: repo,
+                    action: (buttonNdx) =>
                     {
                         if (buttonNdx == 0)
                         {
+                            // from ECLASS
                             // ReSharper disable RedundantCast
                             this.ImportEclassCDsForTargets(
                                 env, (smref != null) ? (object)smref : (object)submodel, targets);
                             // ReSharper enable RedundantCast
+                        }
+
+                        if (buttonNdx == 1)
+                        {
+                            // from SMEs
+                            var res = this.ImportCDsFromSmSme(env, submodel, recurseChilds: true, repairSemIds: true);
+                            Log.Singleton.Info(StoredPrint.Color.Blue, $"Added {res.Item3} CDs to the environment, " +
+                                $"while {res.Item1} invalid semanticIds were present and " +
+                                $"{res.Item2} CDs were already existing.");
+                            return new AnyUiLambdaActionRedrawAllElements(
+                                        submodel, isExpanded: true);
                         }
 
                         return new AnyUiLambdaActionNone();
@@ -2223,11 +2236,28 @@ namespace AasxPackageLogic
                                 "the SubmodelElement to an ConceptDescription.",
                             severityLevel: HintCheck.Severity.Notice)
                     });
+
+                var actionDef = new List<string>(new[] {
+                    "Use existing", "Create empty", "Create \U0001f844 ECLASS",
+                    "Create \U0001f844 this"});
+
+                var toolTipDef = new List<string>(new[] {
+                    "Assign SME to existing CD", "Create empty CD with new id and assign to SME",
+                    "Create CD with existing id from ECLASS and assign to SME",
+                    "Create CD from data of this SME"});
+
+                if (sme is AdminShell.IEnumerateChildren)
+                {
+                    actionDef.Add("Create \U0001f844 all");
+                    toolTipDef.Add("Create CDs from data of this SME and all subsequent children.");
+                }
+
                 this.AddAction(
                     stack, "Concept Description:",
-                    new[] { "Assign to existing CD", "Create empty and assign", "Create and assign from ECLASS" },
-                    repo,
-                    (buttonNdx) =>
+                    actionDef.ToArray(),
+                    toolTips: toolTipDef.ToArray(),
+                    repo: repo,
+                    action: (buttonNdx) =>
                     {
                         if (buttonNdx == 0)
                         {
@@ -2291,6 +2321,7 @@ namespace AasxPackageLogic
 
                         if (buttonNdx == 2)
                         {
+                            // ECLASS
                             // feature available
                             if (Options.Curr.EclassDir == null)
                             {
@@ -2343,6 +2374,35 @@ namespace AasxPackageLogic
 
                             // redraw
                             return new AnyUiLambdaActionRedrawAllElements(nextFocus: sme);
+                        }
+
+                        if (buttonNdx == 3)
+                        {
+                            var res = this.ImportCDsFromSmSme(env, sme, recurseChilds: false, repairSemIds: true);
+                            if (res.Item1 > 0)
+                            {
+                                Log.Singleton.Error("Cannot create CD because no valid semanticId is present " +
+                                    "in SME.");
+                                return new AnyUiLambdaActionNone();
+                            }
+                            if (res.Item2 > 0)
+                            {
+                                Log.Singleton.Error("Cannot create CD because CD with semanticId is already " +
+                                    "present in AAS environment.");
+                                return new AnyUiLambdaActionNone();
+                            }
+                            Log.Singleton.Info(StoredPrint.Color.Blue, $"Added {res.Item3} CDs to the environment.");
+
+                            // redraw
+                            return new AnyUiLambdaActionRedrawAllElements(nextFocus: sme);
+                        }
+
+                        if (buttonNdx == 4)
+                        {
+                            var res = this.ImportCDsFromSmSme(env, sme, recurseChilds: true, repairSemIds: true);
+                            Log.Singleton.Info(StoredPrint.Color.Blue, $"Added {res.Item3} CDs to the environment, " +
+                                $"while {res.Item1} invalid semanticIds were present and " +
+                                $"{res.Item2} CDs were already existing.");
                         }
 
                         return new AnyUiLambdaActionNone();

--- a/src/AasxPackageLogic/PackageCentral/PackageContainerBuffered.cs
+++ b/src/AasxPackageLogic/PackageCentral/PackageContainerBuffered.cs
@@ -79,6 +79,13 @@ namespace AasxPackageLogic.PackageCentral
             // we do it not caring on any errors
             try
             {
+                // make sure the backup dir exists
+                if (!Directory.Exists(backupDir))
+                {
+                    Directory.CreateDirectory(backupDir);
+                    Log.Singleton.Info(StoredPrint.Color.Blue, "Created backup directory : " + backupDir);
+                }
+
                 // get index in form
                 if (BackupIndex == 0)
                 {

--- a/src/AasxPluginAdvancedTextEditor/AasxPluginAdvancedTextEditor.csproj
+++ b/src/AasxPluginAdvancedTextEditor/AasxPluginAdvancedTextEditor.csproj
@@ -6,6 +6,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AvalonEdit" Version="6.0.1" />

--- a/src/AasxPluginBomStructure/AasxPluginBomStructure.csproj
+++ b/src/AasxPluginBomStructure/AasxPluginBomStructure.csproj
@@ -6,6 +6,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <None Update="AasxPluginBomStructure.options.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/AasxPluginDocumentShelf/AasxPluginDocumentShelf.csproj
+++ b/src/AasxPluginDocumentShelf/AasxPluginDocumentShelf.csproj
@@ -6,6 +6,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>false</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Resources\**" />
     <EmbeddedResource Remove="Resources\**" />

--- a/src/AasxPluginExportTable/AasxPluginExportTable.csproj
+++ b/src/AasxPluginExportTable/AasxPluginExportTable.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <None Update="AasxPluginExportTable.plugin">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/AasxPluginGenericForms/AasxPluginGenericForms.csproj
+++ b/src/AasxPluginGenericForms/AasxPluginGenericForms.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>false</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <None Update="AasxPluginGenericForms.plugin">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/AasxPluginImageMap/AasxPluginImageMap.csproj
+++ b/src/AasxPluginImageMap/AasxPluginImageMap.csproj
@@ -6,6 +6,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>false</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AasxIntegrationBaseGdi\AasxIntegrationBaseGdi.csproj" />

--- a/src/AasxPluginKnownSubmodels/AasxPluginKnownSubmodels.csproj
+++ b/src/AasxPluginKnownSubmodels/AasxPluginKnownSubmodels.csproj
@@ -6,6 +6,9 @@
     <UseWindowsForms>false</UseWindowsForms>
     <UseWPF>false</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/src/AasxPluginMtpViewer/AasxPluginMtpViewer.csproj
+++ b/src/AasxPluginMtpViewer/AasxPluginMtpViewer.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <None Update="AasxPluginMtpViewer.options.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/AasxPluginPlotting/AasxPluginPlotting.csproj
+++ b/src/AasxPluginPlotting/AasxPluginPlotting.csproj
@@ -6,6 +6,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AasxIntegrationBaseWpf\AasxIntegrationBaseWpf.csproj" />

--- a/src/AasxPluginSmdExporter/AasxPluginSmdExporter.csproj
+++ b/src/AasxPluginSmdExporter/AasxPluginSmdExporter.csproj
@@ -5,8 +5,11 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <UseWPF>true</UseWPF>
     </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
         <None Update="AasxPluginSmdExporter.plugin">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/src/AasxPluginTechnicalData/AasxPluginTechnicalData.csproj
+++ b/src/AasxPluginTechnicalData/AasxPluginTechnicalData.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>false</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Printing" />
   </ItemGroup>

--- a/src/AasxPluginUaNetClient/AasxPluginUaNetClient.csproj
+++ b/src/AasxPluginUaNetClient/AasxPluginUaNetClient.csproj
@@ -6,6 +6,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <None Update="AasxPluginUaNetClient.plugin">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/AasxPluginUaNetServer/AasxPluginUaNetServer.csproj
+++ b/src/AasxPluginUaNetServer/AasxPluginUaNetServer.csproj
@@ -6,6 +6,9 @@
     <!-- see: https://stackoverflow.com/questions/58085571/nuget-pkg-dlls-missing-from-build-folder-in-net-standard-dll-project-dlls-are -->
       <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
   <!--
       (mristin, 2020-11-25)

--- a/src/AasxPluginWebBrowser/AasxPluginWebBrowser.csproj
+++ b/src/AasxPluginWebBrowser/AasxPluginWebBrowser.csproj
@@ -13,6 +13,9 @@
 	<Platforms>x64</Platforms>
 	<Platform>x64</Platform>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <None Update="AasxPluginWebBrowser.plugin">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
+++ b/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
@@ -6,6 +6,9 @@
     <LangVersion>8.0</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <None Remove="Resources\ZveiContactInformationV10.json" />
     <None Remove="Resources\ZveiDigitalTypeplate.json" />

--- a/src/AasxPredefinedConcepts/ExportPredefinedConcepts.cs
+++ b/src/AasxPredefinedConcepts/ExportPredefinedConcepts.cs
@@ -48,7 +48,8 @@ namespace AasxPredefinedConcepts
                     if (sme.semanticId == null)
                         continue;
 
-                    var cd = env.FindConceptDescription(sme.semanticId.GetAsExactlyOneKey());
+                    var cd = env.FindConceptDescription(
+                        sme.semanticId.GetAsExactlyOneKey(), AdminShell.Key.MatchMode.Identification);
                     if (cd == null)
                         continue;
 

--- a/src/AasxRestConsoleServer/AasxRestConsoleServer.csproj
+++ b/src/AasxRestConsoleServer/AasxRestConsoleServer.csproj
@@ -4,6 +4,9 @@
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AasxRestServerLibrary\AasxRestServerLibrary.csproj" />

--- a/src/AasxRestServerLibrary/AasxHttpContextHelper.cs
+++ b/src/AasxRestServerLibrary/AasxHttpContextHelper.cs
@@ -556,7 +556,7 @@ namespace AasxRestServerLibrary
             }
             context.Server.Logger.Debug(
                 $"Putting AdministrationShell with idShort {aas.idShort ?? "--"} and " +
-                $"id {aas.identification.ToString() }");
+                $"id {aas.identification.ToString()}");
             var existingAas = this.Package.AasEnv.FindAAS(aas.identification);
             if (existingAas != null)
                 this.Package.AasEnv.AdministrationShells.Remove(existingAas);
@@ -803,7 +803,7 @@ namespace AasxRestServerLibrary
             // add Submodel
             context.Server.Logger.Debug(
                 $"Adding Submodel with idShort {submodel.idShort ?? "--"} and " +
-                $"id {submodel.identification?.ToString() }");
+                $"id {submodel.identification?.ToString()}");
             var existingSm = this.Package.AasEnv.FindSubmodel(submodel.identification);
             if (existingSm != null)
                 this.Package.AasEnv.Submodels.Remove(existingSm);
@@ -1595,7 +1595,7 @@ namespace AasxRestServerLibrary
             // add Submodel
             context.Server.Logger.Debug(
                 $"Adding ConceptDescription with idShort {cd.idShort ?? "--"} and " +
-                $"id {cd.identification.ToString() }");
+                $"id {cd.identification.ToString()}");
             var existingCd = this.Package.AasEnv.FindConceptDescription(cd.identification);
             if (existingCd != null)
                 this.Package.AasEnv.ConceptDescriptions.Remove(existingCd);

--- a/src/AasxRestServerLibrary/AasxRestServerLibrary.csproj
+++ b/src/AasxRestServerLibrary/AasxRestServerLibrary.csproj
@@ -4,6 +4,9 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />

--- a/src/AasxSignature/AasxSignature.csproj
+++ b/src/AasxSignature/AasxSignature.csproj
@@ -8,6 +8,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />

--- a/src/AasxToolkit.Tests/AasxToolkit.Tests.csproj
+++ b/src/AasxToolkit.Tests/AasxToolkit.Tests.csproj
@@ -4,6 +4,9 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxToolkit\AasxToolkit.csproj" />
   </ItemGroup>

--- a/src/AasxToolkit/AasxToolkit.csproj
+++ b/src/AasxToolkit/AasxToolkit.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <None Update="data\CopyExternalData.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/AasxUANodesetImExport/AasxUANodesetImExport.csproj
+++ b/src/AasxUANodesetImExport/AasxUANodesetImExport.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
   </ItemGroup>

--- a/src/AasxUaNetConsoleServer/AasxUaNetConsoleServer.csproj
+++ b/src/AasxUaNetConsoleServer/AasxUaNetConsoleServer.csproj
@@ -4,6 +4,9 @@
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <Resource Include="LICENSE.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/AasxUaNetServer/AasxUaNetServer.csproj
+++ b/src/AasxUaNetServer/AasxUaNetServer.csproj
@@ -5,6 +5,9 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.360.33" />

--- a/src/AasxWpfControlLibrary/AasxWpfControlLibrary.csproj
+++ b/src/AasxWpfControlLibrary/AasxWpfControlLibrary.csproj
@@ -6,6 +6,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationFramework.Aero2" />
     <Reference Include="ReachFramework" />

--- a/src/AnyUi/AnyUi.csproj
+++ b/src/AnyUi/AnyUi.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Remove="LICENSE.txt" />

--- a/src/BlazorUI/BlazorUI.csproj
+++ b/src/BlazorUI/BlazorUI.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>false</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="wwwroot\_content\**" />

--- a/src/CheckFormat.ps1
+++ b/src/CheckFormat.ps1
@@ -20,7 +20,20 @@ function Main
     $artefactsDir = CreateAndGetArtefactsDir
 
     $reportPath = Join-Path $artefactsDir "dotnet-format-report.json"
-    dotnet format --check --report $reportPath --exclude "**/DocTest*.cs"
+    
+    # MIHO: dotnet format seems to changed --check with --verify-no-changes
+	# therefore try to detect
+	$checkswitch = "--check"
+	$fmthelp = dotnet format --help | Out-String
+	if ($fmthelp.Contains("--verify-no-changes")) 
+	{		
+		$checkswitch = "--verify-no-changes"
+	}
+		
+	Write-Host "Using dotnet format switch: $checkswitch"
+
+    dotnet format $checkswitch --report $reportPath --exclude "**/DocTest*.cs"
+        
     $formatReport = Get-Content $reportPath |ConvertFrom-Json
     if ($formatReport.Count -ge 1)
     {

--- a/src/MsaglWpfControl/MsaglWpfControl.csproj
+++ b/src/MsaglWpfControl/MsaglWpfControl.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="netstandard" />
   </ItemGroup>

--- a/src/SSIExtension/SSIExtension.csproj
+++ b/src/SSIExtension/SSIExtension.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="5.0.0" />

--- a/src/UIComponents.Flags.Blazor/UIComponents.Flags.Blazor.csproj
+++ b/src/UIComponents.Flags.Blazor/UIComponents.Flags.Blazor.csproj
@@ -5,8 +5,11 @@
 	<IsPackable>true</IsPackable>
     <!-- <RazorLangVersion>3.0</RazorLangVersion> -->
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
-	<ItemGroup>
+  <ItemGroup>
 		<SupportedPlatform Include="browser" />
 	</ItemGroup>
 

--- a/src/WpfMtpControl/WpfMtpControl.csproj
+++ b/src/WpfMtpControl/WpfMtpControl.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxCsharpLibrary\AasxCsharpLibrary.csproj" />
     <ProjectReference Include="..\AasxIntegrationBaseWpf\AasxIntegrationBaseWpf.csproj" />

--- a/src/WpfMtpVisuViewer/WpfMtpVisuViewer.csproj
+++ b/src/WpfMtpVisuViewer/WpfMtpVisuViewer.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <None Update="WpfMtpVisuViewer.options.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/WpfXamlTool/WpfXamlTool.csproj
+++ b/src/WpfXamlTool/WpfXamlTool.csproj
@@ -6,6 +6,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
   <ItemGroup>
     <Resource Include="LICENSE.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/es6numberserializer/es6numberserializer.csproj
+++ b/src/es6numberserializer/es6numberserializer.csproj
@@ -4,5 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
 </Project>

--- a/src/jsoncanonicalizer/jsoncanonicalizer.csproj
+++ b/src/jsoncanonicalizer/jsoncanonicalizer.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\es6numberserializer\es6numberserializer.csproj" />


### PR DESCRIPTION
Starting from a discussion with BaSys, some fixes and enhancements
were motivated. These are:

* fix: "Generate" for AAS was not working
* fix: fix: when BackupDir does not exist, create it
* fix: when copying SME, make unique only if required
* enhance: add CDs based on pure SMEs;
  create CDs for Sm, SME also recursively
* fix: export predefined concept is handling semanticIds
  more flexible

This branch/PR was created by  applying diff from MIHO/EnhanceForBasys.