### PR TITLE
Aw/issue680 fix

### DIFF
--- a/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
+++ b/src/AasxCsharpLibrary/AdminShellPackageEnv.cs
@@ -382,12 +382,10 @@ namespace AdminShellNS
                 PackagePart originPart = null;
                 var xs = package.GetRelationshipsByType(
                     "http://www.admin-shell.io/aasx/relationships/aasx-origin");
-                foreach (var x in xs)
-                    if (x.SourceUri.ToString() == "/")
-                    {
+                foreach (var x in xs) {
                         originPart = package.GetPart(x.TargetUri);
                         break;
-                    }
+                }
 
                 if (originPart == null)
                     throw (new Exception("Unable to find AASX origin. Aborting!"));
@@ -397,7 +395,8 @@ namespace AdminShellNS
                 xs = originPart.GetRelationshipsByType("http://www.admin-shell.io/aasx/relationships/aas-spec");
                 foreach (var x in xs)
                 {
-                    specPart = package.GetPart(x.TargetUri);
+                    var absoluteURI = PackUriHelper.ResolvePartUri(originPart.Uri, x.TargetUri);
+                    specPart = package.GetPart(absoluteURI);
                     break;
                 }
 

--- a/src/AasxCsharpLibrary/Extensions/ExtendReference.cs
+++ b/src/AasxCsharpLibrary/Extensions/ExtendReference.cs
@@ -193,7 +193,8 @@ namespace Extensions
 
         public static string GetAsIdentifier(this IReference reference)
         {
-            if (reference.Type == ReferenceTypes.ExternalReference) // Applying only to Global Reference, based on older implementation, TODO:Make it Generic
+
+            if (reference != null && reference.Type == ReferenceTypes.ExternalReference) // Applying only to Global Reference, based on older implementation, TODO:Make it Generic
             {
                 if (reference.Keys == null || reference.Keys.Count < 1)
                 {

--- a/src/AasxPackageLogic/DispEditHelperEntities.cs
+++ b/src/AasxPackageLogic/DispEditHelperEntities.cs
@@ -65,6 +65,19 @@ namespace AasxPackageLogic
                     "found on its name plate. " +
                     "This  attribute  is  required  as  soon  as  the  AAS  is exchanged via partners in " +
                     "the life cycle of the asset.",
+                    severityLevel: HintCheck.Severity.High),
+                new HintCheck(
+                    () =>
+                    {
+                        int count = 0;
+                        foreach(var aas in env.AssetAdministrationShells)
+                        {
+                            if(aas.AssetInformation.GlobalAssetId == asset.GlobalAssetId)
+                                count++;
+                        }
+                        return (count>=2?true:false);
+                    },
+                    "It is not allowed to have duplicate GlobalAssetIds in the same file. This will break functionality and we strongly encoure to make the Id unique!",
                     severityLevel: HintCheck.Severity.High)
             });
 

--- a/src/AasxPackageLogic/DispEditHelperEntities.cs
+++ b/src/AasxPackageLogic/DispEditHelperEntities.cs
@@ -1454,7 +1454,7 @@ namespace AasxPackageLogic
 
             // Identifiable
             this.DisplayOrEditEntityIdentifiable(
-                stack, aas,
+                stack, env, aas,
                 Options.Curr.TemplateIdAas,
                 null);
 
@@ -1967,7 +1967,7 @@ namespace AasxPackageLogic
 
                 // Identifiable
                 this.DisplayOrEditEntityIdentifiable(
-                    stack, submodel,
+                    stack, env, submodel,
                     (submodel.Kind == Aas.ModellingKind.Template)
                         ? Options.Curr.TemplateIdSubmodelTemplate
                         : Options.Curr.TemplateIdSubmodelInstance,
@@ -2146,7 +2146,7 @@ namespace AasxPackageLogic
             // Identifiable
 
             this.DisplayOrEditEntityIdentifiable(
-                stack, cd,
+                stack, env, cd,
                 Options.Curr.TemplateIdConceptDescription,
                 new DispEditHelperModules.DispEditInjectAction(
                 new[] { "Rename" },

--- a/src/AasxPackageLogic/DispEditHelperModules.cs
+++ b/src/AasxPackageLogic/DispEditHelperModules.cs
@@ -319,6 +319,7 @@ namespace AasxPackageLogic
         //
 
         public void DisplayOrEditEntityIdentifiable(AnyUiStackPanel stack,
+            Aas.Environment env,
             Aas.IIdentifiable identifiable,
             string templateForIdString,
             DispEditInjectAction injectToId = null)
@@ -339,8 +340,19 @@ namespace AasxPackageLogic
                     () => { return identifiable.Id == ""; },
                     "Identification id shall not be empty. You could use the 'Generate' button in order to " +
                         "generate a worldwide unique id. " +
-                        "The template of this id could be set by commandline arguments." )
-
+                        "The template of this id could be set by commandline arguments." ),
+                new HintCheck(
+                    () => {
+                        int count = 0;
+                        foreach(var aas in env.AssetAdministrationShells)
+                        {
+                            if(aas.Id == identifiable.Id)
+                                count++;
+                        }
+                        return (count >= 2?true:false);
+                    },
+                    "It is not allowed to have duplicate Ids in AAS of the same file. This will break functionality and we strongly encoure to make the Id unique!",
+                    breakIfTrue: false)
             });
             if (this.SafeguardAccess(
                     stack, repo, identifiable.Id, "id:", "Create data element!",
@@ -356,7 +368,10 @@ namespace AasxPackageLogic
                     v =>
                     {
                         var dr = new DiaryReference(identifiable);
+                        string value = v as string;
+                        bool duplicate = false;
                         identifiable.Id = v as string;
+                        //mlem
                         this.AddDiaryEntry(identifiable, new DiaryEntryStructChange(), diaryReference: dr);
                         return new AnyUiLambdaActionNone();
                     },


### PR DESCRIPTION
This is related to #680.
Created an (error) HintBubble for duplicate AAS Ids and GlobalAssetIds. The AASX can still be created and saved though, as to ensure no data loss.