### PR TITLE
Fix json export and adapt schema exporter

### DIFF
--- a/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
+++ b/src/AasxPackageExplorer/MainWindow.CommandBindings.cs
@@ -2340,10 +2340,15 @@ namespace AasxPackageExplorer
             if (res == true)
             {
                 RememberForInitialDirectory(dlg.FileName);
-                using (var s = new StreamWriter(dlg.FileName))
+                using (var streamWriter = new StreamWriter(dlg.FileName))
                 {
-                    var json = JsonConvert.SerializeObject(obj, Formatting.Indented);
-                    s.WriteLine(json);
+                    var serializerSettings = new JsonSerializerSettings();
+                    serializerSettings.NullValueHandling = NullValueHandling.Ignore;
+                    serializerSettings.Formatting = Formatting.Indented;
+                    serializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+
+                    var json = JsonConvert.SerializeObject(obj, serializerSettings);
+                    streamWriter.WriteLine(json);
                 }
             }
             if (Options.Curr.UseFlyovers) this.CloseFlyover();

--- a/src/AasxSchemaExport.Tests/TestJsonSchemaExport.cs
+++ b/src/AasxSchemaExport.Tests/TestJsonSchemaExport.cs
@@ -66,7 +66,7 @@ namespace AasxSchemaExport.Tests
             var definitionRef = FindObjectInArrayWithProperty(
                 schema.SelectToken($"{Tokens.AllOf}"),
                 $"{Tokens.Ref}",
-                "aas.json#/definitions/Submodel");
+                $"{Constants.MetaModelSchemaUrl}{Constants.MetaModelSubmodelDefinitionPath}");
 
             Assert.NotNull(
                 definitionRef,

--- a/src/AasxSchemaExport.Tests/TestJsonSchemaExport.cs
+++ b/src/AasxSchemaExport.Tests/TestJsonSchemaExport.cs
@@ -59,17 +59,6 @@ namespace AasxSchemaExport.Tests
         }
 
         [Test]
-        public void Test_unevaluated_properties_should_be_set_to_false()
-        {
-            var schema = ExportSchema();
-
-            Assert.AreEqual(schema.GetValue<bool>(
-                "unevaluatedProperties"),
-                false,
-                "The value of unevaluatedProperties must be set to false.");
-        }
-
-        [Test]
         public void Test_submodel_reference()
         {
             var schema = ExportSchema();

--- a/src/AasxSchemaExport/Constants.cs
+++ b/src/AasxSchemaExport/Constants.cs
@@ -1,0 +1,17 @@
+﻿/*
+Copyright (c) 2022 PHOENIX CONTACT GmbH & Co. KG <info@phoenixcontact.de>
+
+This source code is licensed under the Apache License 2.0 (see LICENSE.txt).
+
+This source code may use other Open Source software components (see LICENSE.txt).
+*/
+
+namespace AasxSchemaExport
+{
+    public static class Constants
+    {
+        public static string JsonSchemaDraftVersion = "https://json-schema.org/draft/2019-09/schema";
+        public static string MetaModelSchemaUrl = "https://admin-shell-io.com/schemas/v2/aas.json";
+        public static string MetaModelSubmodelDefinitionPath = "#/definitions/Submodel";
+    }
+}

--- a/src/AasxSchemaExport/SubmodelTemplateJsonSchemaExporterV20.cs
+++ b/src/AasxSchemaExport/SubmodelTemplateJsonSchemaExporterV20.cs
@@ -56,7 +56,6 @@ namespace AasxSchemaExport
             schema[Tokens.Schema] = "https://json-schema.org/draft/2019-09/schema";
             schema[Tokens.Title] = $"AssetAdministrationShell{submodel.idShort}";
             schema[Tokens.Type] = "object";
-            schema[Tokens.UnevaluatedProperties] = false;
             schema[Tokens.AllOf] = new JArray();
             schema[Tokens.Definitions] = new JObject();
         }

--- a/src/AasxSchemaExport/SubmodelTemplateJsonSchemaExporterV20.cs
+++ b/src/AasxSchemaExport/SubmodelTemplateJsonSchemaExporterV20.cs
@@ -16,9 +16,6 @@ namespace AasxSchemaExport
 {
     public class SubmodelTemplateJsonSchemaExporterV20 : ISchemaExporter
     {
-        private const string MetaModelSchemaUrl = "https://admin-shell-io.com/schemas/v2/aas.json";
-        private const string MetaModelSubmodelDefinitionPath = "#/definitions/Submodel";
-
         private List<Func<SubmodelElementDefinitionContext, bool>> _submodelElementDefinitionSuppliers;
 
         public string ExportSchema(AdminShellV20.Submodel submodel)
@@ -53,7 +50,7 @@ namespace AasxSchemaExport
 
         private void AddRootData(JObject schema, AdminShellV20.Submodel submodel)
         {
-            schema[Tokens.Schema] = "https://json-schema.org/draft/2019-09/schema";
+            schema[Tokens.Schema] = Constants.JsonSchemaDraftVersion;
             schema[Tokens.Title] = $"AssetAdministrationShell{submodel.idShort}";
             schema[Tokens.Type] = "object";
             schema[Tokens.AllOf] = new JArray();
@@ -62,7 +59,7 @@ namespace AasxSchemaExport
 
         private void AddSubmodelReference(JObject schema)
         {
-            var reference = $"{MetaModelSchemaUrl}{MetaModelSubmodelDefinitionPath}";
+            var reference = $"{Constants.MetaModelSchemaUrl}{Constants.MetaModelSubmodelDefinitionPath}";
             AddReferenceToArray(schema, GetRootAllOf, reference);
         }
 
@@ -102,7 +99,7 @@ namespace AasxSchemaExport
 
             var targetAllOf = SelectToken<JArray>(
                 schema,
-                $"$.{Tokens.Definitions}.{Tokens.Elements}.properties.submodelElements.allOf");
+                $"$.{Tokens.Definitions}.{Tokens.Elements}.{Tokens.Properties}.{Tokens.SubmodelElements}.{Tokens.AllOf}");
             var submodelElements = submodel.submodelElements.Select(item => item.submodelElement);
 
             AddDefinitionsForSubmodelElements(schema, targetAllOf, submodelElements);


### PR DESCRIPTION
The current json exporter serializes properties with value
null. Optional properties with the value null must be ignored. 

* Fix the problem with the null values (json exporter)
* Refactor and fixup the json schema exporter